### PR TITLE
Adopt a text-first registry design

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#ffffff">
     <title>Not found — Palomar</title>
     <link rel="stylesheet" href="assets/style.css">
   </head>

--- a/404.html
+++ b/404.html
@@ -1,17 +1,17 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Not found · Palomar</title>
+    <title>Not found — Palomar</title>
     <link rel="stylesheet" href="assets/style.css">
   </head>
   <body>
     <main class="about">
-      <div class="eyebrow">404 · outside the field of view</div>
-      <h1>That record<br><em>isn’t here.</em></h1>
+      <p class="entry-id">404</p>
+      <h1>That record isn’t here</h1>
       <p class="lede">The address may be wrong, or the entry may not have been published.</p>
-      <a class="button primary" href="./">Return to the registry</a>
+      <p><a href="./">Return to the registry</a></p>
     </main>
   </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -1,33 +1,27 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="How the Palomar registry verifies and reviews Lean formalizations.">
-    <meta name="theme-color" content="#0b1723">
-    <title>About · Palomar</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <meta name="theme-color" content="#f2f2f2">
+    <title>About — Palomar</title>
     <link rel="stylesheet" href="assets/style.css">
   </head>
   <body data-page="about">
     <a class="skip-link" href="#content">Skip to content</a>
     <header class="site-header">
-      <a class="brand" href="./">
-        <span class="brand-mark" aria-hidden="true"><span class="orbit"></span><span class="star"></span></span>
-        <span>Palomar</span>
-      </a>
+      <a class="brand" href="./">Palomar</a>
       <nav aria-label="Main navigation">
         <a href="./">Registry</a>
-        <a class="active" href="about.html">About</a>
-        <a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit ↗</a>
+        <a class="active" href="about.html" aria-current="page">About</a>
+        <a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit</a>
       </nav>
     </header>
 
     <main id="content" class="about">
-      <div class="eyebrow">What the registry means</div>
-      <h1>A precise floor,<br><em>not a journal ceiling.</em></h1>
+      <h1>About Palomar</h1>
+      <p class="subtitle">What the registry means</p>
       <p class="lede">
         Palomar gives a stable, searchable home to formal results that clear a
         published minimum standard. It separates machine verification,
@@ -38,23 +32,23 @@
         <h2 id="process-heading">From snapshot to record</h2>
         <ol>
           <li>
-            <span>01</span>
+            <span>1.</span>
             <div><h3>Immutable source</h3><p>A GitHub issue points to a public repository and full Git commit. Moving branches are never registry evidence.</p></div>
           </li>
           <li>
-            <span>02</span>
+            <span>2.</span>
             <div><h3>Small statement surface</h3><p><code>Challenge.lean</code> states the advertised result. Its transitive imports may come only from Lean core, Mathlib, Tau Ceti, or an already indexed Palomar project.</p></div>
           </li>
           <li>
-            <span>03</span>
+            <span>3.</span>
             <div><h3>Sandboxed comparison</h3><p>Comparator rebuilds Challenge and Solution separately under landrun, checks exact declaration identity and permitted axioms, then replays the proof through the Lean kernel.</p></div>
           </li>
           <li>
-            <span>04</span>
+            <span>4.</span>
             <div><h3>Editorial review</h3><p>Versioned AI review checks metadata, informal-to-Lean alignment, definitions, prior literature, notability, and clarity. Failures, uncertainty, and permanent warnings stay visible.</p></div>
           </li>
           <li>
-            <span>05</span>
+            <span>5.</span>
             <div><h3>Append-only publication</h3><p>An accepted result becomes an immutable JSON record with a permanent identifier and version. Corrections add versions; history is not rewritten.</p></div>
           </li>
         </ol>
@@ -74,14 +68,14 @@
       </section>
 
       <section class="cta">
-        <div><div class="eyebrow">Have a result?</div><h2>Submit one immutable snapshot.</h2></div>
-        <a class="button primary" href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Open the submission form ↗</a>
+        <div><h2>Have a result?</h2><p>Submit one immutable snapshot.</p></div>
+        <a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Open the submission form</a>
       </section>
     </main>
 
     <footer>
-      <div><span class="footer-brand">Palomar</span><p>A community-oriented registry prototype for Lean-verified results.</p></div>
-      <div class="footer-links"><a href="https://github.com/kim-em/PalomarPolicy">Policy</a><a href="https://github.com/kim-em/PalomarDatabase">API</a><a href="https://github.com/kim-em/PalomarWeb">Source</a></div>
+      <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
+      <div class="footer-links"><a href="https://github.com/kim-em/PalomarPolicy">Policy</a><a href="https://github.com/kim-em/PalomarDatabase">Data</a><a href="https://github.com/kim-em/PalomarWeb">Source</a></div>
     </footer>
   </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="How the Palomar registry verifies and reviews Lean formalizations.">
-    <meta name="theme-color" content="#f2f2f2">
+    <meta name="theme-color" content="#ffffff">
     <title>About — Palomar</title>
     <link rel="stylesheet" href="assets/style.css">
   </head>

--- a/assets/app.js
+++ b/assets/app.js
@@ -69,14 +69,14 @@ function entryCard(entry) {
   const abstract = el("p", "card-abstract", entry.abstract);
   const meta = el("div", "card-meta");
   const authors = el("div");
-  authors.append(el("small", "", "AUTHORS"), el("span", "", authorNames(entry)));
+  authors.append(el("small", "", "Authors"), el("span", "", authorNames(entry)));
   const theorems = el("div");
-  theorems.append(el("small", "", "THEOREMS"), el("span", "", theoremNames(entry)));
+  theorems.append(el("small", "", "Theorems"), el("span", "", theoremNames(entry)));
   meta.append(authors, theorems);
   const footer = el("div", "card-footer");
   footer.append(
     link(entry.source.repository, entry.source.tree_url, "repo-link"),
-    link("View record", `entry.html?id=${encodeURIComponent(entry.id)}&version=${entry.version}`, "record-link"),
+    link("View record", `entry.html?id=${encodeURIComponent(entry.id)}&version=${entry.version}`),
   );
   card.append(top, title, abstract, meta, footer);
   return card;
@@ -203,7 +203,7 @@ function renderEntry(entry, content, canonicalUrl) {
   }
   if (entry.trust.reasons.length) {
     trust.append(el("h3", "", "Qualification reasons"));
-    const reasons = el("ul", "warning-list");
+    const reasons = el("ul", "reason-list");
     for (const reason of entry.trust.reasons) reasons.append(el("li", "", reason));
     trust.append(reasons);
   }
@@ -229,19 +229,16 @@ function renderEntry(entry, content, canonicalUrl) {
   } else {
     editorial.append(el("p", "no-warnings", "No permanent editorial warnings were recorded."));
   }
-  editorial.append(link("Read the public review", entry.review.report_url, "button quiet"));
+  editorial.append(link("Read the public review", entry.review.report_url));
 
   const machine = el("section", "machine-record");
   machine.append(el("div", "eyebrow", "For machines and mirrors"), el("h2", "", "Canonical JSON"));
   const machineLinks = el("p");
   machineLinks.append(link("Open the canonical JSON record", canonicalUrl.href));
   machine.append(machineLinks);
-  const jsonDetails = el("details", "json-details");
-  jsonDetails.append(el("summary", "", "Show JSON on this page"));
   const pre = el("pre");
   pre.append(el("code", "", JSON.stringify(entry, null, 2)));
-  jsonDetails.append(pre);
-  machine.append(jsonDetails);
+  machine.append(pre);
 
   content.append(heading, evidence, trust, editorial, machine);
 }

--- a/assets/app.js
+++ b/assets/app.js
@@ -44,7 +44,9 @@ function latestVersions(entries) {
 function trustBadge(entry) {
   const high = entry.trust.level === "high";
   const badge = el("span", `trust-badge ${high ? "high" : "qualified"}`);
-  badge.append(el("span", "trust-dot"), document.createTextNode(high ? "Mathlib-only surface" : "Extended import surface"));
+  badge.textContent = high
+    ? "Trust: Mathlib-only surface"
+    : "Trust: extended import surface";
   return badge;
 }
 
@@ -74,7 +76,7 @@ function entryCard(entry) {
   const footer = el("div", "card-footer");
   footer.append(
     link(entry.source.repository, entry.source.tree_url, "repo-link"),
-    link("View record →", `entry.html?id=${encodeURIComponent(entry.id)}&version=${entry.version}`, "record-link"),
+    link("View record", `entry.html?id=${encodeURIComponent(entry.id)}&version=${entry.version}`, "record-link"),
   );
   card.append(top, title, abstract, meta, footer);
   return card;
@@ -128,9 +130,11 @@ async function renderIndex() {
     document.querySelectorAll(".filter").forEach((button) => {
       button.addEventListener("click", () => {
         trust = button.dataset.trust;
-        document.querySelectorAll(".filter").forEach((candidate) =>
-          candidate.classList.toggle("active", candidate === button),
-        );
+        document.querySelectorAll(".filter").forEach((candidate) => {
+          const active = candidate === button;
+          candidate.classList.toggle("active", active);
+          candidate.setAttribute("aria-pressed", String(active));
+        });
         update();
       });
     });
@@ -155,8 +159,8 @@ function externalDetailRow(labelText, text, href) {
   return row;
 }
 
-function renderEntry(entry, content) {
-  document.title = `${entry.title} · Palomar`;
+function renderEntry(entry, content, canonicalUrl) {
+  document.title = `${entry.title} — Palomar`;
   const heading = el("header", "entry-heading");
   const top = el("div", "card-top");
   top.append(el("span", "entry-id", `${entry.id} · version ${entry.version}`), trustBadge(entry));
@@ -225,13 +229,19 @@ function renderEntry(entry, content) {
   } else {
     editorial.append(el("p", "no-warnings", "No permanent editorial warnings were recorded."));
   }
-  editorial.append(link("Read the public review ↗", entry.review.report_url, "button quiet"));
+  editorial.append(link("Read the public review", entry.review.report_url, "button quiet"));
 
   const machine = el("section", "machine-record");
   machine.append(el("div", "eyebrow", "For machines and mirrors"), el("h2", "", "Canonical JSON"));
+  const machineLinks = el("p");
+  machineLinks.append(link("Open the canonical JSON record", canonicalUrl.href));
+  machine.append(machineLinks);
+  const jsonDetails = el("details", "json-details");
+  jsonDetails.append(el("summary", "", "Show JSON on this page"));
   const pre = el("pre");
   pre.append(el("code", "", JSON.stringify(entry, null, 2)));
-  machine.append(pre);
+  jsonDetails.append(pre);
+  machine.append(jsonDetails);
 
   content.append(heading, evidence, trust, editorial, machine);
 }
@@ -250,10 +260,11 @@ async function renderEntryPage() {
     const index = await fetchJson(databaseUrl);
     const summary = index.entries.find((item) => item.id === id && item.version === version);
     if (!summary) throw new Error("entry not found");
-    const entry = await fetchJson(new URL(summary.path, databaseBase));
+    const canonicalUrl = new URL(summary.path, databaseBase);
+    const entry = await fetchJson(canonicalUrl);
     status.hidden = true;
     content.hidden = false;
-    renderEntry(entry, content);
+    renderEntry(entry, content, canonicalUrl);
   } catch (error) {
     status.textContent = `The registry entry could not be loaded: ${error.message}`;
     status.classList.add("error");

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,204 +1,656 @@
 :root {
-  color-scheme: dark;
-  --ink: #e9f0f2;
-  --muted: #9eafb7;
-  --dim: #6f818a;
-  --night: #07111a;
-  --night-2: #0b1723;
-  --panel: rgba(15, 31, 43, 0.8);
-  --line: rgba(164, 193, 202, 0.16);
-  --cyan: #86d9d4;
-  --cyan-bright: #b7fff3;
-  --gold: #e8c783;
-  --warn: #f1a778;
-  --max: 1180px;
-  --mono: "DM Mono", ui-monospace, monospace;
-  --sans: "Manrope", system-ui, sans-serif;
+  color-scheme: light;
+  --ink: #111;
+  --muted: #555;
+  --faint: #777;
+  --paper: #fff;
+  --shade: #f2f2f2;
+  --line: #aaa;
+  --link: #0000cc;
+  --visited: #551a8b;
+  --warning: #8b0000;
+  --max: 64rem;
+  --serif: Georgia, "Times New Roman", Times, serif;
+  --sans: Arial, Helvetica, sans-serif;
+  --mono: "Courier New", Courier, monospace;
 }
 
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+}
 
-html { scroll-behavior: smooth; }
+html {
+  background: var(--paper);
+}
 
 body {
-  margin: 0;
   min-height: 100vh;
-  background:
-    radial-gradient(circle at 78% 6%, rgba(82, 171, 176, 0.12), transparent 25rem),
-    radial-gradient(circle at 15% 29%, rgba(227, 188, 112, 0.05), transparent 22rem),
-    var(--night);
+  margin: 0;
+  background: var(--paper);
   color: var(--ink);
-  font-family: var(--sans);
-  line-height: 1.6;
+  font: 16px/1.45 var(--serif);
 }
 
-body::before {
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  background-image:
-    radial-gradient(circle, rgba(255,255,255,.42) 0 1px, transparent 1.4px),
-    radial-gradient(circle, rgba(134,217,212,.3) 0 1px, transparent 1.3px);
-  background-position: 0 0, 43px 67px;
-  background-size: 137px 137px, 211px 211px;
-  opacity: .18;
-  content: "";
-  mask-image: linear-gradient(to bottom, black, transparent 72%);
+a {
+  color: var(--link);
+  text-decoration: underline;
 }
 
-a { color: inherit; text-decoration: none; }
-a:hover { color: var(--cyan-bright); }
+a:visited {
+  color: var(--visited);
+}
+
+a:hover,
+a:focus-visible {
+  color: #b00000;
+}
 
 .skip-link {
   position: fixed;
   top: -5rem;
   left: 1rem;
-  z-index: 20;
-  padding: .7rem 1rem;
-  background: var(--cyan);
-  color: var(--night);
+  z-index: 10;
+  padding: .45rem .7rem;
+  border: 1px solid var(--ink);
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
 }
-.skip-link:focus { top: 1rem; }
+
+.skip-link:focus {
+  top: 1rem;
+}
 
 .site-header {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   justify-content: space-between;
-  width: min(calc(100% - 3rem), var(--max));
+  width: min(calc(100% - 2rem), var(--max));
   margin: 0 auto;
-  padding: 1.5rem 0;
+  padding: 1rem 0 .7rem;
+  border-bottom: 3px double var(--ink);
+}
+
+.brand,
+.brand:visited {
+  color: var(--ink);
+  font-size: 1.5rem;
+  font-weight: bold;
+  text-decoration: none;
+}
+
+nav {
+  display: flex;
+  gap: 1.2rem;
+  font: .9rem/1.3 var(--sans);
+}
+
+nav a.active {
+  color: var(--ink);
+  font-weight: bold;
+  text-decoration: none;
+}
+
+main,
+footer {
+  width: min(calc(100% - 2rem), var(--max));
+  margin-inline: auto;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: .2rem;
+  font-size: 2rem;
+  line-height: 1.15;
+}
+
+h2 {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+
+h3 {
+  font-size: 1.08rem;
+  line-height: 1.3;
+}
+
+.hero {
+  padding: 2.2rem 0 1.7rem;
   border-bottom: 1px solid var(--line);
 }
 
-.brand { display: flex; gap: .75rem; align-items: center; font-weight: 700; letter-spacing: -.03em; }
-.brand-mark { position: relative; width: 1.7rem; height: 1.7rem; }
-.brand-mark .orbit { position: absolute; inset: 2px; border: 1px solid var(--cyan); border-radius: 50%; transform: rotate(-35deg) scaleY(.42); }
-.brand-mark .star { position: absolute; top: .66rem; left: .66rem; width: .38rem; height: .38rem; border-radius: 50%; background: var(--gold); box-shadow: 0 0 16px var(--gold); }
-
-nav { display: flex; gap: 1.8rem; font-size: .88rem; color: var(--muted); }
-nav a { padding: .2rem 0; border-bottom: 1px solid transparent; }
-nav a.active { color: var(--ink); border-color: var(--cyan); }
-
-main, footer { width: min(calc(100% - 3rem), var(--max)); margin-inline: auto; }
-
-.hero { padding: clamp(5rem, 10vw, 9rem) 0 5rem; }
-.eyebrow { margin-bottom: 1rem; color: var(--cyan); font: 500 .72rem/1.4 var(--mono); letter-spacing: .14em; text-transform: uppercase; }
-h1, h2, h3, p { margin-top: 0; }
-h1 { max-width: 900px; margin-bottom: 1.5rem; font-size: clamp(3.1rem, 8vw, 7rem); font-weight: 500; line-height: .98; letter-spacing: -.075em; }
-h1 em { color: var(--cyan); font-style: normal; }
-.hero-copy, .lede { max-width: 720px; color: var(--muted); font-size: clamp(1.05rem, 2vw, 1.28rem); }
-.hero-actions { display: flex; gap: .8rem; margin-top: 2.3rem; flex-wrap: wrap; }
-
-.button { display: inline-flex; align-items: center; justify-content: center; min-height: 3.2rem; padding: .65rem 1.15rem; border: 1px solid var(--line); border-radius: .2rem; font-size: .88rem; font-weight: 600; }
-.button.primary { border-color: var(--cyan); background: var(--cyan); color: #07191c; }
-.button.primary:hover { background: var(--cyan-bright); color: #07191c; }
-.button.quiet { background: rgba(255,255,255,.025); }
-
-.metric-row { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); max-width: 760px; margin-top: 5rem; border-block: 1px solid var(--line); }
-.metric-row > div { padding: 1.3rem 1.6rem 1.4rem 0; border-right: 1px solid var(--line); }
-.metric-row > div + div { padding-left: 1.6rem; }
-.metric-row > div:last-child { border: 0; }
-.metric-row span { display: block; margin-bottom: .2rem; font: 500 2.1rem/1 var(--mono); color: var(--gold); }
-.metric-row small { color: var(--dim); font-size: .76rem; }
-
-.registry-section { padding: 5rem 0 7rem; border-top: 1px solid var(--line); }
-.section-heading { display: flex; justify-content: space-between; align-items: end; gap: 2rem; margin-bottom: 2rem; }
-.section-heading h2, .process h2, .machine-record h2 { margin: 0; font-size: clamp(1.8rem, 4vw, 3rem); line-height: 1.08; letter-spacing: -.045em; }
-.data-link { color: var(--muted); font: .78rem var(--mono); }
-.toolbar { display: flex; justify-content: space-between; gap: 1rem; padding: 1rem; background: rgba(11, 27, 38, .78); border: 1px solid var(--line); border-radius: .35rem; }
-.search { display: flex; align-items: center; gap: .7rem; flex: 1; max-width: 560px; }
-.search svg { width: 1.1rem; fill: none; stroke: var(--dim); stroke-width: 1.7; }
-.search input { width: 100%; padding: .5rem 0; border: 0; outline: 0; background: transparent; color: var(--ink); font: .85rem var(--sans); }
-.search input::placeholder { color: var(--dim); }
-.filters { display: flex; gap: .35rem; }
-.filter { padding: .55rem .75rem; border: 1px solid transparent; border-radius: .2rem; background: transparent; color: var(--dim); cursor: pointer; font: .72rem var(--mono); }
-.filter:hover, .filter.active { border-color: var(--line); background: rgba(255,255,255,.04); color: var(--ink); }
-
-.status { margin-top: 1.5rem; padding: 2rem; border: 1px dashed var(--line); color: var(--muted); text-align: center; }
-.status.error { border-color: rgba(241,167,120,.4); color: var(--warn); }
-.status.empty { padding-block: 4rem; }
-.entry-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; margin-top: 1rem; }
-.entry-card { display: flex; flex-direction: column; min-height: 390px; padding: 1.6rem; border: 1px solid var(--line); border-radius: .35rem; background: linear-gradient(145deg, rgba(16,34,47,.93), rgba(9,23,33,.88)); transition: transform .18s ease, border-color .18s ease; }
-.entry-card:hover { transform: translateY(-2px); border-color: rgba(134,217,212,.35); }
-.card-top { display: flex; justify-content: space-between; align-items: center; gap: 1rem; }
-.entry-id { color: var(--gold); font: .7rem var(--mono); letter-spacing: .04em; }
-.trust-badge { display: inline-flex; align-items: center; gap: .45rem; color: var(--muted); font: .66rem var(--mono); }
-.trust-dot { width: .48rem; height: .48rem; border-radius: 50%; background: var(--cyan); box-shadow: 0 0 8px rgba(134,217,212,.5); }
-.trust-badge.qualified .trust-dot { background: var(--gold); box-shadow: 0 0 8px rgba(232,199,131,.4); }
-.entry-card h3 { margin: 2rem 0 .8rem; font-size: 1.45rem; line-height: 1.25; letter-spacing: -.035em; }
-.card-abstract { display: -webkit-box; overflow: hidden; color: var(--muted); font-size: .9rem; -webkit-box-orient: vertical; -webkit-line-clamp: 4; }
-.card-meta { display: grid; grid-template-columns: 1fr 1fr; gap: 1.2rem; margin-top: auto; padding-top: 1.5rem; border-top: 1px solid var(--line); }
-.card-meta small { display: block; margin-bottom: .35rem; color: var(--dim); font: .62rem var(--mono); letter-spacing: .08em; }
-.card-meta span { display: -webkit-box; overflow: hidden; color: var(--muted); font-size: .76rem; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
-.card-footer { display: flex; justify-content: space-between; gap: 1rem; margin-top: 1.3rem; color: var(--dim); font: .7rem var(--mono); }
-.repo-link { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.record-link { flex: none; color: var(--cyan); }
-
-footer { display: flex; justify-content: space-between; gap: 3rem; padding: 3rem 0; border-top: 1px solid var(--line); color: var(--dim); font-size: .78rem; }
-.footer-brand { color: var(--ink); font-weight: 700; }
-footer p { margin: .4rem 0 0; }
-.footer-links { display: flex; gap: 1.4rem; align-items: start; }
-
-.about { padding: clamp(5rem, 10vw, 9rem) 0 7rem; }
-.about h1 { font-size: clamp(3rem, 7vw, 6rem); }
-.process { margin-top: 7rem; padding-top: 4rem; border-top: 1px solid var(--line); }
-.process ol { margin: 3rem 0 0; padding: 0; list-style: none; }
-.process li { display: grid; grid-template-columns: 5rem 1fr; padding: 2rem 0; border-top: 1px solid var(--line); }
-.process li > span { color: var(--gold); font: .8rem var(--mono); }
-.process h3 { margin-bottom: .4rem; font-size: 1.2rem; }
-.process p { max-width: 700px; margin-bottom: 0; color: var(--muted); }
-code { font-family: var(--mono); color: var(--cyan); }
-.meaning-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; margin-top: 6rem; background: var(--line); border: 1px solid var(--line); }
-.meaning-grid article { padding: clamp(2rem, 5vw, 4rem); background: var(--night-2); }
-.meaning-grid h2 { font-size: clamp(1.4rem, 3vw, 2.2rem); line-height: 1.2; letter-spacing: -.04em; }
-.meaning-grid p { color: var(--muted); }
-.cta { display: flex; justify-content: space-between; align-items: center; gap: 2rem; margin-top: 6rem; padding: 2.5rem; border: 1px solid rgba(134,217,212,.28); background: rgba(134,217,212,.045); }
-.cta h2 { margin: 0; letter-spacing: -.04em; }
-
-.entry-page { min-height: 70vh; padding: 5rem 0 7rem; }
-.entry-heading { padding-bottom: 4rem; }
-.entry-heading h1 { max-width: 960px; margin-top: 2rem; font-size: clamp(2.7rem, 7vw, 5.6rem); }
-.byline { margin-top: 1.5rem; color: var(--gold); font: .8rem var(--mono); }
-.entry-page section { padding: 4rem 0; border-top: 1px solid var(--line); }
-.details { border: 1px solid var(--line); }
-.detail-row { display: grid; grid-template-columns: minmax(10rem, .7fr) 2fr; padding: 1rem 1.2rem; border-top: 1px solid var(--line); }
-.detail-row:first-child { border: 0; }
-.detail-row dt { color: var(--dim); font: .7rem var(--mono); text-transform: uppercase; }
-.detail-row dd { margin: 0; overflow-wrap: anywhere; color: var(--muted); font-size: .86rem; }
-.detail-row a { color: var(--cyan); }
-.entry-page h3 { margin-top: 2rem; font-size: .82rem; font-family: var(--mono); font-weight: 500; color: var(--dim); text-transform: uppercase; letter-spacing: .08em; }
-.token-list { display: flex; flex-wrap: wrap; gap: .45rem; }
-.token-list code { padding: .35rem .55rem; background: rgba(134,217,212,.07); border: 1px solid rgba(134,217,212,.16); font-size: .72rem; }
-.plain-list, .warning-list { margin: 0; padding-left: 1.2rem; color: var(--muted); }
-.warning-list li::marker { color: var(--gold); }
-.decision { padding: .3rem .6rem; border: 1px solid rgba(134,217,212,.25); color: var(--cyan); font: .7rem var(--mono); }
-.score-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 1px; margin-bottom: 2rem; background: var(--line); border: 1px solid var(--line); }
-.score { padding: 1rem; background: var(--night-2); }
-.score span { display: block; min-height: 2.6em; color: var(--dim); font: .64rem var(--mono); text-transform: uppercase; }
-.score strong { color: var(--gold); font: 500 1.45rem var(--mono); }
-.no-warnings { color: var(--muted); }
-.machine-record pre { max-height: 34rem; overflow: auto; padding: 1.2rem; border: 1px solid var(--line); background: #050d14; font-size: .72rem; }
-.machine-record pre code { color: #bdcbd0; }
-.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
-[hidden] { display: none !important; }
-
-@media (max-width: 780px) {
-  .site-header { width: min(calc(100% - 2rem), var(--max)); }
-  main, footer { width: min(calc(100% - 2rem), var(--max)); }
-  nav { gap: .9rem; font-size: .78rem; }
-  .metric-row { grid-template-columns: 1fr; }
-  .metric-row > div, .metric-row > div + div { padding: 1rem 0; border-right: 0; border-bottom: 1px solid var(--line); }
-  .toolbar { align-items: stretch; flex-direction: column; }
-  .filters { overflow-x: auto; }
-  .entry-grid, .meaning-grid { grid-template-columns: 1fr; }
-  .entry-card { min-height: 350px; }
-  .section-heading, .cta, footer { align-items: flex-start; flex-direction: column; }
-  .process li { grid-template-columns: 3rem 1fr; }
-  .detail-row { grid-template-columns: 1fr; gap: .4rem; }
-  .score-grid { grid-template-columns: repeat(2, 1fr); }
+.subtitle {
+  margin-bottom: 1.2rem;
+  color: var(--muted);
+  font-size: 1.08rem;
+  font-style: italic;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  html { scroll-behavior: auto; }
-  *, *::before, *::after { transition-duration: .01ms !important; animation-duration: .01ms !important; }
+.hero-copy,
+.lede {
+  max-width: 72ch;
+}
+
+.metric-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .4rem 1.5rem;
+  margin-top: 1.3rem;
+  color: var(--muted);
+  font: .85rem/1.4 var(--sans);
+}
+
+.metric-row strong {
+  color: var(--ink);
+  font-family: var(--mono);
+}
+
+.registry-section {
+  padding: 1.8rem 0 4rem;
+}
+
+.section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: .8rem;
+}
+
+.section-heading h2 {
+  margin-bottom: 0;
+}
+
+.data-link {
+  font-size: .9rem;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: .75rem;
+  border-block: 1px solid var(--line);
+  background: var(--shade);
+  font: .85rem/1.3 var(--sans);
+}
+
+.search {
+  display: flex;
+  align-items: center;
+  gap: .45rem;
+  flex: 1;
+  max-width: 37rem;
+}
+
+.search input {
+  width: 100%;
+  min-height: 2rem;
+  padding: .25rem .4rem;
+  border: 1px solid #777;
+  border-radius: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font: .9rem var(--sans);
+}
+
+.search input:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--link);
+  outline-offset: 2px;
+}
+
+.filters {
+  display: flex;
+  align-items: center;
+  gap: .35rem;
+}
+
+.filter {
+  min-height: 2rem;
+  padding: .25rem .5rem;
+  border: 1px solid #777;
+  border-radius: 0;
+  background: #e8e8e8;
+  color: var(--ink);
+  cursor: pointer;
+  font: .8rem var(--sans);
+}
+
+.filter:hover {
+  background: #ddd;
+}
+
+.filter.active {
+  border-color: var(--ink);
+  background: var(--paper);
+  font-weight: bold;
+}
+
+.status {
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 1px dashed var(--line);
+  color: var(--muted);
+  text-align: center;
+}
+
+.status.error {
+  border-color: var(--warning);
+  color: var(--warning);
+}
+
+.status.empty {
+  padding-block: 2rem;
+}
+
+.entry-grid {
+  margin-top: 1rem;
+  border-top: 1px solid var(--line);
+}
+
+.entry-card {
+  padding: 1.15rem .2rem 1.25rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.card-top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.entry-id {
+  color: var(--muted);
+  font: .78rem/1.4 var(--mono);
+}
+
+.trust-badge {
+  color: var(--muted);
+  font: .78rem/1.4 var(--sans);
+}
+
+.trust-badge.qualified {
+  color: var(--warning);
+  font-weight: bold;
+}
+
+.entry-card h3 {
+  margin: .35rem 0 .25rem;
+}
+
+.card-abstract {
+  max-width: 76ch;
+  margin-bottom: .75rem;
+}
+
+.card-meta {
+  display: flex;
+  gap: .75rem 2rem;
+  margin-bottom: .65rem;
+  color: var(--muted);
+  font-size: .88rem;
+}
+
+.card-meta small {
+  display: block;
+  margin-bottom: .1rem;
+  color: var(--faint);
+  font: .68rem/1.3 var(--sans);
+  text-transform: uppercase;
+}
+
+.card-meta > div {
+  min-width: 0;
+}
+
+.card-meta span {
+  overflow-wrap: anywhere;
+}
+
+.card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: .5rem 1rem;
+  font-size: .85rem;
+}
+
+.repo-link {
+  overflow-wrap: anywhere;
+}
+
+footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 1.2rem 0 2rem;
+  border-top: 3px double var(--ink);
+  color: var(--muted);
+  font: .8rem/1.4 var(--sans);
+}
+
+.footer-brand {
+  color: var(--ink);
+  font-family: var(--serif);
+  font-weight: bold;
+}
+
+.footer-links {
+  display: flex;
+  gap: 1rem;
+}
+
+.about {
+  max-width: 52rem;
+  padding: 2.5rem 0 4rem;
+}
+
+.process,
+.meaning-grid,
+.cta {
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--line);
+}
+
+.process ol {
+  margin: 1rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.process li {
+  display: grid;
+  grid-template-columns: 2rem 1fr;
+  padding: .9rem 0;
+  border-top: 1px dotted var(--line);
+}
+
+.process li > span {
+  font-weight: bold;
+}
+
+.process h3 {
+  margin-bottom: .2rem;
+}
+
+.process p {
+  margin-bottom: 0;
+}
+
+.meaning-grid article + article {
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px dotted var(--line);
+}
+
+.eyebrow {
+  margin-bottom: .25rem;
+  color: var(--muted);
+  font: bold .75rem/1.3 var(--sans);
+  text-transform: uppercase;
+}
+
+.cta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.cta h2,
+.cta p {
+  margin-bottom: .2rem;
+}
+
+.entry-page {
+  min-height: 70vh;
+  padding: 2.2rem 0 4rem;
+}
+
+.entry-heading {
+  max-width: 52rem;
+  padding-bottom: 1.5rem;
+}
+
+.entry-heading h1 {
+  margin-top: .5rem;
+  font-size: 1.8rem;
+}
+
+.byline {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.entry-page section {
+  padding: 1.5rem 0;
+  border-top: 1px solid var(--line);
+}
+
+.details {
+  margin: 0;
+  border-block: 1px solid var(--line);
+}
+
+.detail-row {
+  display: grid;
+  grid-template-columns: minmax(10rem, .7fr) 2fr;
+  padding: .55rem .4rem;
+  border-top: 1px dotted var(--line);
+}
+
+.detail-row:first-child {
+  border-top: 0;
+}
+
+.detail-row dt {
+  font-weight: bold;
+}
+
+.detail-row dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.entry-page h3 {
+  margin: 1.2rem 0 .4rem;
+  font-size: .95rem;
+}
+
+code,
+pre {
+  font-family: var(--mono);
+}
+
+.token-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .35rem;
+}
+
+.token-list code {
+  padding: .15rem .3rem;
+  border: 1px solid #bbb;
+  background: var(--shade);
+  font-size: .8rem;
+}
+
+.plain-list,
+.warning-list {
+  margin: .4rem 0;
+  padding-left: 1.5rem;
+}
+
+.warning-list {
+  padding: .65rem .75rem .65rem 2rem;
+  border-left: 4px solid var(--warning);
+  background: #fff8f2;
+}
+
+.decision {
+  font: bold .8rem/1.3 var(--sans);
+  text-transform: uppercase;
+}
+
+.score-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  margin-bottom: 1rem;
+  border-block: 1px solid var(--line);
+}
+
+.score {
+  padding: .55rem;
+  border-right: 1px dotted var(--line);
+}
+
+.score:last-child {
+  border-right: 0;
+}
+
+.score span {
+  display: block;
+  min-height: 2.6em;
+  color: var(--muted);
+  font: .7rem/1.3 var(--sans);
+  text-transform: uppercase;
+}
+
+.score strong {
+  font: bold 1.1rem/1.3 var(--mono);
+}
+
+.no-warnings {
+  color: var(--muted);
+}
+
+.button {
+  font-size: .9rem;
+}
+
+.machine-record pre {
+  max-height: 34rem;
+  overflow: auto;
+  padding: .75rem;
+  border: 1px solid var(--line);
+  background: var(--shade);
+  font-size: .75rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.json-details {
+  margin-top: .9rem;
+}
+
+.json-details summary {
+  color: var(--link);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+@media (max-width: 700px) {
+  .site-header,
+  .section-heading,
+  .toolbar,
+  .cta,
+  footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .site-header {
+    gap: .5rem;
+  }
+
+  nav {
+    flex-wrap: wrap;
+  }
+
+  .toolbar,
+  .search {
+    width: 100%;
+  }
+
+  .filters {
+    flex-wrap: wrap;
+  }
+
+  .card-top,
+  .card-meta,
+  .card-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .detail-row {
+    grid-template-columns: 1fr;
+    gap: .15rem;
+  }
+
+  .score-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .score:nth-child(2n) {
+    border-right: 0;
+  }
+}
+
+@media print {
+  body {
+    font-size: 11pt;
+  }
+
+  .site-header nav,
+  .toolbar,
+  footer {
+    display: none;
+  }
+
+  .site-header,
+  main {
+    width: 100%;
+  }
+
+  a,
+  a:visited {
+    color: var(--ink);
+  }
+
+  .entry-card,
+  .entry-page section {
+    break-inside: avoid;
+  }
+
+  .machine-record pre {
+    max-height: none;
+  }
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -2,12 +2,13 @@
   color-scheme: light;
   --ink: #111;
   --muted: #555;
-  --faint: #777;
+  --faint: #666;
   --paper: #fff;
   --shade: #f2f2f2;
   --line: #aaa;
   --link: #0000cc;
   --visited: #551a8b;
+  --caution: #5d4b00;
   --warning: #8b0000;
   --max: 64rem;
   --serif: Georgia, "Times New Roman", Times, serif;
@@ -253,7 +254,6 @@ button:focus-visible {
 
 .entry-grid {
   margin-top: 1rem;
-  border-top: 1px solid var(--line);
 }
 
 .entry-card {
@@ -279,7 +279,7 @@ button:focus-visible {
 }
 
 .trust-badge.qualified {
-  color: var(--warning);
+  color: var(--caution);
   font-weight: bold;
 }
 
@@ -426,7 +426,7 @@ footer {
 
 .entry-heading h1 {
   margin-top: .5rem;
-  font-size: 1.8rem;
+  font-size: 2rem;
 }
 
 .byline {
@@ -466,7 +466,7 @@ footer {
 
 .entry-page h3 {
   margin: 1.2rem 0 .4rem;
-  font-size: .95rem;
+  font-size: 1rem;
 }
 
 code,
@@ -488,9 +488,16 @@ pre {
 }
 
 .plain-list,
+.reason-list,
 .warning-list {
   margin: .4rem 0;
   padding-left: 1.5rem;
+}
+
+.reason-list {
+  padding: .65rem .75rem .65rem 2rem;
+  border-left: 2px solid var(--caution);
+  background: var(--shade);
 }
 
 .warning-list {
@@ -512,6 +519,9 @@ pre {
 }
 
 .score {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   padding: .55rem;
   border-right: 1px dotted var(--line);
 }
@@ -522,7 +532,7 @@ pre {
 
 .score span {
   display: block;
-  min-height: 2.6em;
+  margin-bottom: .35rem;
   color: var(--muted);
   font: .7rem/1.3 var(--sans);
   text-transform: uppercase;
@@ -536,10 +546,6 @@ pre {
   color: var(--muted);
 }
 
-.button {
-  font-size: .9rem;
-}
-
 .machine-record pre {
   max-height: 34rem;
   overflow: auto;
@@ -549,27 +555,6 @@ pre {
   font-size: .75rem;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
-}
-
-.json-details {
-  margin-top: .9rem;
-}
-
-.json-details summary {
-  color: var(--link);
-  cursor: pointer;
-  text-decoration: underline;
-}
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
 }
 
 [hidden] {
@@ -625,13 +610,18 @@ pre {
 }
 
 @media print {
+  body,
+  .entry-page {
+    min-height: 0;
+  }
+
   body {
     font-size: 11pt;
   }
 
   .site-header nav,
-  .toolbar,
-  footer {
+  .skip-link,
+  .toolbar {
     display: none;
   }
 
@@ -643,6 +633,12 @@ pre {
   a,
   a:visited {
     color: var(--ink);
+  }
+
+  a[href^="http"]::after {
+    content: " (" attr(href) ")";
+    font-size: 90%;
+    overflow-wrap: anywhere;
   }
 
   .entry-card,

--- a/entry.html
+++ b/entry.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="theme-color" content="#f2f2f2">
+    <meta name="theme-color" content="#ffffff">
     <title>Registry entry — Palomar</title>
     <link rel="stylesheet" href="assets/style.css">
   </head>

--- a/entry.html
+++ b/entry.html
@@ -1,31 +1,25 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="theme-color" content="#0b1723">
-    <title>Registry entry · Palomar</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <meta name="theme-color" content="#f2f2f2">
+    <title>Registry entry — Palomar</title>
     <link rel="stylesheet" href="assets/style.css">
   </head>
   <body data-page="entry">
     <a class="skip-link" href="#entry">Skip to entry</a>
     <header class="site-header">
-      <a class="brand" href="./">
-        <span class="brand-mark" aria-hidden="true"><span class="orbit"></span><span class="star"></span></span>
-        <span>Palomar</span>
-      </a>
-      <nav aria-label="Main navigation"><a href="./">Registry</a><a href="about.html">About</a><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit ↗</a></nav>
+      <a class="brand" href="./">Palomar</a>
+      <nav aria-label="Main navigation"><a href="./">Registry</a><a href="about.html">About</a><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit</a></nav>
     </header>
     <main id="entry" class="entry-page">
       <div id="status" class="status">Reading registry entry…</div>
       <article id="entry-content" hidden></article>
     </main>
     <footer>
-      <div><span class="footer-brand">Palomar</span><p>A community-oriented registry prototype for Lean-verified results.</p></div>
-      <div class="footer-links"><a href="https://github.com/kim-em/PalomarPolicy">Policy</a><a href="https://github.com/kim-em/PalomarDatabase">API</a><a href="https://github.com/kim-em/PalomarWeb">Source</a></div>
+      <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
+      <div class="footer-links"><a href="https://github.com/kim-em/PalomarPolicy">Policy</a><a href="https://github.com/kim-em/PalomarDatabase">Data</a><a href="https://github.com/kim-em/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/app.js"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -1,75 +1,58 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="A public registry of Lean-verified mathematical results.">
-    <meta name="theme-color" content="#0b1723">
-    <title>Palomar · Lean-verified mathematics</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <meta name="theme-color" content="#f2f2f2">
+    <title>Palomar — Lean-verified mathematics</title>
     <link rel="stylesheet" href="assets/style.css">
     <link rel="manifest" href="site.webmanifest">
   </head>
   <body data-page="index">
     <a class="skip-link" href="#registry">Skip to registry</a>
     <header class="site-header">
-      <a class="brand" href="./" aria-label="Palomar home">
-        <span class="brand-mark" aria-hidden="true">
-          <span class="orbit"></span>
-          <span class="star"></span>
-        </span>
-        <span>Palomar</span>
-      </a>
+      <a class="brand" href="./" aria-label="Palomar home">Palomar</a>
       <nav aria-label="Main navigation">
-        <a class="active" href="./">Registry</a>
+        <a class="active" href="./" aria-current="page">Registry</a>
         <a href="about.html">About</a>
-        <a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit ↗</a>
+        <a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit</a>
       </nav>
     </header>
 
     <main>
       <section class="hero">
-        <div class="eyebrow">Lean-verified · permanently pinned · openly reviewed</div>
-        <h1>A clear view of<br><em>formal mathematics.</em></h1>
+        <h1>Registry of Lean-verified mathematics</h1>
         <p class="hero-copy">
           Palomar records mathematical claims at immutable Git commits, checks
           their proofs with Comparator, and publishes the exact statement,
           provenance, trust surface, and editorial warnings.
         </p>
-        <div class="hero-actions">
-          <a class="button primary" href="#registry">Explore the registry</a>
-          <a class="button quiet" href="about.html">How verification works</a>
-        </div>
         <div class="metric-row" aria-live="polite">
-          <div><span id="metric-results">—</span><small>accepted results</small></div>
-          <div><span id="metric-projects">—</span><small>source projects</small></div>
-          <div><span id="metric-high-trust">—</span><small>Mathlib-only surfaces</small></div>
+          <span><strong id="metric-results">—</strong> accepted results</span>
+          <span><strong id="metric-projects">—</strong> source projects</span>
+          <span><strong id="metric-high-trust">—</strong> Mathlib-only surfaces</span>
         </div>
       </section>
 
       <section class="registry-section" id="registry" aria-labelledby="registry-heading">
         <div class="section-heading">
-          <div>
-            <div class="eyebrow">The registry</div>
-            <h2 id="registry-heading">Accepted results</h2>
-          </div>
+          <h2 id="registry-heading">Accepted results</h2>
           <a class="data-link" href="https://github.com/kim-em/PalomarDatabase">
-            Raw data &amp; schema ↗
+            Raw data and schema
           </a>
         </div>
 
         <div class="toolbar">
           <label class="search">
-            <span class="sr-only">Search entries</span>
-            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m21 21-4.35-4.35m2.35-5.65a8 8 0 1 1-16 0 8 8 0 0 1 16 0Z"/></svg>
-            <input id="search" type="search" placeholder="Search title, author, theorem, repository…" autocomplete="off">
+            <span>Search:</span>
+            <input id="search" type="search" placeholder="title, author, theorem, or repository" autocomplete="off">
           </label>
           <div class="filters" role="group" aria-label="Trust filters">
-            <button class="filter active" type="button" data-trust="all">All</button>
-            <button class="filter" type="button" data-trust="high">Mathlib-only</button>
-            <button class="filter" type="button" data-trust="qualified">Extended imports</button>
+            <span>Show:</span>
+            <button class="filter active" type="button" data-trust="all" aria-pressed="true">All</button>
+            <button class="filter" type="button" data-trust="high" aria-pressed="false">Mathlib-only</button>
+            <button class="filter" type="button" data-trust="qualified" aria-pressed="false">Extended imports</button>
           </div>
         </div>
 
@@ -81,11 +64,11 @@
     <footer>
       <div>
         <span class="footer-brand">Palomar</span>
-        <p>A community-oriented registry prototype for Lean-verified results.</p>
+        <span> — a registry of Lean-verified results</span>
       </div>
       <div class="footer-links">
         <a href="https://github.com/kim-em/PalomarPolicy">Policy</a>
-        <a href="https://github.com/kim-em/PalomarDatabase">API</a>
+        <a href="https://github.com/kim-em/PalomarDatabase">Data</a>
         <a href="https://github.com/leanprover/comparator">Comparator</a>
         <a href="https://github.com/kim-em/PalomarWeb">Source</a>
       </div>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="A public registry of Lean-verified mathematical results.">
-    <meta name="theme-color" content="#f2f2f2">
+    <meta name="theme-color" content="#ffffff">
     <title>Palomar — Lean-verified mathematics</title>
     <link rel="stylesheet" href="assets/style.css">
     <link rel="manifest" href="site.webmanifest">

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -4,5 +4,5 @@
   "start_url": "./",
   "display": "standalone",
   "background_color": "#ffffff",
-  "theme_color": "#f2f2f2"
+  "theme_color": "#ffffff"
 }

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -3,6 +3,6 @@
   "short_name": "Palomar",
   "start_url": "./",
   "display": "standalone",
-  "background_color": "#07111a",
-  "theme_color": "#0b1723"
+  "background_color": "#ffffff",
+  "theme_color": "#f2f2f2"
 }


### PR DESCRIPTION
## Summary

- replace the dark, decorative landing page and card grid with a light, document-oriented presentation
- use ordinary underlined links, system fonts, compact headings, native-looking controls, and rules instead of visual effects
- preserve runtime JSON loading, search, trust filters, version details, review scores, warnings, and error handling
- make trust state textual, add a direct canonical JSON link, and keep layouts readable on narrow screens and in print

## Context

“Web 1.0” is treated strictly as shorthand for the visual style. This does not introduce a no-JavaScript baseline or change the data-loading and deployment architecture.

## Validation

- node --check assets/app.js
- npx --yes html-validate index.html entry.html about.html 404.html
- git diff --check
- Chromium desktop and 390-pixel mobile screenshot review against the live PalomarDatabase record
- Chromium DOM checks for index data loading, entry data loading, canonical JSON linking, and invalid-entry errors

Closes #1