### PR TITLE
Use plain language for verification details

### DIFF
--- a/about.html
+++ b/about.html
@@ -33,23 +33,23 @@
         <ol>
           <li>
             <span>1.</span>
-            <div><h3>Immutable source</h3><p>A GitHub issue points to a public repository and full Git commit. Moving branches are never registry evidence.</p></div>
+            <div><h3>Fixed source files</h3><p>Each submission points to an exact version of a public repository, so the files that Palomar checked cannot later change.</p></div>
           </li>
           <li>
             <span>2.</span>
-            <div><h3>Small statement surface</h3><p><code>Challenge.lean</code> states the advertised result. Its transitive imports may come only from Lean core, Mathlib, Tau Ceti, or an already indexed Palomar project.</p></div>
+            <div><h3>Readable statement file</h3><p><code>Challenge.lean</code> states the advertised result. The definitions it uses may come only from Lean core, Mathlib, Tau Ceti, or another project already listed by Palomar.</p></div>
           </li>
           <li>
             <span>3.</span>
-            <div><h3>Sandboxed comparison</h3><p>Comparator rebuilds Challenge and Solution separately under landrun, checks exact declaration identity and permitted axioms, then replays the proof through the Lean kernel.</p></div>
+            <div><h3>Independent proof check</h3><p>Palomar checks the statement and proof separately, confirms that the theorem names match, and asks Lean to verify the proof using only the allowed axioms.</p></div>
           </li>
           <li>
             <span>4.</span>
-            <div><h3>Editorial review</h3><p>Versioned AI review checks metadata, informal-to-Lean alignment, definitions, prior literature, notability, and clarity. Failures, uncertainty, and permanent warnings stay visible.</p></div>
+            <div><h3>Documented review</h3><p>An AI-assisted review compares the written mathematical claim with the Lean statement and examines its definitions, prior literature, significance, and clarity. Problems and uncertainties remain visible.</p></div>
           </li>
           <li>
             <span>5.</span>
-            <div><h3>Append-only publication</h3><p>An accepted result becomes an immutable JSON record with a permanent identifier and version. Corrections add versions; history is not rewritten.</p></div>
+            <div><h3>Permanent record</h3><p>Each accepted result receives a permanent identifier and version. Corrections create new versions rather than replacing the history.</p></div>
           </li>
         </ol>
       </section>
@@ -57,18 +57,18 @@
       <section class="meaning-grid">
         <article>
           <div class="eyebrow">Palomar does say</div>
-          <h2>The pinned Solution proves the pinned Challenge.</h2>
-          <p>It also says that a recorded editorial process found the statement and metadata responsible enough to index under the policy version shown.</p>
+          <h2>The recorded proof proves the recorded statement.</h2>
+          <p>It also says that the documented review found the statement and its description suitable for listing under the policy version shown.</p>
         </article>
         <article>
           <div class="eyebrow">Palomar does not say</div>
           <h2>This is peer review, novelty certification, or endorsement.</h2>
-          <p>Readers still need mathematical judgment. The registry makes the exact object, checks, trust boundary, and warnings easier to locate and audit.</p>
+          <p>Readers still need mathematical judgment. The registry makes the exact statement, proof checks, dependencies, and warnings easier to find and inspect.</p>
         </article>
       </section>
 
       <section class="cta">
-        <div><h2>Have a result?</h2><p>Submit one immutable snapshot.</p></div>
+        <div><h2>Have a result?</h2><p>Submit one fixed version of it.</p></div>
         <a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Open the submission form</a>
       </section>
     </main>

--- a/assets/app.js
+++ b/assets/app.js
@@ -78,8 +78,8 @@ function trustBadge(entry) {
   const high = entry.trust.level === "high";
   const badge = el("span", `trust-badge ${high ? "high" : "qualified"}`);
   badge.textContent = high
-    ? "Trust: Mathlib-only surface"
-    : "Trust: extended import surface";
+    ? "Dependencies: Mathlib only"
+    : "Dependencies: additional libraries";
   return badge;
 }
 
@@ -214,7 +214,7 @@ function localPageUrl(page, entry) {
 function challengeFrame(entry) {
   const frame = el("iframe", "challenge-frame");
   frame.src = challengeArtifactUrl(entry, renderBase).href;
-  frame.title = `Rendered Challenge for ${entry.id} version ${entry.version}`;
+  frame.title = `Formatted statement for ${entry.id} version ${entry.version}`;
   frame.loading = "lazy";
   frame.referrerPolicy = "no-referrer";
   frame.setAttribute("sandbox", "allow-scripts");
@@ -262,20 +262,20 @@ function validateChallengeMetadata(entry, metadata) {
 
 function challengeMetadata(metadata) {
   const panel = el("div", "challenge-metadata");
-  panel.append(el("div", "eyebrow", "Parsed source metadata"));
+  panel.append(el("div", "eyebrow", "Statement file information"));
   const imports = el("div", "challenge-metadata-row");
-  imports.append(el("strong", "", "Direct imports"));
+  imports.append(el("strong", "", "Libraries imported by the statement"));
   const tokens = el("span", "token-list");
   for (const item of metadata.imports) tokens.append(el("code", "", item));
   imports.append(tokens);
   panel.append(imports);
   if (metadata.module_doc) {
     const moduleDoc = el("details", "challenge-module-doc");
-    moduleDoc.append(el("summary", "", "Module documentation"));
+    moduleDoc.append(el("summary", "", "Notes from the statement file"));
     moduleDoc.append(el("pre", "", metadata.module_doc));
     panel.append(moduleDoc);
   } else {
-    panel.append(el("p", "challenge-no-module-doc", "No module documentation was found."));
+    panel.append(el("p", "challenge-no-module-doc", "No notes were found in the statement file."));
   }
   return panel;
 }
@@ -284,15 +284,15 @@ async function challengePresentation(entry, { forceFrame = false } = {}) {
   const section = el("section", "challenge-presentation");
   const heading = el("div", "section-heading");
   const titleBlock = el("div");
-  titleBlock.append(el("div", "eyebrow", "Formal statement"), el("h2", "", "Challenge"));
+  titleBlock.append(el("div", "eyebrow", "Formal statement"), el("h2", "", "Statement"));
   heading.append(titleBlock);
   section.append(heading);
 
   const links = el("p", "challenge-links");
-  links.append(link("View canonical Challenge.lean", challengeSourceUrl(entry), "challenge-source"));
+  links.append(link("View statement file (Challenge.lean)", challengeSourceUrl(entry), "challenge-source"));
   const inline = isInlineChallenge(entry);
   if (!forceFrame && !inline) {
-    links.append(" · ", link("Open rendered Challenge", localPageUrl("render.html", entry)));
+    links.append(" · ", link("Open formatted statement", localPageUrl("render.html", entry)));
   }
   section.append(links);
 
@@ -308,7 +308,7 @@ async function challengePresentation(entry, { forceFrame = false } = {}) {
       el(
         "p",
         "challenge-fallback",
-        "This historical rendering predates declaration-only presentation metadata; use the canonical Challenge.lean link above.",
+        "This older entry cannot display its statement on this page. Use the statement file link above.",
       ),
     );
     return {section, metadata: null};
@@ -322,7 +322,7 @@ async function challengePresentation(entry, { forceFrame = false } = {}) {
       el(
         "p",
         "challenge-fallback",
-        "This Challenge is larger than the inline reading limit; use the rendered view above.",
+        "This statement is too large to display here; use the formatted view above.",
       ),
     );
   }
@@ -339,7 +339,7 @@ function acceptanceCallout(entry) {
     el(
       "p",
       "",
-      "Palomar checked the pinned Solution with Lean, matched every advertised declaration with Comparator, verified the permitted axiom set, and completed editorial review. Every required check passed; Palomar accepted the submission.",
+      "Palomar used Lean to check the recorded proof against the recorded statement and confirmed that it uses only the allowed axioms. The documented review was also completed. Every required check passed, so Palomar accepted the submission.",
     ),
   );
   callout.append(check, copy);
@@ -350,29 +350,29 @@ function solutionMetadata(entry, renderMetadata) {
   const section = el("section", "entry-solution");
   const heading = el("div", "section-heading");
   const title = el("div");
-  title.append(el("div", "eyebrow", "Accepted proof artifact"), el("h2", "", "Verified solution"));
+  title.append(el("div", "eyebrow", "Accepted proof"), el("h2", "", "Verified proof"));
   heading.append(title, el("span", "decision accepted-decision", "Accepted"));
   section.append(heading);
   section.append(
     el(
       "p",
       "solution-summary",
-      "The accepted Solution.lean was checked at the immutable source commit against the pinned transitive Lake dependency closure below.",
+      "Lean checked the accepted proof using the exact versions of the source files and libraries listed below.",
     ),
   );
 
   const details = el("dl", "details solution-details");
   details.append(
     externalDetailRow(
-      "Solution file",
+      "Proof file",
       `Open ${entry.formalization.solution_path}`,
       pinnedSourceFileUrl(entry, entry.formalization.solution_path),
     ),
-    detailRow("Solution SHA-256", entry.verification.solution_sha256),
+    detailRow("Proof file checksum (SHA-256)", entry.verification.solution_sha256),
   );
   if (renderMetadata?.schema_version >= 2) {
     const row = el("div", "detail-row");
-    row.append(el("dt", "", "Direct imports"));
+    row.append(el("dt", "", "Libraries imported by the proof"));
     const value = el("dd", "token-list");
     for (const item of renderMetadata.solution_imports) value.append(el("code", "", item));
     row.append(value);
@@ -386,7 +386,7 @@ function solutionMetadata(entry, renderMetadata) {
     el(
       "summary",
       "",
-      `${dependencies.length} pinned repositories in the transitive Lake closure`,
+      `${dependencies.length} source repositories used by the proof`,
     ),
   );
   const list = el("ul", "dependency-list");
@@ -418,7 +418,7 @@ async function renderEntry(entry, content, canonicalUrl) {
   const evidence = el("section", "entry-evidence");
   const evidenceTitle = el("div", "section-heading");
   const titleBlock = el("div");
-  titleBlock.append(el("div", "eyebrow", "Machine evidence"), el("h2", "", "What was checked"));
+  titleBlock.append(el("div", "eyebrow", "Verification"), el("h2", "", "What was checked"));
   evidenceTitle.append(titleBlock);
   evidence.append(evidenceTitle, acceptanceCallout(entry));
   const details = el("dl", "details");
@@ -428,44 +428,53 @@ async function renderEntry(entry, content, canonicalUrl) {
       "Lean verification date",
       displayDate(entry.verification.verified_at.slice(0, 10)),
     ),
-    externalDetailRow("Immutable source", `${entry.source.repository}@${entry.source.commit.slice(0, 12)}`, entry.source.tree_url),
+    externalDetailRow("Fixed source version", `${entry.source.repository}@${entry.source.commit.slice(0, 12)}`, entry.source.tree_url),
     externalDetailRow(
-      "Challenge file",
+      "Statement file",
       `Open ${entry.formalization.challenge_path}`,
       pinnedSourceFileUrl(entry, entry.formalization.challenge_path),
     ),
     externalDetailRow(
-      "Solution file",
+      "Proof file",
       `Open ${entry.formalization.solution_path}`,
       pinnedSourceFileUrl(entry, entry.formalization.solution_path),
     ),
-    detailRow("Lean toolchain", entry.formalization.lean_toolchain),
-    detailRow("Compared theorems", theoremNames(entry)),
+    detailRow("Lean version", entry.formalization.lean_toolchain),
+    detailRow("Theorems checked", theoremNames(entry)),
     detailRow("Permitted axioms", entry.formalization.permitted_axioms.join(", ") || "none"),
-    detailRow("Challenge surface", `${entry.trust.challenge_lines} lines · ${entry.trust.challenge_bytes} bytes`),
-    externalDetailRow("Comparator run", entry.verification.comparator_commit.slice(0, 12), entry.verification.workflow_url),
+    detailRow("Statement file size", `${entry.trust.challenge_lines} lines · ${entry.trust.challenge_bytes} bytes`),
+    externalDetailRow("Verification record", entry.verification.comparator_commit.slice(0, 12), entry.verification.workflow_url),
   );
   evidence.append(details);
 
   const trust = el("section", "entry-trust");
   const trustTitle = el("div", "section-heading");
   const trustBlock = el("div");
-  trustBlock.append(el("div", "eyebrow", "Statement trust"), el("h2", "", entry.trust.level === "high" ? "Mathlib-only challenge surface" : "Qualified challenge surface"));
+  trustBlock.append(
+    el("div", "eyebrow", "Statement dependencies"),
+    el(
+      "h2",
+      "",
+      entry.trust.level === "high"
+        ? "Depends only on Mathlib"
+        : "Depends on additional libraries",
+    ),
+  );
   trustTitle.append(trustBlock, trustBadge(entry));
   trust.append(trustTitle);
   const imports = el("div", "token-list");
   for (const item of entry.trust.challenge_imports) imports.append(el("code", "", item));
-  trust.append(el("h3", "", "Direct imports"), imports);
+  trust.append(el("h3", "", "Libraries imported by the statement"), imports);
   if (entry.trust.challenge_dependencies.length) {
-    trust.append(el("h3", "", "Trusted source repositories"));
+    trust.append(el("h3", "", "Source repositories"));
     const dependencies = el("ul", "plain-list");
     for (const dependency of entry.trust.challenge_dependencies) {
-      dependencies.append(el("li", "", `${dependency.repository} · ${dependency.provenance}`));
+      dependencies.append(el("li", "", dependency.repository));
     }
     trust.append(dependencies);
   }
   if (entry.trust.reasons.length) {
-    trust.append(el("h3", "", "Qualification reasons"));
+    trust.append(el("h3", "", "Why additional libraries are needed"));
     const reasons = el("ul", "reason-list");
     for (const reason of entry.trust.reasons) reasons.append(el("li", "", reason));
     trust.append(reasons);
@@ -495,9 +504,9 @@ async function renderEntry(entry, content, canonicalUrl) {
   editorial.append(link("Read the public review", entry.review.report_url));
 
   const machine = el("section", "machine-record");
-  machine.append(el("div", "eyebrow", "For machines and mirrors"), el("h2", "", "Canonical JSON"));
+  machine.append(el("div", "eyebrow", "Full record"), el("h2", "", "Registry data"));
   const machineLinks = el("p");
-  machineLinks.append(link("Open the canonical JSON record", canonicalUrl.href));
+  machineLinks.append(link("Open the full data record (JSON)", canonicalUrl.href));
   machine.append(machineLinks);
   const pre = el("pre");
   pre.append(el("code", "", JSON.stringify(entry, null, 2)));
@@ -557,7 +566,7 @@ async function renderChallengePage() {
   }
   try {
     const { entry } = await loadEntry(id, version);
-    document.title = `Challenge — ${entry.title} — Palomar`;
+    document.title = `Statement — ${entry.title} — Palomar`;
     const heading = el("header", "entry-heading");
     heading.append(
       el("div", "entry-id", `${entry.id} · version ${entry.version}`),
@@ -568,7 +577,7 @@ async function renderChallengePage() {
     status.hidden = true;
     content.hidden = false;
   } catch (error) {
-    status.textContent = `The rendered Challenge could not be loaded: ${error.message}`;
+    status.textContent = `The formatted statement could not be loaded: ${error.message}`;
     status.classList.add("error");
   }
 }

--- a/index.html
+++ b/index.html
@@ -24,9 +24,9 @@
       <section class="hero">
         <h1>Registry of Lean-verified mathematics</h1>
         <p class="hero-copy">
-          Palomar records mathematical claims at immutable Git commits, checks
-          their proofs with Comparator, and publishes the exact statement,
-          provenance, trust surface, and editorial warnings.
+          Palomar records mathematical claims from fixed versions of their
+          source files, checks their proofs with Lean, and publishes the exact
+          statement, the libraries it uses, and any review warnings.
         </p>
         <div class="metric-row" aria-live="polite">
           <span><strong id="metric-results">—</strong> accepted results</span>
@@ -47,11 +47,11 @@
             <span>Search:</span>
             <input id="search" type="search" placeholder="title, author, theorem, or repository" autocomplete="off">
           </label>
-          <div class="filters" role="group" aria-label="Trust filters">
+          <div class="filters" role="group" aria-label="Statement dependency filters">
             <span>Show:</span>
             <button class="filter active" type="button" data-trust="all" aria-pressed="true">All</button>
-            <button class="filter" type="button" data-trust="high" aria-pressed="false">Mathlib-only</button>
-            <button class="filter" type="button" data-trust="qualified" aria-pressed="false">Extended imports</button>
+            <button class="filter" type="button" data-trust="high" aria-pressed="false">Mathlib only</button>
+            <button class="filter" type="button" data-trust="qualified" aria-pressed="false">Additional libraries</button>
           </div>
         </div>
 

--- a/render.html
+++ b/render.html
@@ -4,11 +4,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#ffffff">
-    <title>Rendered Challenge — Palomar</title>
+    <title>Formatted statement — Palomar</title>
     <link rel="stylesheet" href="assets/style.css">
   </head>
   <body data-page="render">
-    <a class="skip-link" href="#render">Skip to rendered Challenge</a>
+    <a class="skip-link" href="#render">Skip to formatted statement</a>
     <header class="site-header">
       <a class="brand" href="./">Palomar</a>
       <nav aria-label="Main navigation"><a href="./">Registry</a><a href="about.html">About</a><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit</a></nav>

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -134,7 +134,7 @@ class Handler(SimpleHTTPRequestHandler):
             metadata = {
                 "schema_version": 2,
                 "imports": ["Mathlib"],
-                "module_doc": "# Fixture module\n\nParsed outside the Verso surface.",
+                "module_doc": "# Fixture module\n\nParsed outside the Verso renderer.",
                 "declarations": ["Example.theorem"],
                 "solution_imports": ["ExampleDependency"],
             }

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -7,7 +7,10 @@ test("landing cards show the acceptance date and dated identifier", async ({ pag
   const first = page.locator(".entry-card").first();
   await expect(first.locator(".entry-id")).toContainText("PALOMAR-2026-07-29-");
   await expect(first.locator(".entry-date")).toHaveText("Accepted 29 July 2026");
+  await expect(first.locator(".trust-badge")).toHaveText("Dependencies: Mathlib only");
   await expect(page.locator(".entry-card")).toHaveCount(2);
+  await expect(page.getByRole("button", { name: "Mathlib only" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Additional libraries" })).toBeVisible();
 });
 
 test("eligible Challenge renders inline without origin privilege", async ({ page }) => {
@@ -18,7 +21,7 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
     "href",
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/Challenge.lean`,
   );
-  await expect(page.getByRole("link", { name: "Open rendered Challenge" })).toHaveCount(0);
+  await expect(page.getByRole("link", { name: "Open formatted statement" })).toHaveCount(0);
   const iframe = page.locator(".challenge-presentation iframe");
   await expect(iframe).toHaveAttribute("sandbox", "allow-scripts");
   await expect(iframe).toHaveAttribute("referrerpolicy", "no-referrer");
@@ -32,11 +35,11 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   await expect(body).toHaveAttribute("data-top-access", "blocked");
   await expect(body).toHaveAttribute("data-storage-access", "blocked");
   await expect(page.locator("body")).not.toHaveAttribute("data-compromised", "true");
-  await expect(page.locator(".challenge-metadata")).toContainText("Direct imports");
+  await expect(page.locator(".challenge-metadata")).toContainText("Libraries imported by the statement");
   await expect(page.locator(".challenge-metadata code")).toHaveText("Mathlib");
-  await expect(page.locator(".challenge-module-doc summary")).toHaveText("Module documentation");
+  await expect(page.locator(".challenge-module-doc summary")).toHaveText("Notes from the statement file");
   await page.locator(".challenge-module-doc summary").click();
-  await expect(page.locator(".challenge-module-doc pre")).toContainText("Parsed outside the Verso surface");
+  await expect(page.locator(".challenge-module-doc pre")).toContainText("Parsed outside the Verso renderer");
   const rendered = page.frameLocator(".challenge-presentation iframe");
   await expect(rendered.locator(".docstring")).toHaveText("The theorem doc-string.");
   await expect(rendered.locator(".skip-link")).toHaveCount(0);
@@ -46,9 +49,9 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   expect(box.height).toBe(672);
   await expect(page.locator(".acceptance-callout")).toContainText("Accepted");
   await expect(page.locator(".acceptance-callout")).toContainText("29 July 2026");
-  await expect(page.locator(".acceptance-callout")).toContainText("matched every advertised declaration");
+  await expect(page.locator(".acceptance-callout")).toContainText("recorded proof against the recorded statement");
   await expect(page.locator(".acceptance-callout")).toContainText(
-    "Every required check passed; Palomar accepted the submission",
+    "Every required check passed, so Palomar accepted the submission",
   );
   await expect(page.getByRole("link", { name: "Open Solution.lean" }).first()).toHaveAttribute(
     "href",
@@ -67,7 +70,7 @@ test("larger Challenge falls back to the dedicated wrapper", async ({ page }) =>
   await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000124&version=1&database=${database}`);
   await expect(page.locator(".challenge-presentation iframe")).toHaveCount(0);
   await expect(page.locator(".challenge-fallback")).toBeVisible();
-  await page.getByRole("link", { name: "Open rendered Challenge" }).click();
+  await page.getByRole("link", { name: "Open formatted statement" }).click();
   await expect(page).toHaveURL(/render\.html\?id=PALOMAR-2026-07-29-000124/);
   await expect(page.locator(".challenge-presentation iframe")).toHaveAttribute(
     "sandbox",


### PR DESCRIPTION
## Summary

- replace “surface” and related security terminology with ordinary mathematical language
- call the Challenge and Solution the statement and proof in reader-facing copy
- explain source versions, dependencies, verification, and review without implementation jargon
- update browser checks to cover the new labels

## Why

The registry is for mathematicians, but several labels assumed familiarity with software-security and build-system terminology. The revised copy says directly what Palomar checked and which libraries the statement and proof use.

## Validation

- `npm test`
- `node --check assets/app.js`
- `git diff --check`
- full Playwright suite delegated to CI because the local environment lacks `libglib-2.0.so.0` and does not permit Playwright’s dependency installer to use sudo
