### PR TITLE
Make acceptance result explicit

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -344,7 +344,7 @@ function acceptanceCallout(entry) {
     el(
       "p",
       "",
-      "Palomar checked the pinned Solution with Lean, matched every advertised declaration with Comparator, verified the permitted axiom set, and accepted the editorial review.",
+      "Palomar checked the pinned Solution with Lean, matched every advertised declaration with Comparator, verified the permitted axiom set, and completed editorial review. Every required check passed; Palomar accepted the submission.",
     ),
   );
   callout.append(check, copy);

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -55,6 +55,9 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   await expect(page.locator(".acceptance-callout")).toContainText("Accepted");
   await expect(page.locator(".acceptance-callout")).toContainText("29 July 2026");
   await expect(page.locator(".acceptance-callout")).toContainText("matched every advertised declaration");
+  await expect(page.locator(".acceptance-callout")).toContainText(
+    "Every required check passed; Palomar accepted the submission",
+  );
   await expect(page.getByRole("link", { name: "Open Solution.lean" }).first()).toHaveAttribute(
     "href",
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/Solution.lean`,


### PR DESCRIPTION
## Summary
- state unambiguously that every required check passed
- say directly that Palomar accepted the submission
- retain the dated green acceptance callout

## Verification
- npm test
- Playwright browser suite (4 passing)