### PR TITLE
Present Challenge metadata outside Verso

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,5 +1,6 @@
 import {
   challengeArtifactUrl,
+  challengeMetadataUrl,
   challengeSourceUrl,
   entryRecordPath,
   isInlineChallenge,
@@ -30,7 +31,11 @@ function link(text, href, className) {
 
 async function fetchJson(url) {
   const response = await fetch(url, { cache: "no-cache" });
-  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+  if (!response.ok) {
+    const error = new Error(`${response.status} ${response.statusText}`);
+    error.status = response.status;
+    throw error;
+  }
   return response.json();
 }
 
@@ -193,10 +198,52 @@ function challengeFrame(entry) {
   frame.loading = "lazy";
   frame.referrerPolicy = "no-referrer";
   frame.setAttribute("sandbox", "allow-scripts");
+  frame.setAttribute("scrolling", "auto");
   return frame;
 }
 
-function challengePresentation(entry, { forceFrame = false } = {}) {
+function validateChallengeMetadata(entry, metadata) {
+  const expectedDeclarations = [
+    ...entry.formalization.theorem_names,
+    ...entry.formalization.definition_names,
+  ];
+  const expectedImports = entry.trust.challenge_imports;
+  const sameArray = (left, right) =>
+    Array.isArray(left) && left.length === right.length &&
+      left.every((value, index) => value === right[index]);
+  if (
+    metadata?.schema_version !== 1 ||
+    !sameArray(metadata.declarations, expectedDeclarations) ||
+    !sameArray(metadata.imports, expectedImports) ||
+    !(metadata.module_doc === null ||
+      (typeof metadata.module_doc === "string" && metadata.module_doc.length <= 256 * 1024))
+  ) {
+    throw new Error("Challenge render metadata does not match the registry entry");
+  }
+  return metadata;
+}
+
+function challengeMetadata(metadata) {
+  const panel = el("div", "challenge-metadata");
+  panel.append(el("div", "eyebrow", "Parsed source metadata"));
+  const imports = el("div", "challenge-metadata-row");
+  imports.append(el("strong", "", "Direct imports"));
+  const tokens = el("span", "token-list");
+  for (const item of metadata.imports) tokens.append(el("code", "", item));
+  imports.append(tokens);
+  panel.append(imports);
+  if (metadata.module_doc) {
+    const moduleDoc = el("details", "challenge-module-doc");
+    moduleDoc.append(el("summary", "", "Module documentation"));
+    moduleDoc.append(el("pre", "", metadata.module_doc));
+    panel.append(moduleDoc);
+  } else {
+    panel.append(el("p", "challenge-no-module-doc", "No module documentation was found."));
+  }
+  return panel;
+}
+
+async function challengePresentation(entry, { forceFrame = false } = {}) {
   const section = el("section", "challenge-presentation");
   const heading = el("div", "section-heading");
   const titleBlock = el("div");
@@ -210,6 +257,25 @@ function challengePresentation(entry, { forceFrame = false } = {}) {
     links.append(" · ", link("Open rendered Challenge", localPageUrl("render.html", entry)));
   }
   section.append(links);
+
+  let metadata;
+  try {
+    metadata = validateChallengeMetadata(
+      entry,
+      await fetchJson(challengeMetadataUrl(entry, renderBase)),
+    );
+  } catch (error) {
+    if (error.status !== 404) throw error;
+    section.append(
+      el(
+        "p",
+        "challenge-fallback",
+        "This historical rendering predates declaration-only presentation metadata; use the canonical Challenge.lean link above.",
+      ),
+    );
+    return section;
+  }
+  section.append(challengeMetadata(metadata));
 
   if (forceFrame || isInlineChallenge(entry)) {
     section.append(challengeFrame(entry));
@@ -225,7 +291,7 @@ function challengePresentation(entry, { forceFrame = false } = {}) {
   return section;
 }
 
-function renderEntry(entry, content, canonicalUrl) {
+async function renderEntry(entry, content, canonicalUrl) {
   document.title = `${entry.title} — Palomar`;
   const heading = el("header", "entry-heading");
   const top = el("div", "card-top");
@@ -311,7 +377,14 @@ function renderEntry(entry, content, canonicalUrl) {
   pre.append(el("code", "", JSON.stringify(entry, null, 2)));
   machine.append(pre);
 
-  content.append(heading, challengePresentation(entry), evidence, trust, editorial, machine);
+  content.append(
+    heading,
+    await challengePresentation(entry),
+    evidence,
+    trust,
+    editorial,
+    machine,
+  );
 }
 
 async function loadEntry(id, version) {
@@ -337,7 +410,7 @@ async function renderEntryPage() {
     const { entry, canonicalUrl } = await loadEntry(id, version);
     status.hidden = true;
     content.hidden = false;
-    renderEntry(entry, content, canonicalUrl);
+    await renderEntry(entry, content, canonicalUrl);
   } catch (error) {
     status.textContent = `The registry entry could not be loaded: ${error.message}`;
     status.classList.add("error");
@@ -362,7 +435,7 @@ async function renderChallengePage() {
       el("div", "entry-id", `${entry.id} · version ${entry.version}`),
       el("h1", "", entry.title),
     );
-    content.append(heading, challengePresentation(entry, { forceFrame: true }));
+    content.append(heading, await challengePresentation(entry, { forceFrame: true }));
     status.hidden = true;
     content.hidden = false;
   } catch (error) {

--- a/assets/rendering.js
+++ b/assets/rendering.js
@@ -63,6 +63,10 @@ export function challengeArtifactUrl(entry, renderBase) {
   return new URL(`${expectedPath}${render.entrypoint}`, base);
 }
 
+export function challengeMetadataUrl(entry, renderBase) {
+  return new URL("../challenge-metadata.json", challengeArtifactUrl(entry, renderBase));
+}
+
 export function entryRecordPath(id, version, path) {
   const expected = `entries/${id}-v${version}.json`;
   if (!ID.test(id || "") || !Number.isInteger(version) || version < 1 || path !== expected) {

--- a/assets/style.css
+++ b/assets/style.css
@@ -444,6 +444,45 @@ footer {
   font: .9rem/1.4 var(--sans);
 }
 
+.challenge-metadata {
+  margin-bottom: .75rem;
+  padding: .75rem;
+  border: 1px solid var(--line);
+  background: var(--shade);
+}
+
+.challenge-metadata-row {
+  display: flex;
+  align-items: baseline;
+  gap: .75rem;
+  margin-top: .45rem;
+}
+
+.challenge-module-doc {
+  margin-top: .7rem;
+  border-top: 1px dotted var(--line);
+  padding-top: .55rem;
+}
+
+.challenge-module-doc summary {
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.challenge-module-doc pre {
+  margin: .6rem 0 0;
+  max-height: 24rem;
+  overflow: auto;
+  padding: .65rem;
+  background: var(--paper);
+  white-space: pre-wrap;
+}
+
+.challenge-no-module-doc {
+  margin: .6rem 0 0;
+  color: var(--muted);
+}
+
 .challenge-frame {
   display: block;
   width: 100%;

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -101,8 +101,25 @@ class Handler(SimpleHTTPRequestHandler):
             page = f"""<!doctype html>
 <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; object-src 'none'; frame-src 'none'; base-uri 'none'; form-action 'none'">
 <title>Hostile render fixture</title>
-<body><h1>Rendered theorem</h1><script defer src="../attack.js"></script></body>"""
+<style>html, body {{ height: auto; overflow: auto; }} body {{ margin: 0; }}
+.theorem {{ padding: 1rem; }} .theorem-lines {{ height: 70rem; }}</style>
+<body><main><p class="docstring">The theorem doc-string.</p>
+<div class="theorem"><pre>theorem Example.theorem :</pre><div class="theorem-lines"></div>
+<pre id="theorem-end">  True := by trivial</pre></div>
+</main><script defer src="../attack.js"></script></body>"""
             self.send_bytes(page.encode(), "text/html; charset=utf-8")
+            return
+        if re.fullmatch(
+            rf"/database/renders/PALOMAR-[0-9]{{6}}-v1/{HASH}/challenge-metadata\.json",
+            path,
+        ):
+            metadata = {
+                "schema_version": 1,
+                "imports": ["Mathlib"],
+                "module_doc": "# Fixture module\n\nParsed outside the Verso surface.",
+                "declarations": ["Example.theorem"],
+            }
+            self.send_bytes(json.dumps(metadata).encode(), "application/json")
             return
         if re.fullmatch(rf"/database/renders/PALOMAR-[0-9]{{6}}-v1/{HASH}/attack\.js", path):
             script = """

--- a/tests/rendering.test.js
+++ b/tests/rendering.test.js
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   challengeArtifactUrl,
+  challengeMetadataUrl,
   challengeSourceUrl,
   entryRecordPath,
   isInlineChallenge,
@@ -53,6 +54,13 @@ test("artifact URL is derived only from the content-addressed registry fields", 
   const traversal = entry();
   traversal.challenge_render.artifact_path = "renders/../../attacker/";
   assert.throws(() => challengeArtifactUrl(traversal, "https://example.test/"), /invalid/);
+});
+
+test("artifact metadata URL stays inside the content-addressed bundle", () => {
+  assert.equal(
+    challengeMetadataUrl(entry(), "https://kim-em.github.io/PalomarDatabase/").href,
+    `https://kim-em.github.io/PalomarDatabase/renders/PALOMAR-000123-v1/${"a".repeat(64)}/challenge-metadata.json`,
+  );
 });
 
 test("source URL is always the immutable canonical GitHub file", () => {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -13,6 +13,7 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   const iframe = page.locator(".challenge-presentation iframe");
   await expect(iframe).toHaveAttribute("sandbox", "allow-scripts");
   await expect(iframe).toHaveAttribute("referrerpolicy", "no-referrer");
+  await expect(iframe).toHaveAttribute("scrolling", "auto");
   await expect(iframe).toHaveAttribute(
     "src",
     `http://127.0.0.1:4173/database/renders/PALOMAR-000123-v1/${"a".repeat(64)}/Challenge/index.html`,
@@ -22,8 +23,21 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   await expect(body).toHaveAttribute("data-top-access", "blocked");
   await expect(body).toHaveAttribute("data-storage-access", "blocked");
   await expect(page.locator("body")).not.toHaveAttribute("data-compromised", "true");
+  await expect(page.locator(".challenge-metadata")).toContainText("Direct imports");
+  await expect(page.locator(".challenge-metadata code")).toHaveText("Mathlib");
+  await expect(page.locator(".challenge-module-doc summary")).toHaveText("Module documentation");
+  await page.locator(".challenge-module-doc summary").click();
+  await expect(page.locator(".challenge-module-doc pre")).toContainText("Parsed outside the Verso surface");
+  const rendered = page.frameLocator(".challenge-presentation iframe");
+  await expect(rendered.locator(".docstring")).toHaveText("The theorem doc-string.");
+  await expect(rendered.locator(".skip-link")).toHaveCount(0);
+  await expect(rendered.locator("body")).not.toContainText("Fixture module");
   const box = await iframe.boundingBox();
   expect(box.height).toBeLessThanOrEqual(672);
+  await iframe.hover();
+  await page.mouse.wheel(0, 2000);
+  await expect.poll(() => rendered.locator("html").evaluate((node) => node.scrollTop)).toBeGreaterThan(0);
+  await expect(rendered.locator("#theorem-end")).toBeInViewport();
 });
 
 test("larger Challenge falls back to the dedicated wrapper", async ({ page }) => {


### PR DESCRIPTION
Move source-level metadata out of the rendered Lean surface.

- Fetch content-addressed parsed imports and module documentation
- Present them in a separate metadata panel
- Keep the iframe confined and explicitly scrollable
- Add a Playwright wheel test that reaches the theorem bottom
- Gracefully suppress legacy renders that lack declaration-only metadata