### PR TITLE
Require dated Palomar identifiers

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -15,7 +15,7 @@ const databaseUrl = params.get("database") || DEFAULT_DATABASE;
 const databaseBase = new URL(".", databaseUrl);
 const renderBase = params.get("render-base") ||
   (params.has("database") ? databaseBase.href : DEFAULT_RENDER_BASE);
-const PALOMAR_ID = /^PALOMAR-(?:\d{4}-\d{2}-\d{2}-)?\d{6}$/;
+const PALOMAR_ID = /^PALOMAR-\d{4}-\d{2}-\d{2}-\d{6}$/;
 
 function el(tag, className, text) {
   const node = document.createElement(tag);
@@ -66,10 +66,8 @@ function displayDate(value) {
 }
 
 function latestVersions(entries) {
-  const aliases = new Set(entries.flatMap((entry) => entry.aliases || []));
   const latest = new Map();
   for (const entry of entries) {
-    if (aliases.has(entry.id)) continue;
     const previous = latest.get(entry.id);
     if (!previous || entry.version > previous.version) latest.set(entry.id, entry);
   }
@@ -519,15 +517,11 @@ async function renderEntry(entry, content, canonicalUrl) {
 
 async function loadEntry(id, version) {
   const index = await fetchJson(databaseUrl);
-  const replacements = index.entries
-    .filter((item) => Array.isArray(item.aliases) && item.aliases.includes(id))
-    .sort((left, right) => right.version - left.version);
-  if (replacements.length) return { replacement: replacements[0] };
   const summary = index.entries.find((item) => item.id === id && item.version === version);
   if (!summary) throw new Error("entry not found");
   const path = entryRecordPath(id, version, summary.path);
   const canonicalUrl = new URL(path, databaseBase);
-  return { entry: await fetchJson(canonicalUrl), canonicalUrl, replacement: null };
+  return { entry: await fetchJson(canonicalUrl), canonicalUrl };
 }
 
 async function renderEntryPage() {
@@ -541,11 +535,7 @@ async function renderEntryPage() {
     return;
   }
   try {
-    const { entry, canonicalUrl, replacement } = await loadEntry(id, version);
-    if (replacement) {
-      window.location.replace(localPageUrl("entry.html", replacement));
-      return;
-    }
+    const { entry, canonicalUrl } = await loadEntry(id, version);
     status.hidden = true;
     content.hidden = false;
     await renderEntry(entry, content, canonicalUrl);
@@ -566,11 +556,7 @@ async function renderChallengePage() {
     return;
   }
   try {
-    const { entry, replacement } = await loadEntry(id, version);
-    if (replacement) {
-      window.location.replace(localPageUrl("render.html", replacement));
-      return;
-    }
+    const { entry } = await loadEntry(id, version);
     document.title = `Challenge — ${entry.title} — Palomar`;
     const heading = el("header", "entry-heading");
     heading.append(

--- a/assets/rendering.js
+++ b/assets/rendering.js
@@ -1,7 +1,7 @@
 export const INLINE_CHALLENGE_MAX_LINES = 100;
 export const INLINE_CHALLENGE_MAX_BYTES = 32 * 1024;
 
-const ID = /^PALOMAR-(?:[0-9]{4}-[0-9]{2}-[0-9]{2}-)?[0-9]{6}$/;
+const ID = /^PALOMAR-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6}$/;
 const SHA = /^[0-9a-f]{40}$/;
 const SHA256 = /^[0-9a-f]{64}$/;
 const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -18,7 +18,6 @@ def entry(identifier: str, lines: int) -> dict:
     return {
         "id": identifier,
         "accepted_at": "2026-07-29",
-        "aliases": [identifier.replace("PALOMAR-2026-07-29-", "PALOMAR-")],
         "version": 1,
         "title": f"Fixture {identifier}",
         "abstract": "A browser confinement fixture.",
@@ -100,7 +99,6 @@ class Handler(SimpleHTTPRequestHandler):
                         "id": item["id"],
                         "version": 1,
                         "path": f"entries/{item['id']}-v1.json",
-                        "aliases": item["aliases"],
                     }
                     for item in ENTRIES.values()
                 ]
@@ -108,14 +106,14 @@ class Handler(SimpleHTTPRequestHandler):
             self.send_bytes(json.dumps(payload).encode(), "application/json")
             return
         match = re.fullmatch(
-            r"/database/entries/(PALOMAR-(?:[0-9]{4}-[0-9]{2}-[0-9]{2}-)?[0-9]{6})-v1\.json",
+            r"/database/entries/(PALOMAR-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6})-v1\.json",
             path,
         )
         if match and match.group(1) in ENTRIES:
             self.send_bytes(json.dumps(ENTRIES[match.group(1)]).encode(), "application/json")
             return
         if re.fullmatch(
-            rf"/database/renders/PALOMAR-(?:[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}-)?[0-9]{{6}}-v1/{HASH}/Challenge/index\.html",
+            rf"/database/renders/PALOMAR-[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}-[0-9]{{6}}-v1/{HASH}/Challenge/index\.html",
             path,
         ):
             page = f"""<!doctype html>
@@ -130,7 +128,7 @@ class Handler(SimpleHTTPRequestHandler):
             self.send_bytes(page.encode(), "text/html; charset=utf-8")
             return
         if re.fullmatch(
-            rf"/database/renders/PALOMAR-(?:[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}-)?[0-9]{{6}}-v1/{HASH}/challenge-metadata\.json",
+            rf"/database/renders/PALOMAR-[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}-[0-9]{{6}}-v1/{HASH}/challenge-metadata\.json",
             path,
         ):
             metadata = {
@@ -143,7 +141,7 @@ class Handler(SimpleHTTPRequestHandler):
             self.send_bytes(json.dumps(metadata).encode(), "application/json")
             return
         if re.fullmatch(
-            rf"/database/renders/PALOMAR-(?:[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}-)?[0-9]{{6}}-v1/{HASH}/attack\.js",
+            rf"/database/renders/PALOMAR-[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}-[0-9]{{6}}-v1/{HASH}/attack\.js",
             path,
         ):
             script = """

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -10,14 +10,6 @@ test("landing cards show the acceptance date and dated identifier", async ({ pag
   await expect(page.locator(".entry-card")).toHaveCount(2);
 });
 
-test("legacy identifiers redirect to the dated permanent identifier", async ({ page }) => {
-  await page.goto(`/entry.html?id=PALOMAR-000123&version=1&database=${database}`);
-  await expect(page).toHaveURL(/id=PALOMAR-2026-07-29-000123/);
-  await expect(page.locator(".entry-heading .entry-id")).toContainText(
-    "PALOMAR-2026-07-29-000123",
-  );
-});
-
 test("eligible Challenge renders inline without origin privilege", async ({ page }) => {
   await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`);
 


### PR DESCRIPTION
## Summary
- accept only date-bearing Palomar identifiers in presentation URLs and artifact paths
- remove legacy alias and redirect handling
- keep landing and entry browser coverage on the canonical dated format

## Verification
- npm test
- Playwright browser suite (3 passing)