### PR TITLE
Remove Mathlib surface metric

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -138,9 +138,6 @@ async function renderIndex() {
     document.querySelector("#metric-projects").textContent = String(
       new Set(entries.map((entry) => entry.source.repository)).size,
     );
-    document.querySelector("#metric-high-trust").textContent = String(
-      entries.filter((entry) => entry.trust.level === "high").length,
-    );
     if (!entries.length) {
       status.textContent =
         "The telescope is ready. No entries have been published yet; the first accepted database PR will appear here automatically.";

--- a/index.html
+++ b/index.html
@@ -31,7 +31,6 @@
         <div class="metric-row" aria-live="polite">
           <span><strong id="metric-results">—</strong> accepted results</span>
           <span><strong id="metric-projects">—</strong> source projects</span>
-          <span><strong id="metric-high-trust">—</strong> Mathlib-only surfaces</span>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

- remove the “Mathlib-only surfaces” count from the registry homepage
- remove the unused JavaScript calculation for that metric

## Why

The term “surface” is implementation jargon and the aggregate count does not provide useful information to mathematicians browsing the registry. Detailed statement dependency information remains available on individual records.

## Validation

- `npm test`
- `git diff --check`
