### PR TITLE
Make Pages deployments cache-safe

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,19 +15,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
+        with:
+          node-version: "24.4.1"
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:browser
+        env:
+          PALOMAR_PREVIOUS_REF: ${{ github.event.before }}
+      - run: npm run build -- --version "${GITHUB_SHA}" --output .site
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
+        with:
+          path: .site
+
   deploy:
+    needs: test
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-        with:
-          persist-credentials: false
-      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
-        with:
-          path: .
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Test presentation
 
 on:
-  push:
-    branches: [main]
   pull_request:
 
 permissions:
@@ -15,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
+          fetch-depth: 0
           persist-credentials: false
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:
@@ -24,3 +23,5 @@ jobs:
       - run: npm test
       - run: npx playwright install --with-deps chromium
       - run: npm run test:browser
+        env:
+          PALOMAR_PREVIOUS_REF: ${{ github.event.pull_request.base.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 node_modules/
 playwright-report/
 test-results/
+.site/
+.site-test-*/

--- a/assets/app.js
+++ b/assets/app.js
@@ -30,6 +30,11 @@ function link(text, href, className) {
   return node;
 }
 
+function setOptionalText(selector, text) {
+  const node = document.querySelector(selector);
+  if (node) node.textContent = text;
+}
+
 async function fetchJson(url) {
   const response = await fetch(url, { cache: "no-cache" });
   if (!response.ok) {
@@ -132,8 +137,11 @@ async function renderIndex() {
   try {
     const index = await fetchJson(databaseUrl);
     const entries = latestVersions(await loadEntries(index));
-    document.querySelector("#metric-results").textContent = String(entries.length);
-    document.querySelector("#metric-projects").textContent = String(
+    // GitHub Pages may briefly pair HTML and JavaScript from adjacent deployments.
+    // Metrics are presentation-only, so a removed metric must not abort the registry.
+    setOptionalText("#metric-results", String(entries.length));
+    setOptionalText(
+      "#metric-projects",
       new Set(entries.map((entry) => entry.source.repository)).size,
     );
     if (!entries.length) {
@@ -365,7 +373,7 @@ function solutionMetadata(entry, renderMetadata) {
   details.append(
     externalDetailRow(
       "Proof file",
-      `Open ${entry.formalization.solution_path}`,
+      entry.formalization.solution_path,
       pinnedSourceFileUrl(entry, entry.formalization.solution_path),
     ),
     detailRow("Proof file checksum (SHA-256)", entry.verification.solution_sha256),
@@ -431,12 +439,12 @@ async function renderEntry(entry, content, canonicalUrl) {
     externalDetailRow("Fixed source version", `${entry.source.repository}@${entry.source.commit.slice(0, 12)}`, entry.source.tree_url),
     externalDetailRow(
       "Statement file",
-      `Open ${entry.formalization.challenge_path}`,
+      entry.formalization.challenge_path,
       pinnedSourceFileUrl(entry, entry.formalization.challenge_path),
     ),
     externalDetailRow(
       "Proof file",
-      `Open ${entry.formalization.solution_path}`,
+      entry.formalization.solution_path,
       pinnedSourceFileUrl(entry, entry.formalization.solution_path),
     ),
     detailRow("Lean version", entry.formalization.lean_toolchain),

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test tests/rendering.test.js",
+    "build": "node scripts/build-site.mjs",
+    "test": "node --test tests/*.test.js",
     "test:browser": "playwright test"
   },
   "devDependencies": {

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -1,0 +1,73 @@
+import { copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+const htmlFiles = ["404.html", "about.html", "entry.html", "index.html", "render.html"];
+const publicFiles = [...htmlFiles, "site.webmanifest"];
+const assetFiles = ["app.js", "rendering.js", "style.css"];
+
+function options(args) {
+  const result = {
+    output: ".site",
+    version: process.env.PALOMAR_ASSET_VERSION || "",
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const name = args[index];
+    if (name === "--output" || name === "--version") {
+      if (!args[index + 1]) throw new Error(`${name} requires a value`);
+      result[name.slice(2)] = args[index + 1];
+      index += 1;
+    } else {
+      throw new Error(`unknown argument: ${name}`);
+    }
+  }
+  return result;
+}
+
+export async function buildSite({ output, version }) {
+  if (!/^[A-Za-z0-9._-]{1,128}$/.test(version)) {
+    throw new Error("asset version must contain only letters, digits, dots, underscores, or hyphens");
+  }
+
+  const destination = path.resolve(root, output);
+  const relative = path.relative(root, destination);
+  if (!(relative === ".site" || /^\.site-test-[A-Za-z0-9._-]+$/.test(relative))) {
+    throw new Error("output must be .site or a .site-test-* directory");
+  }
+
+  await rm(destination, { recursive: true, force: true });
+  await mkdir(path.join(destination, "assets"), { recursive: true });
+
+  for (const file of publicFiles) {
+    await copyFile(path.join(root, file), path.join(destination, file));
+  }
+  for (const file of assetFiles) {
+    await copyFile(path.join(root, "assets", file), path.join(destination, "assets", file));
+  }
+
+  for (const file of htmlFiles) {
+    const target = path.join(destination, file);
+    const source = await readFile(target, "utf8");
+    const versioned = source
+      .replaceAll('href="assets/style.css"', `href="assets/style.css?v=${version}"`)
+      .replaceAll('src="assets/app.js"', `src="assets/app.js?v=${version}"`);
+    await writeFile(target, versioned);
+  }
+
+  const appTarget = path.join(destination, "assets", "app.js");
+  const app = await readFile(appTarget, "utf8");
+  const versionedImport = app.replace(
+    'from "./rendering.js";',
+    `from "./rendering.js?v=${version}";`,
+  );
+  if (versionedImport === app) throw new Error("could not version the rendering.js import");
+  await writeFile(appTarget, versionedImport);
+  await writeFile(path.join(destination, ".nojekyll"), "");
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const settings = options(process.argv.slice(2));
+  await buildSite(settings);
+  console.log(`Built ${settings.output} with asset version ${settings.version}`);
+}

--- a/tests/build-site.test.js
+++ b/tests/build-site.test.js
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFile, rm } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { buildSite } from "../scripts/build-site.mjs";
+
+const root = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+
+test("deployment build versions coupled browser assets", async () => {
+  const output = `.site-test-${process.pid}`;
+  const destination = path.join(root, output);
+  try {
+    await buildSite({ output, version: "0123456789abcdef" });
+    const index = await readFile(path.join(destination, "index.html"), "utf8");
+    const app = await readFile(path.join(destination, "assets", "app.js"), "utf8");
+    assert.match(index, /assets\/style\.css\?v=0123456789abcdef/);
+    assert.match(index, /assets\/app\.js\?v=0123456789abcdef/);
+    assert.match(app, /\.\/rendering\.js\?v=0123456789abcdef/);
+  } finally {
+    await rm(destination, { recursive: true, force: true });
+  }
+});
+
+test("deployment build refuses to remove a directory outside the repository", async () => {
+  await assert.rejects(
+    buildSite({ output: "../outside", version: "test" }),
+    /output must be \.site or a \.site-test-/,
+  );
+  await assert.rejects(
+    buildSite({ output: ".git", version: "test" }),
+    /output must be \.site or a \.site-test-/,
+  );
+});

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -1,6 +1,15 @@
 import { expect, test } from "@playwright/test";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 const database = encodeURIComponent("http://127.0.0.1:4173/database/index.json");
+const previousRef = process.env.PALOMAR_PREVIOUS_REF;
+const currentIndex = readFileSync(fileURLToPath(new URL("../index.html", import.meta.url)), "utf8");
+
+function fileAtPreviousDeployment(path) {
+  return execFileSync("git", ["show", `${previousRef}:${path}`], { encoding: "utf8" });
+}
 
 test("landing cards show the acceptance date and dated identifier", async ({ page }) => {
   await page.goto(`/?database=${database}`);
@@ -11,6 +20,22 @@ test("landing cards show the acceptance date and dated identifier", async ({ pag
   await expect(page.locator(".entry-card")).toHaveCount(2);
   await expect(page.getByRole("button", { name: "Mathlib only" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Additional libraries" })).toBeVisible();
+});
+
+test("optional metric markup cannot take down the registry", async ({ page }) => {
+  const withoutProjectMetric = currentIndex.replace(
+    /\s*<span><strong id="metric-projects">.*?<\/strong> source projects<\/span>/,
+    "",
+  );
+  expect(withoutProjectMetric).not.toEqual(currentIndex);
+  await page.route("http://127.0.0.1:4173/", (route) => route.fulfill({
+    body: withoutProjectMetric,
+    contentType: "text/html; charset=utf-8",
+  }));
+
+  await page.goto(`/?database=${database}`);
+  await expect(page.locator(".entry-card")).toHaveCount(2);
+  await expect(page.locator("#status")).not.toContainText("could not be loaded");
 });
 
 test("eligible Challenge renders inline without origin privilege", async ({ page }) => {
@@ -53,7 +78,7 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   await expect(page.locator(".acceptance-callout")).toContainText(
     "Every required check passed, so Palomar accepted the submission",
   );
-  await expect(page.getByRole("link", { name: "Open Solution.lean" }).first()).toHaveAttribute(
+  await expect(page.getByRole("link", { name: "Solution.lean" }).first()).toHaveAttribute(
     "href",
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/Solution.lean`,
   );
@@ -80,4 +105,32 @@ test("larger Challenge falls back to the dedicated wrapper", async ({ page }) =>
     "href",
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/Challenge.lean`,
   );
+});
+
+test("current HTML remains compatible with cached JavaScript from the previous deployment", async ({ page }) => {
+  test.skip(!previousRef, "PALOMAR_PREVIOUS_REF is only set in deployment and pull-request CI");
+  await page.route("**/assets/app.js", (route) => route.fulfill({
+    body: fileAtPreviousDeployment("assets/app.js"),
+    contentType: "text/javascript; charset=utf-8",
+  }));
+  await page.route("**/assets/rendering.js", (route) => route.fulfill({
+    body: fileAtPreviousDeployment("assets/rendering.js"),
+    contentType: "text/javascript; charset=utf-8",
+  }));
+
+  await page.goto(`/?database=${database}`);
+  await expect(page.locator(".entry-card")).toHaveCount(2);
+  await expect(page.locator("#status")).not.toContainText("could not be loaded");
+});
+
+test("current JavaScript remains compatible with cached HTML from the previous deployment", async ({ page }) => {
+  test.skip(!previousRef, "PALOMAR_PREVIOUS_REF is only set in deployment and pull-request CI");
+  await page.route("http://127.0.0.1:4173/", (route) => route.fulfill({
+    body: fileAtPreviousDeployment("index.html"),
+    contentType: "text/html; charset=utf-8",
+  }));
+
+  await page.goto(`/?database=${database}`);
+  await expect(page.locator(".entry-card")).toHaveCount(2);
+  await expect(page.locator("#status")).not.toContainText("could not be loaded");
 });


### PR DESCRIPTION
## Summary

- version deployed CSS and JavaScript URLs with the Git commit SHA
- make optional registry metrics resilient to adjacent-deployment HTML/JS skew
- test current markup and code against the previous deployment in pull-request and deployment CI
- require tests to pass before the Pages artifact can deploy
- remove the redundant “Open” prefix from statement and proof file links

## Root cause

GitHub Pages cached `index.html` and `assets/app.js` independently at stable URLs. After the Mathlib-only metric was removed from both files, a browser could combine the new HTML with the cached old script. The old script then assigned `textContent` through a selector for the removed element and aborted registry rendering.

## Validation

- `npm test`
- `npm run test:browser` with system Chromium and the previous deployment ref
- `actionlint .github/workflows/*.yml`
- `git diff --check`
- live-site smoke test in a fresh browser context
