### PR TITLE
Add a direct link to each Challenge file

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -159,6 +159,12 @@ function externalDetailRow(labelText, text, href) {
   return row;
 }
 
+function pinnedSourceFileUrl(entry, path) {
+  const repository = entry.source.repository_url.replace(/\/+$/, "");
+  const encodedPath = path.split("/").map(encodeURIComponent).join("/");
+  return `${repository}/blob/${entry.source.commit}/${encodedPath}`;
+}
+
 function renderEntry(entry, content, canonicalUrl) {
   document.title = `${entry.title} — Palomar`;
   const heading = el("header", "entry-heading");
@@ -176,6 +182,11 @@ function renderEntry(entry, content, canonicalUrl) {
   const details = el("dl", "details");
   details.append(
     externalDetailRow("Immutable source", `${entry.source.repository}@${entry.source.commit.slice(0, 12)}`, entry.source.tree_url),
+    externalDetailRow(
+      "Challenge file",
+      `Open ${entry.formalization.challenge_path}`,
+      pinnedSourceFileUrl(entry, entry.formalization.challenge_path),
+    ),
     detailRow("Lean toolchain", entry.formalization.lean_toolchain),
     detailRow("Compared theorems", theoremNames(entry)),
     detailRow("Permitted axioms", entry.formalization.permitted_axioms.join(", ") || "none"),


### PR DESCRIPTION
## Summary

- add a one-click `Challenge.lean` link to the machine-evidence table on every entry page
- construct the link from the canonical repository URL, exact source commit, and recorded `challenge_path`
- keep the existing immutable-source link and database schema unchanged

## Validation

- `node --check assets/app.js`
- `npx --yes html-validate index.html entry.html about.html 404.html`
- `git diff --check`
- Chromium DOM smoke test against `PALOMAR-000001`, confirming the rendered link is:
  `https://github.com/kim-em/erdos-unit-distance-comparator/blob/8d9b8319a4ed2dd094655978e905512dee6394b6/Challenge.lean`

Rich rendering is deliberately left for a separate design discussion; this PR provides the reliable fallback regardless of that outcome.
