### PR TITLE
Clarify accepted entry presentation

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -15,6 +15,7 @@ const databaseUrl = params.get("database") || DEFAULT_DATABASE;
 const databaseBase = new URL(".", databaseUrl);
 const renderBase = params.get("render-base") ||
   (params.has("database") ? databaseBase.href : DEFAULT_RENDER_BASE);
+const PALOMAR_ID = /^PALOMAR-(?:\d{4}-\d{2}-\d{2}-)?\d{6}$/;
 
 function el(tag, className, text) {
   const node = document.createElement(tag);
@@ -47,9 +48,28 @@ function theoremNames(entry) {
   return entry.formalization.theorem_names.join(", ");
 }
 
+function acceptanceDate(entry) {
+  const value = entry.accepted_at || entry.review?.reviewed_at?.slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value || "")) {
+    throw new Error("entry is missing a valid acceptance date");
+  }
+  return value;
+}
+
+function displayDate(value) {
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "long",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(new Date(`${value}T00:00:00Z`));
+}
+
 function latestVersions(entries) {
+  const aliases = new Set(entries.flatMap((entry) => entry.aliases || []));
   const latest = new Map();
   for (const entry of entries) {
+    if (aliases.has(entry.id)) continue;
     const previous = latest.get(entry.id);
     if (!previous || entry.version > previous.version) latest.set(entry.id, entry);
   }
@@ -78,7 +98,12 @@ function entryCard(entry) {
   ].join(" ").toLowerCase();
 
   const top = el("div", "card-top");
-  top.append(el("span", "entry-id", `${entry.id} · v${entry.version}`), trustBadge(entry));
+  const identity = el("div", "card-identity");
+  identity.append(
+    el("span", "entry-id", `${entry.id} · v${entry.version}`),
+    el("span", "entry-date", `Accepted ${displayDate(acceptanceDate(entry))}`),
+  );
+  top.append(identity, trustBadge(entry));
   const title = el("h3");
   title.append(link(entry.title, localPageUrl("entry.html", entry)));
   const abstract = el("p", "card-abstract", entry.abstract);
@@ -199,6 +224,15 @@ function challengeFrame(entry) {
   frame.referrerPolicy = "no-referrer";
   frame.setAttribute("sandbox", "allow-scripts");
   frame.setAttribute("scrolling", "auto");
+  window.addEventListener("message", (event) => {
+    if (event.source !== frame.contentWindow || event.data?.type !== "palomar-render-height") {
+      return;
+    }
+    const height = event.data.height;
+    if (!Number.isSafeInteger(height) || height <= 0) return;
+    frame.style.height = `${Math.max(160, Math.min(672, height + 2))}px`;
+    frame.dataset.heightAdjusted = "true";
+  });
   return frame;
 }
 
@@ -212,13 +246,21 @@ function validateChallengeMetadata(entry, metadata) {
     Array.isArray(left) && left.length === right.length &&
       left.every((value, index) => value === right[index]);
   if (
-    metadata?.schema_version !== 1 ||
+    ![1, 2].includes(metadata?.schema_version) ||
     !sameArray(metadata.declarations, expectedDeclarations) ||
     !sameArray(metadata.imports, expectedImports) ||
     !(metadata.module_doc === null ||
       (typeof metadata.module_doc === "string" && metadata.module_doc.length <= 256 * 1024))
   ) {
     throw new Error("Challenge render metadata does not match the registry entry");
+  }
+  if (
+    metadata.schema_version >= 2 &&
+    (!Array.isArray(metadata.solution_imports) ||
+      metadata.solution_imports.length > 1_000 ||
+      !metadata.solution_imports.every((item) => typeof item === "string" && item.length > 0))
+  ) {
+    throw new Error("Challenge render metadata contains invalid Solution imports");
   }
   return metadata;
 }
@@ -253,7 +295,8 @@ async function challengePresentation(entry, { forceFrame = false } = {}) {
 
   const links = el("p", "challenge-links");
   links.append(link("View canonical Challenge.lean", challengeSourceUrl(entry), "challenge-source"));
-  if (!forceFrame) {
+  const inline = isInlineChallenge(entry);
+  if (!forceFrame && !inline) {
     links.append(" · ", link("Open rendered Challenge", localPageUrl("render.html", entry)));
   }
   section.append(links);
@@ -273,11 +316,11 @@ async function challengePresentation(entry, { forceFrame = false } = {}) {
         "This historical rendering predates declaration-only presentation metadata; use the canonical Challenge.lean link above.",
       ),
     );
-    return section;
+    return {section, metadata: null};
   }
   section.append(challengeMetadata(metadata));
 
-  if (forceFrame || isInlineChallenge(entry)) {
+  if (forceFrame || inline) {
     section.append(challengeFrame(entry));
   } else {
     section.append(
@@ -288,6 +331,83 @@ async function challengePresentation(entry, { forceFrame = false } = {}) {
       ),
     );
   }
+  return {section, metadata};
+}
+
+function acceptanceCallout(entry) {
+  const callout = el("div", "acceptance-callout");
+  const check = el("span", "acceptance-check", "✓");
+  check.setAttribute("aria-hidden", "true");
+  const copy = el("div");
+  copy.append(
+    el("strong", "", `Accepted on ${displayDate(acceptanceDate(entry))}`),
+    el(
+      "p",
+      "",
+      "Palomar checked the pinned Solution with Lean, matched every advertised declaration with Comparator, verified the permitted axiom set, and accepted the editorial review.",
+    ),
+  );
+  callout.append(check, copy);
+  return callout;
+}
+
+function solutionMetadata(entry, renderMetadata) {
+  const section = el("section", "entry-solution");
+  const heading = el("div", "section-heading");
+  const title = el("div");
+  title.append(el("div", "eyebrow", "Accepted proof artifact"), el("h2", "", "Verified solution"));
+  heading.append(title, el("span", "decision accepted-decision", "Accepted"));
+  section.append(heading);
+  section.append(
+    el(
+      "p",
+      "solution-summary",
+      "The accepted Solution.lean was checked at the immutable source commit against the pinned transitive Lake dependency closure below.",
+    ),
+  );
+
+  const details = el("dl", "details solution-details");
+  details.append(
+    externalDetailRow(
+      "Solution file",
+      `Open ${entry.formalization.solution_path}`,
+      pinnedSourceFileUrl(entry, entry.formalization.solution_path),
+    ),
+    detailRow("Solution SHA-256", entry.verification.solution_sha256),
+  );
+  if (renderMetadata?.schema_version >= 2) {
+    const row = el("div", "detail-row");
+    row.append(el("dt", "", "Direct imports"));
+    const value = el("dd", "token-list");
+    for (const item of renderMetadata.solution_imports) value.append(el("code", "", item));
+    row.append(value);
+    details.append(row);
+  }
+  section.append(details);
+
+  const dependencies = entry.formalization.project_dependencies;
+  const closure = el("details", "solution-dependencies");
+  closure.append(
+    el(
+      "summary",
+      "",
+      `${dependencies.length} pinned repositories in the transitive Lake closure`,
+    ),
+  );
+  const list = el("ul", "dependency-list");
+  for (const dependency of dependencies) {
+    const item = el("li");
+    item.append(
+      link(
+        dependency.repository,
+        `https://github.com/${dependency.repository}/tree/${dependency.revision}`,
+      ),
+      el("code", "", dependency.revision.slice(0, 12)),
+    );
+    list.append(item);
+  }
+  closure.append(list);
+  section.append(closure);
   return section;
 }
 
@@ -305,13 +425,24 @@ async function renderEntry(entry, content, canonicalUrl) {
   const titleBlock = el("div");
   titleBlock.append(el("div", "eyebrow", "Machine evidence"), el("h2", "", "What was checked"));
   evidenceTitle.append(titleBlock);
+  evidence.append(evidenceTitle, acceptanceCallout(entry));
   const details = el("dl", "details");
   details.append(
+    detailRow("Acceptance date", displayDate(acceptanceDate(entry))),
+    detailRow(
+      "Lean verification date",
+      displayDate(entry.verification.verified_at.slice(0, 10)),
+    ),
     externalDetailRow("Immutable source", `${entry.source.repository}@${entry.source.commit.slice(0, 12)}`, entry.source.tree_url),
     externalDetailRow(
       "Challenge file",
       `Open ${entry.formalization.challenge_path}`,
       pinnedSourceFileUrl(entry, entry.formalization.challenge_path),
+    ),
+    externalDetailRow(
+      "Solution file",
+      `Open ${entry.formalization.solution_path}`,
+      pinnedSourceFileUrl(entry, entry.formalization.solution_path),
     ),
     detailRow("Lean toolchain", entry.formalization.lean_toolchain),
     detailRow("Compared theorems", theoremNames(entry)),
@@ -319,7 +450,7 @@ async function renderEntry(entry, content, canonicalUrl) {
     detailRow("Challenge surface", `${entry.trust.challenge_lines} lines · ${entry.trust.challenge_bytes} bytes`),
     externalDetailRow("Comparator run", entry.verification.comparator_commit.slice(0, 12), entry.verification.workflow_url),
   );
-  evidence.append(evidenceTitle, details);
+  evidence.append(details);
 
   const trust = el("section", "entry-trust");
   const trustTitle = el("div", "section-heading");
@@ -377,11 +508,13 @@ async function renderEntry(entry, content, canonicalUrl) {
   pre.append(el("code", "", JSON.stringify(entry, null, 2)));
   machine.append(pre);
 
+  const challenge = await challengePresentation(entry);
   content.append(
     heading,
-    await challengePresentation(entry),
+    challenge.section,
     evidence,
     trust,
+    solutionMetadata(entry, challenge.metadata),
     editorial,
     machine,
   );
@@ -389,11 +522,15 @@ async function renderEntry(entry, content, canonicalUrl) {
 
 async function loadEntry(id, version) {
   const index = await fetchJson(databaseUrl);
+  const replacements = index.entries
+    .filter((item) => Array.isArray(item.aliases) && item.aliases.includes(id))
+    .sort((left, right) => right.version - left.version);
+  if (replacements.length) return { replacement: replacements[0] };
   const summary = index.entries.find((item) => item.id === id && item.version === version);
   if (!summary) throw new Error("entry not found");
   const path = entryRecordPath(id, version, summary.path);
   const canonicalUrl = new URL(path, databaseBase);
-  return { entry: await fetchJson(canonicalUrl), canonicalUrl };
+  return { entry: await fetchJson(canonicalUrl), canonicalUrl, replacement: null };
 }
 
 async function renderEntryPage() {
@@ -401,13 +538,17 @@ async function renderEntryPage() {
   const content = document.querySelector("#entry-content");
   const id = params.get("id");
   const version = Number(params.get("version"));
-  if (!/^PALOMAR-\d{6}$/.test(id || "") || !Number.isInteger(version) || version < 1) {
+  if (!PALOMAR_ID.test(id || "") || !Number.isInteger(version) || version < 1) {
     status.textContent = "This registry link is missing a valid Palomar ID and version.";
     status.classList.add("error");
     return;
   }
   try {
-    const { entry, canonicalUrl } = await loadEntry(id, version);
+    const { entry, canonicalUrl, replacement } = await loadEntry(id, version);
+    if (replacement) {
+      window.location.replace(localPageUrl("entry.html", replacement));
+      return;
+    }
     status.hidden = true;
     content.hidden = false;
     await renderEntry(entry, content, canonicalUrl);
@@ -422,20 +563,25 @@ async function renderChallengePage() {
   const content = document.querySelector("#render-content");
   const id = params.get("id");
   const version = Number(params.get("version"));
-  if (!/^PALOMAR-\d{6}$/.test(id || "") || !Number.isInteger(version) || version < 1) {
+  if (!PALOMAR_ID.test(id || "") || !Number.isInteger(version) || version < 1) {
     status.textContent = "This render link is missing a valid Palomar ID and version.";
     status.classList.add("error");
     return;
   }
   try {
-    const { entry } = await loadEntry(id, version);
+    const { entry, replacement } = await loadEntry(id, version);
+    if (replacement) {
+      window.location.replace(localPageUrl("render.html", replacement));
+      return;
+    }
     document.title = `Challenge — ${entry.title} — Palomar`;
     const heading = el("header", "entry-heading");
     heading.append(
       el("div", "entry-id", `${entry.id} · version ${entry.version}`),
       el("h1", "", entry.title),
     );
-    content.append(heading, await challengePresentation(entry, { forceFrame: true }));
+    const challenge = await challengePresentation(entry, { forceFrame: true });
+    content.append(heading, challenge.section);
     status.hidden = true;
     content.hidden = false;
   } catch (error) {

--- a/assets/rendering.js
+++ b/assets/rendering.js
@@ -1,7 +1,7 @@
 export const INLINE_CHALLENGE_MAX_LINES = 100;
 export const INLINE_CHALLENGE_MAX_BYTES = 32 * 1024;
 
-const ID = /^PALOMAR-[0-9]{6}$/;
+const ID = /^PALOMAR-(?:[0-9]{4}-[0-9]{2}-[0-9]{2}-)?[0-9]{6}$/;
 const SHA = /^[0-9a-f]{40}$/;
 const SHA256 = /^[0-9a-f]{64}$/;
 const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;

--- a/assets/style.css
+++ b/assets/style.css
@@ -486,10 +486,83 @@ footer {
 .challenge-frame {
   display: block;
   width: 100%;
-  height: min(42rem, 70vh);
-  min-height: 18rem;
+  height: 18rem;
+  min-height: 10rem;
+  max-height: 42rem;
   border: 1px solid var(--line);
   background: var(--paper);
+}
+
+.acceptance-callout {
+  display: flex;
+  gap: .8rem;
+  margin-bottom: 1rem;
+  padding: .8rem;
+  border: 1px solid #77a67b;
+  background: #eef8ef;
+}
+
+.acceptance-check {
+  display: grid;
+  flex: 0 0 2rem;
+  width: 2rem;
+  height: 2rem;
+  place-items: center;
+  border-radius: 50%;
+  background: #19712b;
+  color: #fff;
+  font: bold 1.25rem/1 var(--sans);
+}
+
+.acceptance-callout strong {
+  color: #145c24;
+  font: bold 1rem/1.3 var(--sans);
+}
+
+.acceptance-callout p,
+.solution-summary {
+  margin: .2rem 0 0;
+}
+
+.card-identity {
+  display: grid;
+  gap: .18rem;
+}
+
+.entry-date {
+  color: var(--muted);
+  font: .75rem/1.3 var(--sans);
+}
+
+.accepted-decision {
+  color: #19712b;
+}
+
+.solution-dependencies {
+  margin-top: 1rem;
+}
+
+.solution-dependencies summary {
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.dependency-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: .35rem 1rem;
+  margin: .75rem 0 0;
+  padding-left: 1.25rem;
+}
+
+.dependency-list li {
+  min-width: 0;
+}
+
+.dependency-list code {
+  display: block;
+  color: var(--muted);
+  font-size: .72rem;
 }
 
 .challenge-fallback {
@@ -660,6 +733,10 @@ pre {
   .detail-row {
     grid-template-columns: 1fr;
     gap: .15rem;
+  }
+
+  .dependency-list {
+    grid-template-columns: 1fr;
   }
 
   .score-grid {

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -17,6 +17,8 @@ HASH = "a" * 64
 def entry(identifier: str, lines: int) -> dict:
     return {
         "id": identifier,
+        "accepted_at": "2026-07-29",
+        "aliases": [identifier.replace("PALOMAR-2026-07-29-", "PALOMAR-")],
         "version": 1,
         "title": f"Fixture {identifier}",
         "abstract": "A browser confinement fixture.",
@@ -29,12 +31,25 @@ def entry(identifier: str, lines: int) -> dict:
         },
         "formalization": {
             "challenge_path": "Challenge.lean",
+            "solution_path": "Solution.lean",
             "theorem_names": ["Example.theorem"],
             "definition_names": [],
             "lean_toolchain": "leanprover/lean4:v4.31.0-rc2",
             "permitted_axioms": [],
+            "project_dependencies": [
+                {
+                    "name": "exampleDependency",
+                    "repository": "example/dependency",
+                    "revision": "3" * 40,
+                }
+            ],
         },
-        "verification": {"comparator_commit": "2" * 40, "workflow_url": "https://example.test/run"},
+        "verification": {
+            "comparator_commit": "2" * 40,
+            "workflow_url": "https://example.test/run",
+            "solution_sha256": "4" * 64,
+            "verified_at": "2026-07-29T08:46:32Z",
+        },
         "trust": {
             "level": "high",
             "challenge_lines": lines,
@@ -47,6 +62,7 @@ def entry(identifier: str, lines: int) -> dict:
             "scores": {"clarity": 5},
             "warnings": [],
             "report_url": "https://example.test/review",
+            "reviewed_at": "2026-07-29T08:53:02Z",
         },
         "challenge_render": {
             "format": "verso-html",
@@ -58,8 +74,8 @@ def entry(identifier: str, lines: int) -> dict:
 
 
 ENTRIES = {
-    "PALOMAR-000123": entry("PALOMAR-000123", 100),
-    "PALOMAR-000124": entry("PALOMAR-000124", 101),
+    "PALOMAR-2026-07-29-000123": entry("PALOMAR-2026-07-29-000123", 100),
+    "PALOMAR-2026-07-29-000124": entry("PALOMAR-2026-07-29-000124", 101),
 }
 
 
@@ -84,18 +100,22 @@ class Handler(SimpleHTTPRequestHandler):
                         "id": item["id"],
                         "version": 1,
                         "path": f"entries/{item['id']}-v1.json",
+                        "aliases": item["aliases"],
                     }
                     for item in ENTRIES.values()
                 ]
             }
             self.send_bytes(json.dumps(payload).encode(), "application/json")
             return
-        match = re.fullmatch(r"/database/entries/(PALOMAR-[0-9]{6})-v1\.json", path)
+        match = re.fullmatch(
+            r"/database/entries/(PALOMAR-(?:[0-9]{4}-[0-9]{2}-[0-9]{2}-)?[0-9]{6})-v1\.json",
+            path,
+        )
         if match and match.group(1) in ENTRIES:
             self.send_bytes(json.dumps(ENTRIES[match.group(1)]).encode(), "application/json")
             return
         if re.fullmatch(
-            rf"/database/renders/PALOMAR-[0-9]{{6}}-v1/{HASH}/Challenge/index\.html",
+            rf"/database/renders/PALOMAR-(?:[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}-)?[0-9]{{6}}-v1/{HASH}/Challenge/index\.html",
             path,
         ):
             page = f"""<!doctype html>
@@ -110,24 +130,29 @@ class Handler(SimpleHTTPRequestHandler):
             self.send_bytes(page.encode(), "text/html; charset=utf-8")
             return
         if re.fullmatch(
-            rf"/database/renders/PALOMAR-[0-9]{{6}}-v1/{HASH}/challenge-metadata\.json",
+            rf"/database/renders/PALOMAR-(?:[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}-)?[0-9]{{6}}-v1/{HASH}/challenge-metadata\.json",
             path,
         ):
             metadata = {
-                "schema_version": 1,
+                "schema_version": 2,
                 "imports": ["Mathlib"],
                 "module_doc": "# Fixture module\n\nParsed outside the Verso surface.",
                 "declarations": ["Example.theorem"],
+                "solution_imports": ["ExampleDependency"],
             }
             self.send_bytes(json.dumps(metadata).encode(), "application/json")
             return
-        if re.fullmatch(rf"/database/renders/PALOMAR-[0-9]{{6}}-v1/{HASH}/attack\.js", path):
+        if re.fullmatch(
+            rf"/database/renders/PALOMAR-(?:[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}-)?[0-9]{{6}}-v1/{HASH}/attack\.js",
+            path,
+        ):
             script = """
 document.body.dataset.scriptRan = "true";
 try { top.document.body.dataset.compromised = "true"; }
 catch (_) { document.body.dataset.topAccess = "blocked"; }
 try { localStorage.setItem("palomar-attack", "true"); }
 catch (_) { document.body.dataset.storageAccess = "blocked"; }
+parent.postMessage({type: "palomar-render-height", height: Math.ceil(document.querySelector("main").getBoundingClientRect().height)}, "*");
 """
             self.send_bytes(script.encode(), "text/javascript; charset=utf-8")
             return

--- a/tests/rendering.test.js
+++ b/tests/rendering.test.js
@@ -11,7 +11,7 @@ import {
 
 function entry(overrides = {}) {
   const value = {
-    id: "PALOMAR-000123",
+    id: "PALOMAR-2026-07-29-000123",
     version: 1,
     source: {
       repository: "example/challenge",
@@ -26,7 +26,7 @@ function entry(overrides = {}) {
     trust: { challenge_lines: 100, challenge_bytes: 32 * 1024 },
     challenge_render: {
       format: "verso-html",
-      artifact_path: `renders/PALOMAR-000123-v1/${"a".repeat(64)}/`,
+      artifact_path: `renders/PALOMAR-2026-07-29-000123-v1/${"a".repeat(64)}/`,
       entrypoint: "Challenge/index.html",
       artifact_tree_sha256: "a".repeat(64),
     },
@@ -49,7 +49,7 @@ test("inline policy includes both size limits and exactly one declaration", () =
 test("artifact URL is derived only from the content-addressed registry fields", () => {
   assert.equal(
     challengeArtifactUrl(entry(), "https://kim-em.github.io/PalomarDatabase/").href,
-    `https://kim-em.github.io/PalomarDatabase/renders/PALOMAR-000123-v1/${"a".repeat(64)}/Challenge/index.html`,
+    `https://kim-em.github.io/PalomarDatabase/renders/PALOMAR-2026-07-29-000123-v1/${"a".repeat(64)}/Challenge/index.html`,
   );
   const traversal = entry();
   traversal.challenge_render.artifact_path = "renders/../../attacker/";
@@ -59,7 +59,7 @@ test("artifact URL is derived only from the content-addressed registry fields", 
 test("artifact metadata URL stays inside the content-addressed bundle", () => {
   assert.equal(
     challengeMetadataUrl(entry(), "https://kim-em.github.io/PalomarDatabase/").href,
-    `https://kim-em.github.io/PalomarDatabase/renders/PALOMAR-000123-v1/${"a".repeat(64)}/challenge-metadata.json`,
+    `https://kim-em.github.io/PalomarDatabase/renders/PALOMAR-2026-07-29-000123-v1/${"a".repeat(64)}/challenge-metadata.json`,
   );
 });
 
@@ -75,11 +75,11 @@ test("source URL is always the immutable canonical GitHub file", () => {
 
 test("index paths cannot redirect entry fetching", () => {
   assert.equal(
-    entryRecordPath("PALOMAR-000123", 1, "entries/PALOMAR-000123-v1.json"),
-    "entries/PALOMAR-000123-v1.json",
+    entryRecordPath("PALOMAR-2026-07-29-000123", 1, "entries/PALOMAR-2026-07-29-000123-v1.json"),
+    "entries/PALOMAR-2026-07-29-000123-v1.json",
   );
   assert.throws(
-    () => entryRecordPath("PALOMAR-000123", 1, "https://attacker.invalid/entry.json"),
+    () => entryRecordPath("PALOMAR-2026-07-29-000123", 1, "https://attacker.invalid/entry.json"),
     /invalid entry path/,
   );
 });

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -2,21 +2,38 @@ import { expect, test } from "@playwright/test";
 
 const database = encodeURIComponent("http://127.0.0.1:4173/database/index.json");
 
-test("eligible Challenge renders inline without origin privilege", async ({ page }) => {
+test("landing cards show the acceptance date and dated identifier", async ({ page }) => {
+  await page.goto(`/?database=${database}`);
+  const first = page.locator(".entry-card").first();
+  await expect(first.locator(".entry-id")).toContainText("PALOMAR-2026-07-29-");
+  await expect(first.locator(".entry-date")).toHaveText("Accepted 29 July 2026");
+  await expect(page.locator(".entry-card")).toHaveCount(2);
+});
+
+test("legacy identifiers redirect to the dated permanent identifier", async ({ page }) => {
   await page.goto(`/entry.html?id=PALOMAR-000123&version=1&database=${database}`);
+  await expect(page).toHaveURL(/id=PALOMAR-2026-07-29-000123/);
+  await expect(page.locator(".entry-heading .entry-id")).toContainText(
+    "PALOMAR-2026-07-29-000123",
+  );
+});
+
+test("eligible Challenge renders inline without origin privilege", async ({ page }) => {
+  await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`);
 
   const source = page.locator(".challenge-presentation .challenge-source");
   await expect(source).toHaveAttribute(
     "href",
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/Challenge.lean`,
   );
+  await expect(page.getByRole("link", { name: "Open rendered Challenge" })).toHaveCount(0);
   const iframe = page.locator(".challenge-presentation iframe");
   await expect(iframe).toHaveAttribute("sandbox", "allow-scripts");
   await expect(iframe).toHaveAttribute("referrerpolicy", "no-referrer");
   await expect(iframe).toHaveAttribute("scrolling", "auto");
   await expect(iframe).toHaveAttribute(
     "src",
-    `http://127.0.0.1:4173/database/renders/PALOMAR-000123-v1/${"a".repeat(64)}/Challenge/index.html`,
+    `http://127.0.0.1:4173/database/renders/PALOMAR-2026-07-29-000123-v1/${"a".repeat(64)}/Challenge/index.html`,
   );
   const body = page.frameLocator(".challenge-presentation iframe").locator("body");
   await expect(body).toHaveAttribute("data-script-ran", "true");
@@ -32,8 +49,19 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   await expect(rendered.locator(".docstring")).toHaveText("The theorem doc-string.");
   await expect(rendered.locator(".skip-link")).toHaveCount(0);
   await expect(rendered.locator("body")).not.toContainText("Fixture module");
+  await expect(iframe).toHaveAttribute("data-height-adjusted", "true");
   const box = await iframe.boundingBox();
-  expect(box.height).toBeLessThanOrEqual(672);
+  expect(box.height).toBe(672);
+  await expect(page.locator(".acceptance-callout")).toContainText("Accepted");
+  await expect(page.locator(".acceptance-callout")).toContainText("29 July 2026");
+  await expect(page.locator(".acceptance-callout")).toContainText("matched every advertised declaration");
+  await expect(page.getByRole("link", { name: "Open Solution.lean" }).first()).toHaveAttribute(
+    "href",
+    `https://github.com/example/challenge/blob/${"1".repeat(40)}/Solution.lean`,
+  );
+  await expect(page.locator(".entry-solution .token-list code")).toHaveText("ExampleDependency");
+  await page.locator(".solution-dependencies summary").click();
+  await expect(page.locator(".dependency-list")).toContainText("example/dependency");
   await iframe.hover();
   await page.mouse.wheel(0, 2000);
   await expect.poll(() => rendered.locator("html").evaluate((node) => node.scrollTop)).toBeGreaterThan(0);
@@ -41,11 +69,11 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
 });
 
 test("larger Challenge falls back to the dedicated wrapper", async ({ page }) => {
-  await page.goto(`/entry.html?id=PALOMAR-000124&version=1&database=${database}`);
+  await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000124&version=1&database=${database}`);
   await expect(page.locator(".challenge-presentation iframe")).toHaveCount(0);
   await expect(page.locator(".challenge-fallback")).toBeVisible();
   await page.getByRole("link", { name: "Open rendered Challenge" }).click();
-  await expect(page).toHaveURL(/render\.html\?id=PALOMAR-000124/);
+  await expect(page).toHaveURL(/render\.html\?id=PALOMAR-2026-07-29-000124/);
   await expect(page.locator(".challenge-presentation iframe")).toHaveAttribute(
     "sandbox",
     "allow-scripts",


### PR DESCRIPTION
## Summary
- size inline Challenge frames from their rendered declaration surface and hide the redundant dedicated-render link
- add explicit dated acceptance evidence, Solution links/imports, and the pinned transitive repository closure
- display dated Palomar identifiers and acceptance dates on landing cards, with redirects from legacy IDs
- add browser coverage for confinement, scrolling, sizing, redirects, dates, and the large-Challenge fallback

## Verification
- npm test
- Playwright browser suite (4 passing)