### PR TITLE
Present immutable version history

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,37 @@ referrer.
 
 The website is a presentation layer only. Permanent data and schemas live in
 PalomarDatabase; consumers should use that repository directly. A versioned ID
-such as `PALOMAR-2026-07-29-000001-v1` names one immutable record. An ID without a version
-means the latest record; later versions may change its theorem, source, authors,
-or subject, so stable citations must include the version.
+such as `PALOMAR-2026-07-29-000001-v1` names one immutable record. An ID without
+a version means the latest record; later versions may change its theorem,
+source, authors, or subject, so stable citations must include the version.
+
+## Version presentation
+
+Palomar uses integer versions and treats the greatest registered version of a
+permanent ID as current. Registry cards show only that version and link to its
+history when older snapshots exist.
+
+An entry URL with both `id` and `version` identifies one immutable snapshot:
+
+```text
+https://kim-em.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000001&version=1
+```
+
+Its HTML canonical link points to that same official, explicit version,
+including when a newer version exists or the site is viewed through a mirror or
+local fixture. An `id`-only URL is a floating convenience link: the site
+resolves it to the current version and replaces the browser URL with the
+explicit snapshot URL.
+
+Entry pages list all registered versions. Older pages display a prominent link
+to the current version. Each page renders the selected version's own authorship,
+statement, proof, trust information, review, and warnings; information is never
+borrowed from a newer record. The site provides links, not computed diffs.
+PalomarDatabase does not yet define change summaries, withdrawal states, or
+major/minor versions, so the website does not infer them. If a richer version
+scheme is adopted later, it will require a new URL contract; existing integer
+snapshot URLs remain permanent.
+
+This remains a runtime-JSON site: JavaScript is required for registry and entry
+content. The static entry shell explains this and links to the immutable JSON
+records for no-JavaScript readers.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ https://kim-em.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000001&vers
 
 Its HTML canonical link points to that same official, explicit version,
 including when a newer version exists or the site is viewed through a mirror or
-local fixture. An `id`-only URL is a floating convenience link: the site
+local fixture. An `id`-only entry URL is a floating convenience link: the site
 resolves it to the current version and replaces the browser URL with the
 explicit snapshot URL.
 

--- a/assets/app.js
+++ b/assets/app.js
@@ -20,6 +20,8 @@ import {
   workflowRunId,
 } from "./security.mjs";
 
+const CANONICAL_WEB_BASE = "https://kim-em.github.io/PalomarWeb/";
+
 const params = new URLSearchParams(window.location.search);
 const PALOMAR_ID = /^PALOMAR-\d{4}-\d{2}-\d{2}-\d{6}$/;
 
@@ -113,7 +115,7 @@ function trustBadge(entry) {
   return badge;
 }
 
-function entryCard(entry) {
+function entryCard(entry, versionCount) {
   const card = el("article", "entry-card");
   card.dataset.trust = entry.trust.level;
   card.dataset.search = [
@@ -128,7 +130,7 @@ function entryCard(entry) {
   const top = el("div", "card-top");
   const identity = el("div", "card-identity");
   identity.append(
-    el("span", "entry-id", `${entry.id} · v${entry.version}`),
+    el("span", "entry-id", `${entry.id} · current version ${entry.version}`),
     el("span", "entry-date", `Accepted ${displayDate(acceptanceDate(entry))}`),
   );
   top.append(identity, trustBadge(entry));
@@ -142,10 +144,21 @@ function entryCard(entry) {
   theorems.append(el("small", "", "Theorems"), el("span", "", theoremNames(entry)));
   meta.append(authors, theorems);
   const footer = el("div", "card-footer");
+  const historyUrl = new URL(localPageUrl("entry.html", entry));
+  historyUrl.hash = "version-history";
   footer.append(
     externalLink(entry.source.repository, entry.source.tree_url, "repo-link"),
     internalLink("View record", localPageUrl("entry.html", entry)),
   );
+  if (versionCount > 1) {
+    footer.append(
+      internalLink(
+        `${versionCount} versions`,
+        historyUrl,
+        "version-history-link",
+      ),
+    );
+  }
   card.append(top, title, abstract, meta, footer);
   return card;
 }
@@ -165,7 +178,12 @@ async function renderIndex() {
   try {
     const { databaseUrl, databaseBase } = dataSource();
     const index = validateIndex(await fetchJson(databaseUrl));
-    const entries = latestVersions(await loadEntries(index, databaseBase));
+    const allEntries = await loadEntries(index, databaseBase);
+    const entries = latestVersions(allEntries);
+    const versionCounts = new Map();
+    for (const entry of allEntries) {
+      versionCounts.set(entry.id, (versionCounts.get(entry.id) || 0) + 1);
+    }
     // GitHub Pages may briefly pair HTML and JavaScript from adjacent deployments.
     // Metrics are presentation-only, so a removed metric must not abort the registry.
     setOptionalText("#metric-results", String(entries.length));
@@ -181,7 +199,7 @@ async function renderIndex() {
     }
     status.hidden = true;
     for (const entry of entries.sort((a, b) => a.id.localeCompare(b.id))) {
-      grid.append(entryCard(entry));
+      grid.append(entryCard(entry, versionCounts.get(entry.id)));
     }
     let trust = "all";
     const search = document.querySelector("#search");
@@ -242,6 +260,93 @@ function localPageUrl(page, entry) {
     }
   }
   return safeInternalUrl(target, window.location.href);
+}
+
+function canonicalEntryPageUrl(entry) {
+  const target = new URL("entry.html", CANONICAL_WEB_BASE);
+  target.searchParams.set("id", entry.id);
+  target.searchParams.set("version", String(entry.version));
+  return safeExternalUrl(target);
+}
+
+function setCanonicalEntryPage(entry) {
+  let canonical = document.querySelector('link[rel="canonical"]');
+  if (!canonical) {
+    canonical = document.createElement("link");
+    canonical.rel = "canonical";
+    document.head.append(canonical);
+  }
+  canonical.href = canonicalEntryPageUrl(entry).href;
+}
+
+function versionNotice(entry, currentVersion) {
+  if (entry.version === currentVersion) return null;
+  const notice = el("aside", "version-notice");
+  notice.setAttribute("role", "status");
+  notice.append(
+    el("strong", "", "Newer version available"),
+    el(
+      "p",
+      "",
+      `You are viewing immutable version ${entry.version}. Version ${currentVersion} is the current version of this record.`,
+    ),
+  );
+  notice.append(
+    internalLink(
+      `View current version ${currentVersion}`,
+      localPageUrl("entry.html", { id: entry.id, version: currentVersion }),
+    ),
+  );
+  return notice;
+}
+
+function versionHistory(entry, versions, currentVersion) {
+  const section = el("section", "version-history");
+  section.id = "version-history";
+  section.setAttribute("aria-labelledby", "version-history-heading");
+  const heading = el("div", "section-heading");
+  const title = el("div");
+  title.append(
+    el("div", "eyebrow", "Registry history"),
+    el("h2", "", "Versions"),
+  );
+  title.querySelector("h2").id = "version-history-heading";
+  heading.append(title);
+  section.append(
+    heading,
+    el(
+      "p",
+      "version-history-intro",
+      "Every version is an immutable accepted snapshot. The authorship, statement, proof, review, warnings, and dependency information on this page belong to the selected version only.",
+    ),
+  );
+
+  const list = el("ol", "version-list");
+  list.reversed = true;
+  for (const summary of [...versions].reverse()) {
+    const item = el("li");
+    const label = `Version ${summary.version}`;
+    if (summary.version === entry.version) {
+      const selected = el("strong", "selected-version", label);
+      selected.setAttribute("aria-current", "page");
+      item.append(selected);
+    } else {
+      item.append(internalLink(label, localPageUrl("entry.html", summary)));
+    }
+    item.append(
+      el(
+        "span",
+        `version-state ${summary.version === currentVersion ? "current" : "superseded"}`,
+        summary.version === currentVersion ? "Current" : "Superseded",
+      ),
+    );
+    if (summary.version === entry.version) {
+      item.append(el("span", "viewing-version", "Viewing"));
+    }
+    list.append(item);
+  }
+  section.append(list);
+  return section;
 }
 
 function challengeFrame(entry, renderBase) {
@@ -447,8 +552,16 @@ function solutionMetadata(entry, renderMetadata) {
   return section;
 }
 
-async function renderEntry(entry, content, canonicalUrl, renderBase) {
+async function renderEntry(
+  entry,
+  content,
+  canonicalUrl,
+  renderBase,
+  versions,
+  currentVersion,
+) {
   document.title = `${entry.title} — Palomar`;
+  setCanonicalEntryPage(entry);
   const heading = el("header", "entry-heading");
   const top = el("div", "card-top");
   top.append(el("span", "entry-id", `${entry.id} · version ${entry.version}`), trustBadge(entry));
@@ -566,8 +679,11 @@ async function renderEntry(entry, content, canonicalUrl, renderBase) {
   machine.append(pre);
 
   const challenge = await challengePresentation(entry, renderBase);
+  content.append(heading);
+  const notice = versionNotice(entry, currentVersion);
+  if (notice) content.append(notice);
   content.append(
-    heading,
+    versionHistory(entry, versions, currentVersion),
     challenge.section,
     evidence,
     trust,
@@ -577,31 +693,66 @@ async function renderEntry(entry, content, canonicalUrl, renderBase) {
   );
 }
 
-async function loadEntry(id, version) {
+async function loadEntry(id, requestedVersion) {
   const { databaseUrl, databaseBase, renderBase } = dataSource();
   const index = validateIndex(await fetchJson(databaseUrl));
+  const versions = index.entries
+    .filter((item) => item.id === id)
+    .sort((left, right) => left.version - right.version);
+  if (!versions.length) throw new Error("entry not found");
+  const currentVersion = versions.at(-1).version;
+  const version = requestedVersion ?? currentVersion;
   const summary = index.entries.find((item) => item.id === id && item.version === version);
   if (!summary) throw new Error("entry not found");
   const canonicalUrl = entryRecordUrl(summary, databaseBase);
   const entry = validateEntry(await fetchJson(canonicalUrl), summary);
-  return { entry, canonicalUrl, renderBase };
+  return {
+    entry,
+    canonicalUrl,
+    renderBase,
+    versions,
+    currentVersion,
+  };
 }
 
 async function renderEntryPage() {
   const status = document.querySelector("#status");
   const content = document.querySelector("#entry-content");
   const id = params.get("id");
-  const version = Number(params.get("version"));
-  if (!PALOMAR_ID.test(id || "") || !Number.isInteger(version) || version < 1) {
-    status.textContent = "This registry link is missing a valid Palomar ID and version.";
+  const versionParameter = params.get("version");
+  const version = versionParameter === null ? null : Number(versionParameter);
+  if (
+    !PALOMAR_ID.test(id || "") ||
+    (version !== null && (!Number.isInteger(version) || version < 1))
+  ) {
+    status.textContent = "This registry link has a missing or invalid Palomar ID or version.";
     status.classList.add("error");
     return;
   }
   try {
-    const { entry, canonicalUrl, renderBase } = await loadEntry(id, version);
+    const {
+      entry,
+      canonicalUrl,
+      renderBase,
+      versions,
+      currentVersion,
+    } = await loadEntry(id, version);
+    if (version === null) {
+      window.history.replaceState(null, "", localPageUrl("entry.html", entry));
+    }
     status.hidden = true;
     content.hidden = false;
-    await renderEntry(entry, content, canonicalUrl, renderBase);
+    await renderEntry(
+      entry,
+      content,
+      canonicalUrl,
+      renderBase,
+      versions,
+      currentVersion,
+    );
+    if (window.location.hash === "#version-history") {
+      document.querySelector("#version-history").scrollIntoView();
+    }
   } catch (error) {
     status.textContent = `The registry entry could not be loaded: ${error.message}`;
     status.classList.add("error");

--- a/assets/app.js
+++ b/assets/app.js
@@ -24,6 +24,7 @@ const CANONICAL_WEB_BASE = "https://kim-em.github.io/PalomarWeb/";
 
 const params = new URLSearchParams(window.location.search);
 const PALOMAR_ID = /^PALOMAR-\d{4}-\d{2}-\d{2}-\d{6}$/;
+const VERSION_PARAMETER = /^[1-9][0-9]*$/;
 
 function dataSource() {
   const databaseUrl = selectDatabaseUrl(window.location.href, window.location.search);
@@ -151,13 +152,13 @@ function entryCard(entry, versionCount) {
     internalLink("View record", localPageUrl("entry.html", entry)),
   );
   if (versionCount > 1) {
-    footer.append(
-      internalLink(
-        `${versionCount} versions`,
-        historyUrl,
-        "version-history-link",
-      ),
+    const historyLink = internalLink(
+      `${versionCount} versions`,
+      historyUrl,
+      "version-history-link",
     );
+    historyLink.setAttribute("aria-label", `${versionCount} versions of ${entry.id}`);
+    footer.append(historyLink);
   }
   card.append(top, title, abstract, meta, footer);
   return card;
@@ -178,12 +179,12 @@ async function renderIndex() {
   try {
     const { databaseUrl, databaseBase } = dataSource();
     const index = validateIndex(await fetchJson(databaseUrl));
-    const allEntries = await loadEntries(index, databaseBase);
-    const entries = latestVersions(allEntries);
     const versionCounts = new Map();
-    for (const entry of allEntries) {
-      versionCounts.set(entry.id, (versionCounts.get(entry.id) || 0) + 1);
+    for (const summary of index.entries) {
+      versionCounts.set(summary.id, (versionCounts.get(summary.id) || 0) + 1);
     }
+    const currentIndex = { entries: latestVersions(index.entries) };
+    const entries = await loadEntries(currentIndex, databaseBase);
     // GitHub Pages may briefly pair HTML and JavaScript from adjacent deployments.
     // Metrics are presentation-only, so a removed metric must not abort the registry.
     setOptionalText("#metric-results", String(entries.length));
@@ -282,9 +283,11 @@ function setCanonicalEntryPage(entry) {
 function versionNotice(entry, currentVersion) {
   if (entry.version === currentVersion) return null;
   const notice = el("aside", "version-notice");
-  notice.setAttribute("role", "status");
+  const heading = el("h2", "", "Newer version available");
+  heading.id = "newer-version-heading";
+  notice.setAttribute("aria-labelledby", heading.id);
   notice.append(
-    el("strong", "", "Newer version available"),
+    heading,
     el(
       "p",
       "",
@@ -323,12 +326,13 @@ function versionHistory(entry, versions, currentVersion) {
 
   const list = el("ol", "version-list");
   list.reversed = true;
+  list.setAttribute("role", "list");
   for (const summary of [...versions].reverse()) {
     const item = el("li");
     const label = `Version ${summary.version}`;
     if (summary.version === entry.version) {
       const selected = el("strong", "selected-version", label);
-      selected.setAttribute("aria-current", "page");
+      selected.setAttribute("aria-current", "true");
       item.append(selected);
     } else {
       item.append(internalLink(label, localPageUrl("entry.html", summary)));
@@ -720,16 +724,20 @@ async function renderEntryPage() {
   const content = document.querySelector("#entry-content");
   const id = params.get("id");
   const versionParameter = params.get("version");
-  const version = versionParameter === null ? null : Number(versionParameter);
+  const version = versionParameter === null || !VERSION_PARAMETER.test(versionParameter)
+    ? null
+    : Number(versionParameter);
   if (
     !PALOMAR_ID.test(id || "") ||
-    (version !== null && (!Number.isInteger(version) || version < 1))
+    (versionParameter !== null &&
+      (!VERSION_PARAMETER.test(versionParameter) || !Number.isSafeInteger(version)))
   ) {
     status.textContent = "This registry link has a missing or invalid Palomar ID or version.";
     status.classList.add("error");
     return;
   }
   try {
+    const requestedHash = window.location.hash;
     const {
       entry,
       canonicalUrl,
@@ -738,7 +746,9 @@ async function renderEntryPage() {
       currentVersion,
     } = await loadEntry(id, version);
     if (version === null) {
-      window.history.replaceState(null, "", localPageUrl("entry.html", entry));
+      const resolvedUrl = localPageUrl("entry.html", entry);
+      resolvedUrl.hash = requestedHash;
+      window.history.replaceState(null, "", resolvedUrl);
     }
     status.hidden = true;
     content.hidden = false;
@@ -750,7 +760,7 @@ async function renderEntryPage() {
       versions,
       currentVersion,
     );
-    if (window.location.hash === "#version-history") {
+    if (requestedHash === "#version-history") {
       document.querySelector("#version-history").scrollIntoView();
     }
   } catch (error) {
@@ -763,8 +773,13 @@ async function renderChallengePage() {
   const status = document.querySelector("#status");
   const content = document.querySelector("#render-content");
   const id = params.get("id");
-  const version = Number(params.get("version"));
-  if (!PALOMAR_ID.test(id || "") || !Number.isInteger(version) || version < 1) {
+  const versionParameter = params.get("version") || "";
+  const version = Number(versionParameter);
+  if (
+    !PALOMAR_ID.test(id || "") ||
+    !VERSION_PARAMETER.test(versionParameter) ||
+    !Number.isSafeInteger(version)
+  ) {
     status.textContent = "This render link is missing a valid Palomar ID and version.";
     status.classList.add("error");
     return;

--- a/assets/style.css
+++ b/assets/style.css
@@ -436,7 +436,8 @@ footer {
   background: #fffbea;
 }
 
-.version-notice strong {
+.version-notice h2 {
+  margin: 0;
   color: var(--caution);
   font: bold 1rem/1.3 var(--sans);
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -429,6 +429,67 @@ footer {
   font-size: 2rem;
 }
 
+.version-notice {
+  margin-bottom: 1.5rem;
+  padding: .85rem 1rem;
+  border: 2px solid var(--caution);
+  background: #fffbea;
+}
+
+.version-notice strong {
+  color: var(--caution);
+  font: bold 1rem/1.3 var(--sans);
+}
+
+.version-notice p {
+  margin: .25rem 0;
+}
+
+.version-history-intro {
+  max-width: 72ch;
+}
+
+.version-list {
+  margin: .8rem 0 0;
+  padding: 0;
+  border-block: 1px solid var(--line);
+  list-style: none;
+}
+
+.version-list li {
+  display: flex;
+  align-items: baseline;
+  gap: .5rem;
+  padding: .55rem .4rem;
+  border-top: 1px dotted var(--line);
+}
+
+.version-list li:first-child {
+  border-top: 0;
+}
+
+.version-state,
+.viewing-version {
+  padding: .1rem .35rem;
+  border: 1px solid var(--line);
+  font: bold .7rem/1.3 var(--sans);
+  text-transform: uppercase;
+}
+
+.version-state.current {
+  border-color: #77a67b;
+  color: #145c24;
+}
+
+.version-state.superseded {
+  color: var(--muted);
+}
+
+.viewing-version {
+  border-style: dashed;
+  color: var(--ink);
+}
+
 .byline {
   color: var(--muted);
   font-style: italic;
@@ -728,6 +789,10 @@ pre {
   .card-footer {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .version-list li {
+    flex-wrap: wrap;
   }
 
   .detail-row {

--- a/entry.html
+++ b/entry.html
@@ -15,7 +15,15 @@
       <nav aria-label="Main navigation"><a href="./">Registry</a><a href="about.html">About</a><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit</a></nav>
     </header>
     <main id="entry" class="entry-page">
-      <div id="status" class="status">Reading registry entry…</div>
+      <div id="status" class="status">
+        Reading registry entry…
+        <noscript>
+          <br>
+          Entry pages require JavaScript because they read immutable records from
+          PalomarDatabase at runtime. You can instead
+          <a href="https://github.com/kim-em/PalomarDatabase/tree/main/entries">browse the JSON records directly</a>.
+        </noscript>
+      </div>
       <article id="entry-content" hidden></article>
     </main>
     <footer>

--- a/index.html
+++ b/index.html
@@ -56,7 +56,15 @@
           </div>
         </div>
 
-        <div id="status" class="status">Reading the Palomar database…</div>
+        <div id="status" class="status">
+          Reading the Palomar database…
+          <noscript>
+            <br>
+            The registry requires JavaScript because it reads PalomarDatabase at
+            runtime. You can instead
+            <a href="https://github.com/kim-em/PalomarDatabase/tree/main/entries">browse the JSON records directly</a>.
+          </noscript>
+        </div>
         <div id="entry-grid" class="entry-grid" aria-live="polite"></div>
       </section>
     </main>

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -14,15 +14,15 @@ PORT = 4173
 HASH = "a" * 64
 
 
-def entry(identifier: str, lines: int) -> dict:
+def entry(identifier: str, lines: int, version: int = 1) -> dict:
     issue = int(identifier.rsplit("-", 1)[-1])
     return {
         "schema_version": 2,
         "id": identifier,
         "accepted_at": "2026-07-29",
-        "version": 1,
+        "version": version,
         "status": "accepted",
-        "title": f"Fixture {identifier}",
+        "title": f"Fixture {identifier} version {version}",
         "abstract": "A browser confinement fixture.",
         "authors": [{"name": "Example"}],
         "submission": {
@@ -91,7 +91,7 @@ def entry(identifier: str, lines: int) -> dict:
         },
         "challenge_render": {
             "format": "verso-html",
-            "artifact_path": f"renders/{identifier}-v1/{HASH}/",
+            "artifact_path": f"renders/{identifier}-v{version}/{HASH}/",
             "entrypoint": "Challenge/index.html",
             "artifact_tree_sha256": HASH,
             "verso_commit": "6" * 40,
@@ -103,8 +103,15 @@ def entry(identifier: str, lines: int) -> dict:
 
 
 ENTRIES = {
-    "PALOMAR-2026-07-29-000123": entry("PALOMAR-2026-07-29-000123", 100),
-    "PALOMAR-2026-07-29-000124": entry("PALOMAR-2026-07-29-000124", 101),
+    ("PALOMAR-2026-07-29-000123", 1): entry(
+        "PALOMAR-2026-07-29-000123", 100, 1
+    ),
+    ("PALOMAR-2026-07-29-000123", 2): entry(
+        "PALOMAR-2026-07-29-000123", 100, 2
+    ),
+    ("PALOMAR-2026-07-29-000124", 1): entry(
+        "PALOMAR-2026-07-29-000124", 101, 1
+    ),
 }
 
 
@@ -129,10 +136,10 @@ class Handler(SimpleHTTPRequestHandler):
                 "entries": [
                     {
                         "id": item["id"],
-                        "version": 1,
+                        "version": item["version"],
                         "title": item["title"],
                         "status": "accepted",
-                        "path": f"entries/{item['id']}-v1.json",
+                        "path": f"entries/{item['id']}-v{item['version']}.json",
                     }
                     for item in ENTRIES.values()
                 ]
@@ -140,14 +147,15 @@ class Handler(SimpleHTTPRequestHandler):
             self.send_bytes(json.dumps(payload).encode(), "application/json")
             return
         match = re.fullmatch(
-            r"/database/entries/(PALOMAR-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6})-v1\.json",
+            r"/database/entries/(PALOMAR-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6})-v([1-9][0-9]*)\.json",
             path,
         )
-        if match and match.group(1) in ENTRIES:
-            self.send_bytes(json.dumps(ENTRIES[match.group(1)]).encode(), "application/json")
+        entry_key = (match.group(1), int(match.group(2))) if match else None
+        if entry_key in ENTRIES:
+            self.send_bytes(json.dumps(ENTRIES[entry_key]).encode(), "application/json")
             return
         if re.fullmatch(
-            rf"/database/renders/PALOMAR-[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}-[0-9]{{6}}-v1/{HASH}/Challenge/index\.html",
+            rf"/database/renders/PALOMAR-[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}-[0-9]{{6}}-v[1-9][0-9]*/{HASH}/Challenge/index\.html",
             path,
         ):
             page = f"""<!doctype html>
@@ -162,7 +170,7 @@ class Handler(SimpleHTTPRequestHandler):
             self.send_bytes(page.encode(), "text/html; charset=utf-8")
             return
         if re.fullmatch(
-            rf"/database/renders/PALOMAR-[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}-[0-9]{{6}}-v1/{HASH}/challenge-metadata\.json",
+            rf"/database/renders/PALOMAR-[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}-[0-9]{{6}}-v[1-9][0-9]*/{HASH}/challenge-metadata\.json",
             path,
         ):
             metadata = {
@@ -175,7 +183,7 @@ class Handler(SimpleHTTPRequestHandler):
             self.send_bytes(json.dumps(metadata).encode(), "application/json")
             return
         if re.fullmatch(
-            rf"/database/renders/PALOMAR-[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}-[0-9]{{6}}-v1/{HASH}/attack\.js",
+            rf"/database/renders/PALOMAR-[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}-[0-9]{{6}}-v[1-9][0-9]*/{HASH}/attack\.js",
             path,
         ):
             script = """

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -12,6 +12,7 @@ function fileAtPreviousDeployment(path) {
 }
 
 test("landing cards show the acceptance date and dated identifier", async ({ page }) => {
+  await page.route("**/entries/PALOMAR-2026-07-29-000123-v1.json", (route) => route.abort());
   await page.goto(`/?database=${database}`);
   const first = page.locator(".entry-card").first();
   await expect(first.locator(".entry-id")).toContainText("PALOMAR-2026-07-29-");
@@ -22,18 +23,26 @@ test("landing cards show the acceptance date and dated identifier", async ({ pag
     "href",
     /entry\.html\?.*version=2.*#version-history$/,
   );
+  await expect(first.locator(".version-history-link")).toHaveAttribute(
+    "aria-label",
+    "2 versions of PALOMAR-2026-07-29-000123",
+  );
   await expect(page.locator(".entry-card")).toHaveCount(2);
   await expect(page.getByRole("button", { name: "Mathlib only" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Additional libraries" })).toBeVisible();
 });
 
 test("an unversioned entry link resolves to the current immutable URL", async ({ page }) => {
-  await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}`);
+  await page.goto(
+    `/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}#version-history`,
+  );
 
   await expect(page.locator(".entry-heading h1")).toHaveText(
     "Fixture PALOMAR-2026-07-29-000123 version 2",
   );
   await expect(page).toHaveURL(/entry\.html\?id=PALOMAR-2026-07-29-000123&version=2&database=/);
+  await expect(page).toHaveURL(/#version-history$/);
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
     "href",
     "https://kim-em.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000123&version=2",
@@ -46,6 +55,7 @@ test("entry pages list immutable versions and flag superseded snapshots", async 
   );
 
   const notice = page.locator(".version-notice");
+  await expect(notice.getByRole("heading", { name: "Newer version available" })).toBeVisible();
   await expect(notice).toContainText("Newer version available");
   await expect(notice).toContainText("Version 2 is the current version");
   await expect(notice.getByRole("link", { name: "View current version 2" })).toHaveAttribute(
@@ -61,10 +71,36 @@ test("entry pages list immutable versions and flag superseded snapshots", async 
   await expect(history.locator("li").nth(1)).toContainText("Version 1");
   await expect(history.locator("li").nth(1)).toContainText("Superseded");
   await expect(history.locator("li").nth(1)).toContainText("Viewing");
+  await expect(page.locator(".entry-heading h1")).toHaveText(
+    "Fixture PALOMAR-2026-07-29-000123 version 1",
+  );
+  await expect(page.locator(".machine-record a")).toHaveText(
+    "Open PALOMAR-2026-07-29-000123-v1.json",
+  );
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
     "href",
     "https://kim-em.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000123&version=1",
   );
+});
+
+test("a single current version has no supersession treatment", async ({ page }) => {
+  await page.goto(`/?database=${database}`);
+  const card = page.locator(".entry-card").nth(1);
+  await expect(card.locator(".version-history-link")).toHaveCount(0);
+
+  await page.goto(
+    `/entry.html?id=PALOMAR-2026-07-29-000124&version=1&database=${database}`,
+  );
+  await expect(page.locator(".version-notice")).toHaveCount(0);
+  await expect(page.locator("#version-history li")).toHaveCount(1);
+});
+
+test("entry version parameters use canonical positive-integer spelling", async ({ page }) => {
+  await page.goto(
+    `/entry.html?id=PALOMAR-2026-07-29-000123&version=2.0&database=${database}`,
+  );
+  await expect(page.locator("#status")).toContainText("missing or invalid Palomar ID or version");
+  await expect(page.locator("#entry-content")).toBeHidden();
 });
 
 test("the index version-history link reaches history loaded at runtime", async ({ page }) => {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -15,11 +15,64 @@ test("landing cards show the acceptance date and dated identifier", async ({ pag
   await page.goto(`/?database=${database}`);
   const first = page.locator(".entry-card").first();
   await expect(first.locator(".entry-id")).toContainText("PALOMAR-2026-07-29-");
+  await expect(first.locator(".entry-id")).toContainText("current version 2");
   await expect(first.locator(".entry-date")).toHaveText("Accepted 29 July 2026");
   await expect(first.locator(".trust-badge")).toHaveText("Dependencies: Mathlib only");
+  await expect(first.getByRole("link", { name: "2 versions" })).toHaveAttribute(
+    "href",
+    /entry\.html\?.*version=2.*#version-history$/,
+  );
   await expect(page.locator(".entry-card")).toHaveCount(2);
   await expect(page.getByRole("button", { name: "Mathlib only" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Additional libraries" })).toBeVisible();
+});
+
+test("an unversioned entry link resolves to the current immutable URL", async ({ page }) => {
+  await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}`);
+
+  await expect(page.locator(".entry-heading h1")).toHaveText(
+    "Fixture PALOMAR-2026-07-29-000123 version 2",
+  );
+  await expect(page).toHaveURL(/entry\.html\?id=PALOMAR-2026-07-29-000123&version=2&database=/);
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    "href",
+    "https://kim-em.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000123&version=2",
+  );
+});
+
+test("entry pages list immutable versions and flag superseded snapshots", async ({ page }) => {
+  await page.goto(
+    `/entry.html?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`,
+  );
+
+  const notice = page.locator(".version-notice");
+  await expect(notice).toContainText("Newer version available");
+  await expect(notice).toContainText("Version 2 is the current version");
+  await expect(notice.getByRole("link", { name: "View current version 2" })).toHaveAttribute(
+    "href",
+    /entry\.html\?.*version=2/,
+  );
+
+  const history = page.locator("#version-history");
+  await expect(history.getByRole("heading", { name: "Versions" })).toBeVisible();
+  await expect(history.locator("li")).toHaveCount(2);
+  await expect(history.locator("li").nth(0)).toContainText("Version 2");
+  await expect(history.locator("li").nth(0)).toContainText("Current");
+  await expect(history.locator("li").nth(1)).toContainText("Version 1");
+  await expect(history.locator("li").nth(1)).toContainText("Superseded");
+  await expect(history.locator("li").nth(1)).toContainText("Viewing");
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    "href",
+    "https://kim-em.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000123&version=1",
+  );
+});
+
+test("the index version-history link reaches history loaded at runtime", async ({ page }) => {
+  await page.goto(`/?database=${database}`);
+  await page.locator(".entry-card").first().getByRole("link", { name: "2 versions" }).click();
+
+  await expect(page).toHaveURL(/#version-history$/);
+  await expect(page.locator("#version-history")).toBeInViewport();
 });
 
 test("optional metric markup cannot take down the registry", async ({ page }) => {


### PR DESCRIPTION
## Summary

- identify the greatest accepted integer version as current on registry cards and link cards with multiple snapshots to their history
- list every immutable version on entry pages, with explicit Current, Superseded, and Viewing labels
- show a prominent newer-version notice on older snapshots while keeping all authorship, proof, review, warning, and trust data scoped to the selected record
- resolve ID-only convenience URLs to an explicit version and emit an official, version-specific canonical link
- provide useful no-JavaScript guidance and document the full presentation contract

## Presentation contract

The existing validated database index already supplies the minimum history data: every accepted summary's `id`, integer `version`, `path`, `title`, and `status`. No database schema change is needed for link-only history.

An explicit URL of the form `entry.html?id=...&version=N` permanently identifies version N. Its canonical link points to that same official version even after later versions appear. An ID-only URL is intentionally floating: it resolves to the greatest accepted version and replaces the browser URL with that explicit snapshot URL.

The website does not synthesize change summaries, diffs, withdrawal states, or major/minor meaning because PalomarDatabase does not publish those fields. Adding any of them remains a policy and schema decision; a future richer version scheme must preserve existing integer snapshot URLs. Update authorization remains the separate PalomarPolicy#8 question and is not decided here.

The history and supersession notice use semantic sections, an announced status, text labels in addition to color, responsive layout, and print-compatible styling. Palomar remains a runtime-JSON site; without JavaScript, its static shell now explains that limitation and links directly to the immutable records.

The implementation is layered on the current trust-boundary hardening: index summaries and selected entries are validated before use, and all history navigation passes through the same-origin URL guard.

## Validation

- `npm test` — 18 passed
- `PALOMAR_PREVIOUS_REF=origin/main npm run test:browser` — 11 passed, including both previous-deployment cache compatibility checks
- `npx --yes html-validate index.html entry.html render.html about.html 404.html`
- desktop superseded-entry and 390px registry visual review

Closes #2

