### PR TITLE
Present accepted Challenge renderings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test presentation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
+        with:
+          node-version: "24.4.1"
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:browser

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *~
 .DS_Store
+node_modules/
+playwright-report/
+test-results/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,16 @@ python -m http.server 8000
 ```
 
 Then open <http://localhost:8000>. Override the database endpoint for a local
-fixture by adding `?database=https://example.test/index.json`.
+fixture by adding `?database=https://example.test/index.json`. The matching
+render tree is resolved beside that custom database by default; use
+`&render-base=https://example.test/render-root/` to override it.
+
+Entry pages embed a rendered Challenge when the comparator names exactly one
+declaration and `Challenge.lean` is at most 100 lines and 32 KiB. Larger
+Challenges link to a dedicated rendered view. The pinned GitHub source link is
+always present. Rendered HTML is loaded in a fixed-height iframe with
+`sandbox="allow-scripts"` (deliberately without `allow-same-origin`) and no
+referrer.
 
 The website is a presentation layer only. Permanent data and schemas live in
 PalomarDatabase; consumers should use that repository directly.

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,9 +1,19 @@
+import {
+  challengeArtifactUrl,
+  challengeSourceUrl,
+  entryRecordPath,
+  isInlineChallenge,
+} from "./rendering.js";
+
 const DEFAULT_DATABASE =
   "https://raw.githubusercontent.com/kim-em/PalomarDatabase/main/index.json";
+const DEFAULT_RENDER_BASE = "https://kim-em.github.io/PalomarDatabase/";
 
 const params = new URLSearchParams(window.location.search);
 const databaseUrl = params.get("database") || DEFAULT_DATABASE;
 const databaseBase = new URL(".", databaseUrl);
+const renderBase = params.get("render-base") ||
+  (params.has("database") ? databaseBase.href : DEFAULT_RENDER_BASE);
 
 function el(tag, className, text) {
   const node = document.createElement(tag);
@@ -65,7 +75,7 @@ function entryCard(entry) {
   const top = el("div", "card-top");
   top.append(el("span", "entry-id", `${entry.id} · v${entry.version}`), trustBadge(entry));
   const title = el("h3");
-  title.append(link(entry.title, `entry.html?id=${encodeURIComponent(entry.id)}&version=${entry.version}`));
+  title.append(link(entry.title, localPageUrl("entry.html", entry)));
   const abstract = el("p", "card-abstract", entry.abstract);
   const meta = el("div", "card-meta");
   const authors = el("div");
@@ -76,7 +86,7 @@ function entryCard(entry) {
   const footer = el("div", "card-footer");
   footer.append(
     link(entry.source.repository, entry.source.tree_url, "repo-link"),
-    link("View record", `entry.html?id=${encodeURIComponent(entry.id)}&version=${entry.version}`),
+    link("View record", localPageUrl("entry.html", entry)),
   );
   card.append(top, title, abstract, meta, footer);
   return card;
@@ -165,6 +175,56 @@ function pinnedSourceFileUrl(entry, path) {
   return `${repository}/blob/${entry.source.commit}/${encodedPath}`;
 }
 
+function localPageUrl(page, entry) {
+  const target = new URL(page, window.location.href);
+  target.search = "";
+  target.searchParams.set("id", entry.id);
+  target.searchParams.set("version", String(entry.version));
+  for (const name of ["database", "render-base"]) {
+    if (params.has(name)) target.searchParams.set(name, params.get(name));
+  }
+  return target.href;
+}
+
+function challengeFrame(entry) {
+  const frame = el("iframe", "challenge-frame");
+  frame.src = challengeArtifactUrl(entry, renderBase).href;
+  frame.title = `Rendered Challenge for ${entry.id} version ${entry.version}`;
+  frame.loading = "lazy";
+  frame.referrerPolicy = "no-referrer";
+  frame.setAttribute("sandbox", "allow-scripts");
+  return frame;
+}
+
+function challengePresentation(entry, { forceFrame = false } = {}) {
+  const section = el("section", "challenge-presentation");
+  const heading = el("div", "section-heading");
+  const titleBlock = el("div");
+  titleBlock.append(el("div", "eyebrow", "Formal statement"), el("h2", "", "Challenge"));
+  heading.append(titleBlock);
+  section.append(heading);
+
+  const links = el("p", "challenge-links");
+  links.append(link("View canonical Challenge.lean", challengeSourceUrl(entry), "challenge-source"));
+  if (!forceFrame) {
+    links.append(" · ", link("Open rendered Challenge", localPageUrl("render.html", entry)));
+  }
+  section.append(links);
+
+  if (forceFrame || isInlineChallenge(entry)) {
+    section.append(challengeFrame(entry));
+  } else {
+    section.append(
+      el(
+        "p",
+        "challenge-fallback",
+        "This Challenge is larger than the inline reading limit; use the rendered view above.",
+      ),
+    );
+  }
+  return section;
+}
+
 function renderEntry(entry, content, canonicalUrl) {
   document.title = `${entry.title} — Palomar`;
   const heading = el("header", "entry-heading");
@@ -251,7 +311,16 @@ function renderEntry(entry, content, canonicalUrl) {
   pre.append(el("code", "", JSON.stringify(entry, null, 2)));
   machine.append(pre);
 
-  content.append(heading, evidence, trust, editorial, machine);
+  content.append(heading, challengePresentation(entry), evidence, trust, editorial, machine);
+}
+
+async function loadEntry(id, version) {
+  const index = await fetchJson(databaseUrl);
+  const summary = index.entries.find((item) => item.id === id && item.version === version);
+  if (!summary) throw new Error("entry not found");
+  const path = entryRecordPath(id, version, summary.path);
+  const canonicalUrl = new URL(path, databaseBase);
+  return { entry: await fetchJson(canonicalUrl), canonicalUrl };
 }
 
 async function renderEntryPage() {
@@ -265,11 +334,7 @@ async function renderEntryPage() {
     return;
   }
   try {
-    const index = await fetchJson(databaseUrl);
-    const summary = index.entries.find((item) => item.id === id && item.version === version);
-    if (!summary) throw new Error("entry not found");
-    const canonicalUrl = new URL(summary.path, databaseBase);
-    const entry = await fetchJson(canonicalUrl);
+    const { entry, canonicalUrl } = await loadEntry(id, version);
     status.hidden = true;
     content.hidden = false;
     renderEntry(entry, content, canonicalUrl);
@@ -279,5 +344,33 @@ async function renderEntryPage() {
   }
 }
 
+async function renderChallengePage() {
+  const status = document.querySelector("#status");
+  const content = document.querySelector("#render-content");
+  const id = params.get("id");
+  const version = Number(params.get("version"));
+  if (!/^PALOMAR-\d{6}$/.test(id || "") || !Number.isInteger(version) || version < 1) {
+    status.textContent = "This render link is missing a valid Palomar ID and version.";
+    status.classList.add("error");
+    return;
+  }
+  try {
+    const { entry } = await loadEntry(id, version);
+    document.title = `Challenge — ${entry.title} — Palomar`;
+    const heading = el("header", "entry-heading");
+    heading.append(
+      el("div", "entry-id", `${entry.id} · version ${entry.version}`),
+      el("h1", "", entry.title),
+    );
+    content.append(heading, challengePresentation(entry, { forceFrame: true }));
+    status.hidden = true;
+    content.hidden = false;
+  } catch (error) {
+    status.textContent = `The rendered Challenge could not be loaded: ${error.message}`;
+    status.classList.add("error");
+  }
+}
+
 if (document.body.dataset.page === "index") renderIndex();
 if (document.body.dataset.page === "entry") renderEntryPage();
+if (document.body.dataset.page === "render") renderChallengePage();

--- a/assets/rendering.js
+++ b/assets/rendering.js
@@ -1,0 +1,72 @@
+export const INLINE_CHALLENGE_MAX_LINES = 100;
+export const INLINE_CHALLENGE_MAX_BYTES = 32 * 1024;
+
+const ID = /^PALOMAR-[0-9]{6}$/;
+const SHA = /^[0-9a-f]{40}$/;
+const SHA256 = /^[0-9a-f]{64}$/;
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+export function isInlineChallenge(entry) {
+  const formalization = entry?.formalization;
+  const trust = entry?.trust;
+  const theoremNames = formalization?.theorem_names;
+  const definitionNames = formalization?.definition_names;
+  if (!Array.isArray(theoremNames) || !Array.isArray(definitionNames)) return false;
+  return (
+    theoremNames.length + definitionNames.length === 1 &&
+    Number.isInteger(trust?.challenge_lines) &&
+    trust.challenge_lines >= 0 &&
+    trust.challenge_lines <= INLINE_CHALLENGE_MAX_LINES &&
+    Number.isInteger(trust?.challenge_bytes) &&
+    trust.challenge_bytes >= 0 &&
+    trust.challenge_bytes <= INLINE_CHALLENGE_MAX_BYTES
+  );
+}
+
+export function challengeSourceUrl(entry) {
+  const repository = entry?.source?.repository;
+  const repositoryUrl = entry?.source?.repository_url?.replace(/\/+$/, "");
+  const commit = entry?.source?.commit;
+  const challengePath = entry?.formalization?.challenge_path;
+  if (
+    !REPOSITORY.test(repository || "") ||
+    repositoryUrl !== `https://github.com/${repository}` ||
+    !SHA.test(commit || "") ||
+    challengePath !== "Challenge.lean"
+  ) {
+    throw new Error("entry has invalid canonical Challenge source metadata");
+  }
+  return `${repositoryUrl}/blob/${commit}/Challenge.lean`;
+}
+
+export function challengeArtifactUrl(entry, renderBase) {
+  const id = entry?.id;
+  const version = entry?.version;
+  const render = entry?.challenge_render;
+  if (!ID.test(id || "") || !Number.isInteger(version) || version < 1) {
+    throw new Error("entry has an invalid Palomar identifier or version");
+  }
+  const treeHash = render?.artifact_tree_sha256;
+  const expectedPath = `renders/${id}-v${version}/${treeHash}/`;
+  if (
+    render?.format !== "verso-html" ||
+    render?.entrypoint !== "Challenge/index.html" ||
+    !SHA256.test(treeHash || "") ||
+    render?.artifact_path !== expectedPath
+  ) {
+    throw new Error("entry has invalid Challenge render metadata");
+  }
+  const base = new URL(renderBase);
+  if (!['http:', 'https:'].includes(base.protocol)) {
+    throw new Error("Challenge render base must use HTTP or HTTPS");
+  }
+  return new URL(`${expectedPath}${render.entrypoint}`, base);
+}
+
+export function entryRecordPath(id, version, path) {
+  const expected = `entries/${id}-v${version}.json`;
+  if (!ID.test(id || "") || !Number.isInteger(version) || version < 1 || path !== expected) {
+    throw new Error("registry index contains an invalid entry path");
+  }
+  return expected;
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -439,6 +439,29 @@ footer {
   border-top: 1px solid var(--line);
 }
 
+.challenge-links {
+  margin-bottom: .75rem;
+  font: .9rem/1.4 var(--sans);
+}
+
+.challenge-frame {
+  display: block;
+  width: 100%;
+  height: min(42rem, 70vh);
+  min-height: 18rem;
+  border: 1px solid var(--line);
+  background: var(--paper);
+}
+
+.challenge-fallback {
+  max-width: 62ch;
+  color: var(--muted);
+}
+
+.render-page {
+  width: min(calc(100% - 2rem), 90rem);
+}
+
 .details {
   margin: 0;
   border-block: 1px solid var(--line);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "palomar-web",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "palomar-web",
+      "devDependencies": {
+        "@playwright/test": "1.62.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "palomar-web",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test tests/rendering.test.js",
+    "test:browser": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.62.1"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,21 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "site.spec.js",
+  fullyParallel: false,
+  workers: 1,
+  reporter: "line",
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    browserName: "chromium",
+    launchOptions: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+      ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH }
+      : {},
+  },
+  webServer: {
+    command: "python3 tests/fixture_server.py",
+    url: "http://127.0.0.1:4173/entry.html",
+    reuseExistingServer: false,
+  },
+});

--- a/render.html
+++ b/render.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#ffffff">
+    <title>Rendered Challenge — Palomar</title>
+    <link rel="stylesheet" href="assets/style.css">
+  </head>
+  <body data-page="render">
+    <a class="skip-link" href="#render">Skip to rendered Challenge</a>
+    <header class="site-header">
+      <a class="brand" href="./">Palomar</a>
+      <nav aria-label="Main navigation"><a href="./">Registry</a><a href="about.html">About</a><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit</a></nav>
+    </header>
+    <main id="render" class="entry-page render-page">
+      <div id="status" class="status">Reading registry entry…</div>
+      <article id="render-content" hidden></article>
+    </main>
+    <footer>
+      <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
+      <div class="footer-links"><a href="https://github.com/kim-em/PalomarPolicy">Policy</a><a href="https://github.com/kim-em/PalomarDatabase">Data</a><a href="https://github.com/kim-em/PalomarWeb">Source</a></div>
+    </footer>
+    <script type="module" src="assets/app.js"></script>
+  </body>
+</html>

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Serve the static site plus synthetic registry and hostile render fixtures."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+HOST = "127.0.0.1"
+PORT = 4173
+HASH = "a" * 64
+
+
+def entry(identifier: str, lines: int) -> dict:
+    return {
+        "id": identifier,
+        "version": 1,
+        "title": f"Fixture {identifier}",
+        "abstract": "A browser confinement fixture.",
+        "authors": [{"name": "Example"}],
+        "source": {
+            "repository": "example/challenge",
+            "repository_url": "https://github.com/example/challenge",
+            "commit": "1" * 40,
+            "tree_url": f"https://github.com/example/challenge/tree/{'1' * 40}",
+        },
+        "formalization": {
+            "challenge_path": "Challenge.lean",
+            "theorem_names": ["Example.theorem"],
+            "definition_names": [],
+            "lean_toolchain": "leanprover/lean4:v4.31.0-rc2",
+            "permitted_axioms": [],
+        },
+        "verification": {"comparator_commit": "2" * 40, "workflow_url": "https://example.test/run"},
+        "trust": {
+            "level": "high",
+            "challenge_lines": lines,
+            "challenge_bytes": 1024,
+            "challenge_imports": ["Mathlib"],
+            "challenge_dependencies": [],
+            "reasons": [],
+        },
+        "review": {
+            "scores": {"clarity": 5},
+            "warnings": [],
+            "report_url": "https://example.test/review",
+        },
+        "challenge_render": {
+            "format": "verso-html",
+            "artifact_path": f"renders/{identifier}-v1/{HASH}/",
+            "entrypoint": "Challenge/index.html",
+            "artifact_tree_sha256": HASH,
+        },
+    }
+
+
+ENTRIES = {
+    "PALOMAR-000123": entry("PALOMAR-000123", 100),
+    "PALOMAR-000124": entry("PALOMAR-000124", 101),
+}
+
+
+class Handler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=str(ROOT), **kwargs)
+
+    def send_bytes(self, payload: bytes, content_type: str) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(payload)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self) -> None:  # noqa: N802 - inherited HTTP method name
+        path = self.path.split("?", 1)[0]
+        if path == "/database/index.json":
+            payload = {
+                "entries": [
+                    {
+                        "id": item["id"],
+                        "version": 1,
+                        "path": f"entries/{item['id']}-v1.json",
+                    }
+                    for item in ENTRIES.values()
+                ]
+            }
+            self.send_bytes(json.dumps(payload).encode(), "application/json")
+            return
+        match = re.fullmatch(r"/database/entries/(PALOMAR-[0-9]{6})-v1\.json", path)
+        if match and match.group(1) in ENTRIES:
+            self.send_bytes(json.dumps(ENTRIES[match.group(1)]).encode(), "application/json")
+            return
+        if re.fullmatch(
+            rf"/database/renders/PALOMAR-[0-9]{{6}}-v1/{HASH}/Challenge/index\.html",
+            path,
+        ):
+            page = f"""<!doctype html>
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'none'; form-action 'none'">
+<title>Hostile render fixture</title>
+<body><h1>Rendered theorem</h1><script defer src="../attack.js"></script></body>"""
+            self.send_bytes(page.encode(), "text/html; charset=utf-8")
+            return
+        if re.fullmatch(rf"/database/renders/PALOMAR-[0-9]{{6}}-v1/{HASH}/attack\.js", path):
+            script = """
+document.body.dataset.scriptRan = "true";
+try { top.document.body.dataset.compromised = "true"; }
+catch (_) { document.body.dataset.topAccess = "blocked"; }
+try { localStorage.setItem("palomar-attack", "true"); }
+catch (_) { document.body.dataset.storageAccess = "blocked"; }
+"""
+            self.send_bytes(script.encode(), "text/javascript; charset=utf-8")
+            return
+        super().do_GET()
+
+
+if __name__ == "__main__":
+    ThreadingHTTPServer((HOST, PORT), Handler).serve_forever()

--- a/tests/rendering.test.js
+++ b/tests/rendering.test.js
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  challengeArtifactUrl,
+  challengeSourceUrl,
+  entryRecordPath,
+  isInlineChallenge,
+} from "../assets/rendering.js";
+
+function entry(overrides = {}) {
+  const value = {
+    id: "PALOMAR-000123",
+    version: 1,
+    source: {
+      repository: "example/challenge",
+      repository_url: "https://github.com/example/challenge",
+      commit: "1".repeat(40),
+    },
+    formalization: {
+      challenge_path: "Challenge.lean",
+      theorem_names: ["Example.theorem"],
+      definition_names: [],
+    },
+    trust: { challenge_lines: 100, challenge_bytes: 32 * 1024 },
+    challenge_render: {
+      format: "verso-html",
+      artifact_path: `renders/PALOMAR-000123-v1/${"a".repeat(64)}/`,
+      entrypoint: "Challenge/index.html",
+      artifact_tree_sha256: "a".repeat(64),
+    },
+  };
+  return Object.assign(value, overrides);
+}
+
+test("inline policy includes both size limits and exactly one declaration", () => {
+  assert.equal(isInlineChallenge(entry()), true);
+  assert.equal(isInlineChallenge(entry({ trust: { challenge_lines: 101, challenge_bytes: 1 } })), false);
+  assert.equal(
+    isInlineChallenge(entry({ trust: { challenge_lines: 1, challenge_bytes: 32 * 1024 + 1 } })),
+    false,
+  );
+  const two = entry();
+  two.formalization.definition_names.push("Example.definition");
+  assert.equal(isInlineChallenge(two), false);
+});
+
+test("artifact URL is derived only from the content-addressed registry fields", () => {
+  assert.equal(
+    challengeArtifactUrl(entry(), "https://kim-em.github.io/PalomarDatabase/").href,
+    `https://kim-em.github.io/PalomarDatabase/renders/PALOMAR-000123-v1/${"a".repeat(64)}/Challenge/index.html`,
+  );
+  const traversal = entry();
+  traversal.challenge_render.artifact_path = "renders/../../attacker/";
+  assert.throws(() => challengeArtifactUrl(traversal, "https://example.test/"), /invalid/);
+});
+
+test("source URL is always the immutable canonical GitHub file", () => {
+  assert.equal(
+    challengeSourceUrl(entry()),
+    `https://github.com/example/challenge/blob/${"1".repeat(40)}/Challenge.lean`,
+  );
+  const moving = entry();
+  moving.source.commit = "main";
+  assert.throws(() => challengeSourceUrl(moving), /canonical/);
+});
+
+test("index paths cannot redirect entry fetching", () => {
+  assert.equal(
+    entryRecordPath("PALOMAR-000123", 1, "entries/PALOMAR-000123-v1.json"),
+    "entries/PALOMAR-000123-v1.json",
+  );
+  assert.throws(
+    () => entryRecordPath("PALOMAR-000123", 1, "https://attacker.invalid/entry.json"),
+    /invalid entry path/,
+  );
+});

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+
+const database = encodeURIComponent("http://127.0.0.1:4173/database/index.json");
+
+test("eligible Challenge renders inline without origin privilege", async ({ page }) => {
+  await page.goto(`/entry.html?id=PALOMAR-000123&version=1&database=${database}`);
+
+  const source = page.locator(".challenge-presentation .challenge-source");
+  await expect(source).toHaveAttribute(
+    "href",
+    `https://github.com/example/challenge/blob/${"1".repeat(40)}/Challenge.lean`,
+  );
+  const iframe = page.locator(".challenge-presentation iframe");
+  await expect(iframe).toHaveAttribute("sandbox", "allow-scripts");
+  await expect(iframe).toHaveAttribute("referrerpolicy", "no-referrer");
+  await expect(iframe).toHaveAttribute(
+    "src",
+    `http://127.0.0.1:4173/database/renders/PALOMAR-000123-v1/${"a".repeat(64)}/Challenge/index.html`,
+  );
+  const body = page.frameLocator(".challenge-presentation iframe").locator("body");
+  await expect(body).toHaveAttribute("data-script-ran", "true");
+  await expect(body).toHaveAttribute("data-top-access", "blocked");
+  await expect(body).toHaveAttribute("data-storage-access", "blocked");
+  await expect(page.locator("body")).not.toHaveAttribute("data-compromised", "true");
+  const box = await iframe.boundingBox();
+  expect(box.height).toBeLessThanOrEqual(672);
+});
+
+test("larger Challenge falls back to the dedicated wrapper", async ({ page }) => {
+  await page.goto(`/entry.html?id=PALOMAR-000124&version=1&database=${database}`);
+  await expect(page.locator(".challenge-presentation iframe")).toHaveCount(0);
+  await expect(page.locator(".challenge-fallback")).toBeVisible();
+  await page.getByRole("link", { name: "Open rendered Challenge" }).click();
+  await expect(page).toHaveURL(/render\.html\?id=PALOMAR-000124/);
+  await expect(page.locator(".challenge-presentation iframe")).toHaveAttribute(
+    "sandbox",
+    "allow-scripts",
+  );
+  await expect(page.locator(".challenge-source")).toHaveAttribute(
+    "href",
+    `https://github.com/example/challenge/blob/${"1".repeat(40)}/Challenge.lean`,
+  );
+});


### PR DESCRIPTION
## Summary

- render a single declaration inline when it is at most 100 lines and 32 KiB
- provide a dedicated wrapper page for larger Challenges
- always link the immutable canonical `Challenge.lean`
- derive artifact URLs only from validated content-addressed registry fields
- run the interactive render in an opaque-origin iframe with `sandbox="allow-scripts"` and no referrer
- add unit and adversarial Chromium coverage plus CI

## Why

Readers should get an interactive Verso view without giving hostile source-derived output access to the Palomar page origin.

Closes #5.

## Validation

- `4` unit tests passed
- `2` adversarial Chromium tests passed
- `git diff --check`