### PR TITLE
Add Palomar submission FAQ

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,6 +16,7 @@
       <nav aria-label="Main navigation">
         <a href="./">Registry</a>
         <a class="active" href="about.html" aria-current="page">About</a>
+        <a href="faq.html">FAQ</a>
         <a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit</a>
       </nav>
     </header>

--- a/assets/style.css
+++ b/assets/style.css
@@ -349,9 +349,29 @@ footer {
   gap: 1rem;
 }
 
-.about {
+.about,
+.faq {
   max-width: 52rem;
   padding: 2.5rem 0 4rem;
+}
+
+.faq > section {
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--line);
+}
+
+.faq h3 {
+  margin-top: 1.6rem;
+  margin-bottom: .35rem;
+}
+
+.faq li + li {
+  margin-top: .35rem;
+}
+
+.faq li > ul {
+  margin-top: .35rem;
 }
 
 .process,

--- a/entry.html
+++ b/entry.html
@@ -12,7 +12,7 @@
     <a class="skip-link" href="#entry">Skip to entry</a>
     <header class="site-header">
       <a class="brand" href="./">Palomar</a>
-      <nav aria-label="Main navigation"><a href="./">Registry</a><a href="about.html">About</a><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit</a></nav>
+      <nav aria-label="Main navigation"><a href="./">Registry</a><a href="about.html">About</a><a href="faq.html">FAQ</a><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit</a></nav>
     </header>
     <main id="entry" class="entry-page">
       <div id="status" class="status">

--- a/faq.html
+++ b/faq.html
@@ -173,9 +173,9 @@
           Palomar was initially incubated by the
           <a href="https://lean-fro.org/">Lean FRO</a> and
           <a href="https://icarm.math.brown.edu/">ICARM</a>. The initial
-          moderator team is Kim Morrison, Nestor Guillen, Terence Tao, Akshay
+          Scientific Advisory Board is Kim Morrison, Nestor Guillen, Terence Tao, Akshay
           Venkatesh, Jeremy Avigad, Bryna Kra, Ravi Vakil, Jaume de Dios, and
-          Matthew Ballard. The team and its governance are expected to change as
+          Matthew Ballard. The board, maintainer team, and project governance are expected to change as
           the project develops. Kim Morrison is the initial point of contact.
           Questions and proposals are welcome in the
           <a href="https://leanprover.zulipchat.com/#narrow/channel/621638-Palomar">Palomar channel on the Lean Zulip</a>.

--- a/faq.html
+++ b/faq.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Frequently asked questions about Palomar and submitting Lean-verified mathematics.">
+    <meta name="theme-color" content="#ffffff">
+    <title>FAQ — Palomar</title>
+    <link rel="stylesheet" href="assets/style.css">
+  </head>
+  <body data-page="faq">
+    <a class="skip-link" href="#content">Skip to content</a>
+    <header class="site-header">
+      <a class="brand" href="./">Palomar</a>
+      <nav aria-label="Main navigation">
+        <a href="./">Registry</a>
+        <a href="about.html">About</a>
+        <a class="active" href="faq.html" aria-current="page">FAQ</a>
+        <a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit</a>
+      </nav>
+    </header>
+
+    <main id="content" class="faq">
+      <h1>Frequently asked questions</h1>
+      <p class="subtitle">About the registry and how to submit</p>
+
+      <section id="what-is-palomar">
+        <h2>What is Palomar?</h2>
+        <p>
+          Palomar is a public, searchable registry of formally verified
+          mathematical results. Each entry points to an immutable version of a
+          public repository and records the exact statement checked, its
+          dependencies, its proof-verification result, and the findings of a
+          documented editorial review.
+        </p>
+        <p>
+          Palomar is not a journal, peer review, a novelty certificate, or an
+          endorsement of the authors or their work. Acceptance means that the
+          recorded proof proves the recorded statement and that the submission
+          cleared Palomar’s published minimum standard. The source, warnings,
+          and review evidence remain available so readers can make their own
+          judgments.
+        </p>
+      </section>
+
+      <section id="why-now">
+        <h2>Why do we need this today?</h2>
+        <p>
+          Formalized mathematics is growing quickly, but much of it remains
+          scattered across repositories, announcements, and private links. A
+          theorem that cannot be found, searched, cited, or inspected is much
+          less useful than it could be. Palomar gives worthwhile formalizations
+          a durable, indexable record organized around the mathematical result,
+          not just the repository that happens to contain it.
+        </p>
+        <p>
+          Greater output—especially AI-assisted output—also makes a clear
+          minimum standard more important. Palomar combines three lightweight
+          checks: <a href="https://github.com/leanprover/comparator">Comparator</a>
+          separates the advertised statement from its solution and checks that
+          they really match; <code>formalization.yaml</code> makes authorship,
+          sources, automation, limitations, and review status explicit; and a
+          quick, public AI-assisted review checks statement fidelity,
+          definitions, provenance, significance, and clarity. The aim is to
+          exclude low-substance “slop,” misleading claims, and crackpot-style
+          work without pretending that this fast screen is expert peer review.
+        </p>
+      </section>
+
+      <section id="getting-ready">
+        <h2>Getting ready to submit</h2>
+        <p>
+          Start with a public GitHub repository and choose the exact commit you
+          want Palomar to review. The commit must be identified by its full
+          40-character SHA. Palomar checks that immutable snapshot; it does not
+          follow a branch or tag as it changes.
+        </p>
+        <p>The repository root must contain:</p>
+        <ul>
+          <li><code>lean-toolchain</code>, pinned to a supported Lean release or release candidate;</li>
+          <li><code>lakefile.toml</code> and, preferably, a committed <code>lake-manifest.json</code>;</li>
+          <li><code>Challenge.lean</code>, containing the small, readable statement a mathematician should audit;</li>
+          <li><code>Solution.lean</code>, connecting that statement to the completed proof;</li>
+          <li><code>comparator.json</code>, naming every theorem and definition Comparator should compare; and</li>
+          <li><code>formalization.yaml</code>, describing the project, result, sources, authorship, automation, review, and known limitations.</li>
+        </ul>
+
+        <h3>What does Comparator require?</h3>
+        <p>
+          <code>Challenge.lean</code> states the result independently, normally
+          with <code>sorry</code>; <code>Solution.lean</code> supplies the proved
+          version. Their compared declarations must have the same names and
+          types. Comparator rebuilds and compares them, checks the permitted
+          axioms, and verifies the proof. Palomar currently permits only
+          <code>propext</code>, <code>Quot.sound</code>, and
+          <code>Classical.choice</code>.
+        </p>
+        <p>
+          Keep <code>Challenge.lean</code> short and mathematically ordinary.
+          Its transitive imports must come from Lean core, Mathlib, Tau Ceti, or
+          a project already indexed by Palomar. A Palomar-indexed dependency is
+          accepted but displayed with a prominent warning because it enlarges
+          the statement’s trust surface. Dependencies used only by the solution
+          may be arbitrary pinned Git dependencies. Local/path dependencies and
+          <code>lakefile.lean</code> are not accepted by the current prototype.
+        </p>
+
+        <h3>What belongs in <code>formalization.yaml</code>?</h3>
+        <p>
+          At minimum, include the project name, authors, and license; at least
+          one identifiable source; the automation methods used (including
+          <code>manual</code>, when appropriate); and the review status. For
+          editorial review, also give a plain-language account of every compared
+          theorem, precise bibliographic references, what is original or
+          adapted, the role of AI and human review, and any fidelity gaps, extra
+          assumptions, or scope limitations. Follow the
+          <a href="https://github.com/mathlib-initiative/formalization.yaml">formalization.yaml standard</a>
+          and Palomar’s
+          <a href="https://github.com/kim-em/PalomarPolicy/blob/main/CONTRIBUTING.md">submission policy</a>.
+        </p>
+      </section>
+
+      <section id="how-to-submit">
+        <h2>How to submit</h2>
+        <ol>
+          <li>Push the final snapshot to a public GitHub repository and copy its full 40-character commit SHA.</li>
+          <li><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Open the short submission form</a>. Enter the repository URL and commit SHA; for a correction to an existing entry, also enter its Palomar ID.</li>
+          <li>Submit the issue and watch it for status labels and comments. The issue is the public home for verification and review.</li>
+        </ol>
+        <p>
+          Palomar first runs mechanical verification. A passing issue moves to
+          <code>status:awaiting-review</code>; a problem moves to
+          <code>status:changes-requested</code> and the mechanical report explains
+          what failed. During editorial review, the issue moves through
+          <code>status:review-in-progress</code> and then to
+          <code>status:accepted</code>, <code>status:changes-requested</code>,
+          <code>status:rejected</code>, or <code>status:escalated</code>.
+        </p>
+        <p>
+          Once mechanical verification has passed, we aim to complete the
+          editorial review within one hour. This is a target rather than a
+          guarantee, especially when a submission needs specialist judgment.
+        </p>
+        <p>
+          The review comment gives the reasons, warnings, and any requested
+          changes—not just a label. A request for changes means the issue may be
+          reconsidered after specific correctable problems are addressed; a
+          rejection means the submission failed a fundamental mechanical or
+          editorial requirement. An escalation means specialist or human
+          judgment is needed. Because every review is tied to an immutable
+          commit, any revised source must be submitted at a new full commit SHA
+          following the moderator’s instructions on the issue.
+        </p>
+        <p>
+          Palomar does not have an appeals or reconsideration process. After a
+          rejection, a materially revised project may be submitted as a new
+          submission after the cooldown period. The cooldown mechanism has not
+          yet been implemented; until it is, follow the moderator’s instructions
+          on the rejected issue.
+        </p>
+        <p>
+          For accepted work, publication is complete when the corresponding
+          database pull request is merged and the result appears in the
+          registry. Corrections become new versions; earlier accepted snapshots
+          remain part of the public record.
+        </p>
+      </section>
+
+      <section id="who-we-are">
+        <h2>Who are we?</h2>
+        <p>
+          Palomar was initially incubated by the
+          <a href="https://lean-fro.org/">Lean FRO</a> and
+          <a href="https://icarm.math.brown.edu/">ICARM</a>. The initial
+          moderator team is Kim Morrison, Nestor Guillen, Terence Tao, Akshay
+          Venkatesh, Jeremy Avigad, Bryna Kra, Ravi Vakil, Jaume de Dios, and
+          Matthew Ballard. The team and its governance are expected to change as
+          the project develops. Kim Morrison is the initial point of contact.
+          Questions and proposals are welcome in the
+          <a href="https://leanprover.zulipchat.com/#narrow/channel/621638-Palomar">Palomar channel on the Lean Zulip</a>.
+        </p>
+      </section>
+
+      <section id="other-proof-assistants">
+        <h2>What about other proof assistants?</h2>
+        <p>
+          We would be open to adding support for other proof assistants. Please
+          be ready to:
+        </p>
+        <ul>
+          <li>
+            prepare pull requests that add support for the language, including:
+            <ul>
+              <li>running its verification pipeline;</li>
+              <li>requiring a separation between “the statement” and “the solution”;</li>
+              <li>rendering the main result to HTML; and</li>
+              <li>parsing upstream dependencies for display;</li>
+            </ul>
+          </li>
+          <li>work with us to make sure the implementation is secure and performant;</li>
+          <li>bring a sample of 10–100 candidate projects that could be indexed for this proof assistant;</li>
+          <li>have someone ready to join its maintainer team; and</li>
+          <li>if we are still operating on a shoestring budget, be willing to fund the additional review and CI costs for the language.</li>
+        </ul>
+        <p>
+          Please contact the maintainer team early in the
+          <a href="https://leanprover.zulipchat.com/#narrow/channel/621638-Palomar">Palomar channel on the Lean Zulip</a>
+          if you intend to pursue this.
+        </p>
+      </section>
+
+      <section class="cta">
+        <div><h2>Ready to submit?</h2><p>The form asks for a repository and one fixed commit.</p></div>
+        <a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Open the submission form</a>
+      </section>
+    </main>
+
+    <footer>
+      <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
+      <div class="footer-links"><a href="https://github.com/kim-em/PalomarPolicy">Policy</a><a href="https://github.com/kim-em/PalomarDatabase">Data</a><a href="https://github.com/kim-em/PalomarWeb">Source</a></div>
+    </footer>
+  </body>
+</html>

--- a/faq.html
+++ b/faq.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="Frequently asked questions about Palomar and submitting Lean-verified mathematics.">
     <meta name="theme-color" content="#ffffff">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; frame-src 'self' https://kim-em.github.io; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>FAQ — Palomar</title>
     <link rel="stylesheet" href="assets/style.css">
   </head>

--- a/faq.html
+++ b/faq.html
@@ -76,6 +76,12 @@
           40-character SHA. Palomar checks that immutable snapshot; it does not
           follow a branch or tag as it changes.
         </p>
+        <p>
+          The <a href="https://github.com/kim-em/PalomarTemplate">Palomar starter repository</a>
+          provides this layout, pinned dependencies, documentation generation,
+          CI checks for Lean and Comparator, and a documented
+          <code>formalization.yaml</code> starting point.
+        </p>
         <p>The repository root must contain:</p>
         <ul>
           <li><code>lean-toolchain</code>, pinned to a supported Lean release or release candidate;</li>
@@ -126,14 +132,18 @@
         <h2>How to submit</h2>
         <ol>
           <li>Push the final snapshot to a public GitHub repository and copy its full 40-character commit SHA.</li>
-          <li><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Open the short submission form</a>. Enter the repository URL and commit SHA; for a correction to an existing entry, also enter its Palomar ID.</li>
+          <li><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Open the short submission form</a>. Enter the repository URL and commit SHA, confirm the required acknowledgements, and, for a correction to an existing entry, enter its Palomar ID.</li>
           <li>Submit the issue and watch it for status labels and comments. The issue is the public home for verification and review.</li>
         </ol>
         <p>
-          Palomar first runs mechanical verification. A passing issue moves to
-          <code>status:awaiting-review</code>; a problem moves to
+          Palomar first labels the issue <code>status:verifying</code> while
+          mechanical verification runs. A passing issue moves to
+          <code>status:awaiting-review</code>; a failed check moves to
           <code>status:changes-requested</code> and the mechanical report explains
-          what failed. During editorial review, the issue moves through
+          what failed. If Palomar’s verification infrastructure itself fails,
+          the issue instead receives <code>status:verification-error</code>; no
+          submitter action is required until the maintainers respond. During
+          editorial review, the issue moves through
           <code>status:review-in-progress</code> and then to
           <code>status:accepted</code>, <code>status:changes-requested</code>,
           <code>status:rejected</code>, or <code>status:escalated</code>.

--- a/faq.html
+++ b/faq.html
@@ -108,8 +108,9 @@
 
         <h3>What belongs in <code>formalization.yaml</code>?</h3>
         <p>
-          At minimum, include the project name, authors, and license; at least
-          one identifiable source; the automation methods used (including
+          At minimum, include the project name, authors, and license; one or two
+          arXiv classifications and one to eight MSC 2020 classifications; at
+          least one identifiable source; the automation methods used (including
           <code>manual</code>, when appropriate); and the review status. For
           editorial review, also give a plain-language account of every compared
           theorem, precise bibliographic references, what is original or

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
       <nav aria-label="Main navigation">
         <a class="active" href="./" aria-current="page">Registry</a>
         <a href="about.html">About</a>
+        <a href="faq.html">FAQ</a>
         <a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit</a>
       </nav>
     </header>

--- a/render.html
+++ b/render.html
@@ -12,7 +12,7 @@
     <a class="skip-link" href="#render">Skip to formatted statement</a>
     <header class="site-header">
       <a class="brand" href="./">Palomar</a>
-      <nav aria-label="Main navigation"><a href="./">Registry</a><a href="about.html">About</a><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit</a></nav>
+      <nav aria-label="Main navigation"><a href="./">Registry</a><a href="about.html">About</a><a href="faq.html">FAQ</a><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit</a></nav>
     </header>
     <main id="render" class="entry-page render-page">
       <div id="status" class="status">Reading registry entry…</div>

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
-const htmlFiles = ["404.html", "about.html", "entry.html", "index.html", "render.html"];
+const htmlFiles = ["404.html", "about.html", "entry.html", "faq.html", "index.html", "render.html"];
 const publicFiles = [...htmlFiles, "site.webmanifest"];
 const assetFiles = ["app.js", "rendering.js", "security.mjs", "style.css"];
 

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
-const htmlFiles = ["404.html", "about.html", "entry.html", "faq.html", "index.html", "render.html"];
+export const htmlFiles = ["404.html", "about.html", "entry.html", "faq.html", "index.html", "render.html"];
 const publicFiles = [...htmlFiles, "site.webmanifest"];
 const assetFiles = ["app.js", "rendering.js", "security.mjs", "style.css"];
 

--- a/tests/build-site.test.js
+++ b/tests/build-site.test.js
@@ -14,9 +14,11 @@ test("deployment build versions coupled browser assets", async () => {
   try {
     await buildSite({ output, version: "0123456789abcdef" });
     const index = await readFile(path.join(destination, "index.html"), "utf8");
+    const faq = await readFile(path.join(destination, "faq.html"), "utf8");
     const app = await readFile(path.join(destination, "assets", "app.js"), "utf8");
     assert.match(index, /assets\/style\.css\?v=0123456789abcdef/);
     assert.match(index, /assets\/app\.js\?v=0123456789abcdef/);
+    assert.match(faq, /assets\/style\.css\?v=0123456789abcdef/);
     assert.match(app, /\.\/rendering\.js\?v=0123456789abcdef/);
     assert.match(app, /\.\/security\.mjs\?v=0123456789abcdef/);
     await readFile(path.join(destination, "assets", "security.mjs"), "utf8");

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -275,7 +275,7 @@ test("unsafe source paths and malformed displayed digests fail closed", () => {
 });
 
 test("every HTML entry point carries the restrictive CSP", async () => {
-  for (const name of ["index.html", "entry.html", "render.html", "about.html", "404.html"]) {
+  for (const name of ["index.html", "entry.html", "render.html", "about.html", "faq.html", "404.html"]) {
     const html = await readFile(new URL(`../${name}`, import.meta.url), "utf8");
     assert.match(html, /Content-Security-Policy/);
     assert.match(html, /default-src 'none'/);

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
+import { htmlFiles } from "../scripts/build-site.mjs";
+
 import {
   DEFAULT_DATABASE,
   DEFAULT_RENDER_BASE,
@@ -275,7 +277,7 @@ test("unsafe source paths and malformed displayed digests fail closed", () => {
 });
 
 test("every HTML entry point carries the restrictive CSP", async () => {
-  for (const name of ["index.html", "entry.html", "render.html", "about.html", "faq.html", "404.html"]) {
+  for (const name of htmlFiles) {
     const html = await readFile(new URL(`../${name}`, import.meta.url), "utf8");
     assert.match(html, /Content-Security-Policy/);
     assert.match(html, /default-src 'none'/);


### PR DESCRIPTION
## Summary

- add a dedicated FAQ explaining Palomar, its purpose, and its review boundary
- document the required repository layout, Comparator, and formalization.yaml
- give submitters a direct three-step intake flow and explain status outcomes
- publish the initial moderator team and Palomar Zulip contact
- describe the path for supporting other proof assistants
- include the FAQ in navigation, deployment builds, and CSP coverage

## Policy details

- target editorial review within one hour after mechanical verification
- no appeals or reconsideration; materially revised projects may be resubmitted after the planned cooldown
- allow Palomar-indexed Challenge dependencies while warning that they enlarge the statement trust surface

## Verification

- npm test (18 tests pass)
- production build includes and versions faq.html

Browser tests were not rerun locally because the installed Chromium cannot start without libglib-2.0.so.0.