### PR TITLE
Update GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -34,8 +34,8 @@ jobs:
         env:
           PALOMAR_PREVIOUS_REF: ${{ github.event.before }}
       - run: npm run build -- --version "${GITHUB_SHA}" --output .site
-      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: .site
 
@@ -48,4 +48,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
## Summary

- update `actions/checkout` to v7.0.1
- update `actions/configure-pages` to v6.0.0
- update `actions/upload-pages-artifact` to v5.0.0
- update `actions/deploy-pages` to v5.0.0
- keep every action pinned to its exact commit SHA

## Why

The previous action versions target Node.js 20. GitHub now forces them to run on Node.js 24 and emits deprecation warnings. These official releases use Node.js 24 directly; the new Pages upload action also embeds `actions/upload-artifact` v7 instead of v4.

## Validation

- confirmed each pinned SHA matches the named official release
- confirmed each JavaScript action declares `runs.using: node24`
- confirmed `upload-pages-artifact` v5 uses `upload-artifact` v7
- `npm test`
- `git diff --check`
