### PR TITLE
Clarify certificate and statement trust surfaces

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,10 +29,17 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm test
+      - name: Resolve previous deployment revision
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          if [ -n "$BEFORE" ] && git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
+            echo "PALOMAR_PREVIOUS_REF=$BEFORE" >> "$GITHUB_ENV"
+          fi
       - run: npx playwright install --with-deps chromium
       - run: npm run test:browser
         env:
-          PALOMAR_PREVIOUS_REF: ${{ github.event.before }}
+          PALOMAR_PREVIOUS_REF: ${{ env.PALOMAR_PREVIOUS_REF }}
       - run: npm run build -- --version "${GITHUB_SHA}" --output .site
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The read-only human view of
 The site is static and deployed with GitHub Pages. It fetches `index.json` and
 entry records directly from the database repository at runtime, so publishing a
 database PR does not require a coordinated website deployment or a server.
+Registry cards display arXiv and MSC2020 classifications, and the toolbar can
+filter the current records by either taxonomy.
 
 Local preview:
 
@@ -32,6 +34,14 @@ PalomarDatabase; consumers should use that repository directly. A versioned ID
 such as `PALOMAR-2026-07-29-000001-v1` names one immutable record. An ID without
 a version means the latest record; later versions may change its theorem,
 source, authors, or subject, so stable citations must include the version.
+
+## RSS
+
+The static database deployment generates a main RSS feed and separate feeds for
+every arXiv and MSC2020 classification represented by a current entry. The web
+site advertises the main feed with RSS autodiscovery and links the relevant
+category feeds from each entry page. Static hosting is sufficient because feed
+XML is regenerated whenever the append-only database changes.
 
 ## Version presentation
 

--- a/about.html
+++ b/about.html
@@ -42,11 +42,11 @@
           </li>
           <li>
             <span>3.</span>
-            <div><h3>Independent proof check</h3><p>Palomar checks the statement and proof separately, confirms that the theorem names match, and asks Lean to verify the proof using only the allowed axioms.</p></div>
+            <div><h3>Independent proof check</h3><p>Lean and Comparator mechanically check that the recorded Solution proves the recorded formal Challenge under the listed axiom and dependency rules.</p></div>
           </li>
           <li>
             <span>4.</span>
-            <div><h3>Documented review</h3><p>An AI-assisted review compares the written mathematical claim with the Lean statement and examines its definitions, prior literature, significance, and clarity. Problems and uncertainties remain visible.</p></div>
+            <div><h3>Documented review</h3><p>A separate AI-mediated editorial review judges whether the formal Challenge matches the written mathematical claim and examines its definitions, prior literature, significance, and clarity. It is not human peer review or a novelty certificate; problems and uncertainties remain visible.</p></div>
           </li>
           <li>
             <span>5.</span>
@@ -58,8 +58,8 @@
       <section class="meaning-grid">
         <article>
           <div class="eyebrow">Palomar does say</div>
-          <h2>The recorded proof proves the recorded statement.</h2>
-          <p>It also says that the documented review found the statement and its description suitable for listing under the policy version shown.</p>
+          <h2>Mechanical proof checking and editorial judgment are separate.</h2>
+          <p>Lean and Comparator check the exact formal proof claim. The documented AI-mediated review separately judges the link from that formal statement to the informal mathematical claim under the policy version shown.</p>
         </article>
         <article>
           <div class="eyebrow">Palomar does not say</div>

--- a/assets/app.js
+++ b/assets/app.js
@@ -359,7 +359,7 @@ function challengeFrame(entry, renderBase) {
     challengeArtifactUrl(entry, renderBase).href,
     window.location.href,
   ).href;
-  frame.title = `Formatted statement for ${entry.id} version ${entry.version}`;
+  frame.title = `Named compared declarations for ${entry.id} version ${entry.version}`;
   frame.loading = "lazy";
   frame.referrerPolicy = "no-referrer";
   frame.setAttribute("sandbox", "allow-scripts");
@@ -429,13 +429,27 @@ async function challengePresentation(entry, renderBase, { forceFrame = false } =
   const section = el("section", "challenge-presentation");
   const heading = el("div", "section-heading");
   const titleBlock = el("div");
-  titleBlock.append(el("div", "eyebrow", "Formal statement"), el("h2", "", "Statement"));
+  titleBlock.append(
+    el("div", "eyebrow", "Formal comparison surface"),
+    el("h2", "", "Named compared declarations"),
+  );
   heading.append(titleBlock);
   section.append(heading);
 
   const links = el("p", "challenge-links");
+  const dependencyRecordUrl = localPageUrl("entry.html", entry);
+  dependencyRecordUrl.hash = "statement-dependencies";
   links.append(
-    externalLink("View statement file (Challenge.lean)", challengeSourceUrl(entry), "challenge-source"),
+    externalLink(
+      "View full pinned statement file (Challenge.lean)",
+      challengeSourceUrl(entry),
+      "challenge-source",
+    ),
+    " · ",
+    internalLink(
+      "Inspect statement dependencies",
+      dependencyRecordUrl,
+    ),
   );
   const inline = isInlineChallenge(entry);
   if (!forceFrame && !inline) {
@@ -445,6 +459,13 @@ async function challengePresentation(entry, renderBase, { forceFrame = false } =
     );
   }
   section.append(links);
+  section.append(
+    el(
+      "p",
+      "challenge-surface-disclosure",
+      "This formatted view shows only the declarations named in comparator.json. Comparator also checks the declarations used by their types. The full pinned Challenge.lean and the dependency record define the complete certified and reviewed statement surface.",
+    ),
+  );
 
   let metadata;
   try {
@@ -484,13 +505,25 @@ function acceptanceCallout(entry) {
   const check = el("span", "acceptance-check", "✓");
   check.setAttribute("aria-hidden", "true");
   const copy = el("div");
+  const evidenceLinks = el("p", "certificate-evidence-links");
+  evidenceLinks.append(
+    externalLink("Mechanical evidence", entry.verification.workflow_url),
+    " · ",
+    externalLink("Editorial evidence", entry.review.report_url),
+  );
   copy.append(
     el("strong", "", `Accepted on ${displayDate(acceptanceDate(entry))}`),
     el(
       "p",
       "",
-      "Palomar used Lean to check the recorded proof against the recorded statement and confirmed that it uses only the allowed axioms. The documented review was also completed. Every required check passed, so Palomar accepted the submission.",
+      "Mechanical assurance: Lean and Comparator checked that the recorded Solution proves the recorded formal Challenge under the listed axiom and dependency rules.",
     ),
+    el(
+      "p",
+      "",
+      "Editorial assurance: an AI-mediated review judged whether that formal Challenge matches the informal mathematical claim under the recorded policy. This is not human peer review or a novelty certificate.",
+    ),
+    evidenceLinks,
   );
   callout.append(check, copy);
   return callout;
@@ -613,6 +646,7 @@ async function renderEntry(
   evidence.append(details);
 
   const trust = el("section", "entry-trust");
+  trust.id = "statement-dependencies";
   const trustTitle = el("div", "section-heading");
   const trustBlock = el("div");
   trustBlock.append(
@@ -634,7 +668,10 @@ async function renderEntry(
     trust.append(el("h3", "", "Source repositories"));
     const dependencies = el("ul", "plain-list");
     for (const dependency of entry.trust.challenge_dependencies) {
-      dependencies.append(el("li", "", dependency.repository));
+      const provenance = dependency.provenance === "palomar-indexed"
+        ? `Palomar-indexed: ${dependency.palomar_id}`
+        : "allowlisted";
+      dependencies.append(el("li", "", `${dependency.repository} (${provenance})`));
     }
     trust.append(dependencies);
   }

--- a/assets/app.js
+++ b/assets/app.js
@@ -21,6 +21,7 @@ import {
 } from "./security.mjs";
 
 const CANONICAL_WEB_BASE = "https://kim-em.github.io/PalomarWeb/";
+const FEED_BASE = "https://kim-em.github.io/PalomarDatabase/feeds/";
 
 const params = new URLSearchParams(window.location.search);
 const PALOMAR_ID = /^PALOMAR-\d{4}-\d{2}-\d{2}-\d{6}$/;
@@ -31,6 +32,11 @@ function dataSource() {
   const databaseBase = databaseBaseFor(databaseUrl);
   const renderBase = selectRenderBase(window.location.href, window.location.search, databaseBase);
   return { databaseUrl, databaseBase, renderBase };
+}
+
+function categoryFeedBase() {
+  if (!params.has("database")) return FEED_BASE;
+  return new URL("feeds/", dataSource().databaseBase);
 }
 
 function el(tag, className, text) {
@@ -81,6 +87,22 @@ function theoremNames(entry) {
   return entry.formalization.theorem_names.join(", ");
 }
 
+function classification(entry) {
+  return {
+    arxiv: Array.isArray(entry.classification?.arxiv) ? entry.classification.arxiv : [],
+    msc2020: Array.isArray(entry.classification?.msc2020) ? entry.classification.msc2020 : [],
+  };
+}
+
+function categoryTokens(entry) {
+  const categories = classification(entry);
+  const tokens = el("span", "category-tokens");
+  for (const code of categories.arxiv) tokens.append(el("code", "arxiv-category", code));
+  for (const code of categories.msc2020) tokens.append(el("code", "msc-category", `MSC ${code}`));
+  if (!tokens.children.length) tokens.append(el("span", "unclassified", "Not recorded"));
+  return tokens;
+}
+
 function acceptanceDate(entry) {
   const value = entry.accepted_at || entry.review?.reviewed_at?.slice(0, 10);
   if (!/^\d{4}-\d{2}-\d{2}$/.test(value || "")) {
@@ -117,8 +139,11 @@ function trustBadge(entry) {
 }
 
 function entryCard(entry, versionCount) {
+  const categories = classification(entry);
   const card = el("article", "entry-card");
   card.dataset.trust = entry.trust.level;
+  card.dataset.arxiv = categories.arxiv.join(" ");
+  card.dataset.msc = categories.msc2020.join(" ");
   card.dataset.search = [
     entry.title,
     entry.abstract,
@@ -126,6 +151,8 @@ function entryCard(entry, versionCount) {
     theoremNames(entry),
     entry.source.repository,
     entry.id,
+    ...categories.arxiv,
+    ...categories.msc2020,
   ].join(" ").toLowerCase();
 
   const top = el("div", "card-top");
@@ -143,7 +170,9 @@ function entryCard(entry, versionCount) {
   authors.append(el("small", "", "Authors"), el("span", "", authorNames(entry)));
   const theorems = el("div");
   theorems.append(el("small", "", "Theorems"), el("span", "", theoremNames(entry)));
-  meta.append(authors, theorems);
+  const subjects = el("div", "card-subjects");
+  subjects.append(el("small", "", "Subjects"), categoryTokens(entry));
+  meta.append(authors, theorems, subjects);
   const footer = el("div", "card-footer");
   const historyUrl = new URL(localPageUrl("entry.html", entry));
   historyUrl.hash = "version-history";
@@ -204,12 +233,34 @@ async function renderIndex() {
     }
     let trust = "all";
     const search = document.querySelector("#search");
+    const arxiv = document.querySelector("#arxiv-filter");
+    const msc = document.querySelector("#msc-filter");
+    const fillCategories = (select, values) => {
+      if (!select) return;
+      for (const value of [...values].sort()) {
+        const option = el("option", "", value);
+        option.value = value;
+        select.append(option);
+      }
+    };
+    fillCategories(arxiv, new Set(entries.flatMap((entry) => classification(entry).arxiv)));
+    fillCategories(msc, new Set(entries.flatMap((entry) => classification(entry).msc2020)));
+    if (arxiv && [...arxiv.options].some((option) => option.value === params.get("arxiv"))) {
+      arxiv.value = params.get("arxiv");
+    }
+    if (msc && [...msc.options].some((option) => option.value === params.get("msc"))) {
+      msc.value = params.get("msc");
+    }
     const update = () => {
       const query = search.value.trim().toLowerCase();
+      const arxivValue = arxiv?.value || "";
+      const mscValue = msc?.value || "";
       let shown = 0;
       for (const card of grid.children) {
         const visible =
           (trust === "all" || card.dataset.trust === trust) &&
+          (!arxivValue || card.dataset.arxiv.split(" ").includes(arxivValue)) &&
+          (!mscValue || card.dataset.msc.split(" ").includes(mscValue)) &&
           (!query || card.dataset.search.includes(query));
         card.hidden = !visible;
         if (visible) shown += 1;
@@ -218,6 +269,8 @@ async function renderIndex() {
       status.textContent = shown ? "" : "No registry entries match those filters.";
     };
     search.addEventListener("input", update);
+    arxiv?.addEventListener("change", update);
+    msc?.addEventListener("change", update);
     document.querySelectorAll(".filter").forEach((button) => {
       button.addEventListener("click", () => {
         trust = button.dataset.trust;
@@ -229,6 +282,7 @@ async function renderIndex() {
         update();
       });
     });
+    update();
   } catch (error) {
     status.textContent = `The registry could not be loaded: ${error.message}`;
     status.classList.add("error");
@@ -536,6 +590,43 @@ function acceptanceCallout(entry) {
   return callout;
 }
 
+function classificationSection(entry, currentVersion) {
+  const categories = classification(entry);
+  const section = el("section", "entry-classification");
+  const heading = el("div", "section-heading");
+  const title = el("div");
+  title.append(el("div", "eyebrow", "Discoverability"), el("h2", "", "Subject classification"));
+  heading.append(title);
+  section.append(heading);
+  const details = el("dl", "details classification-details");
+  const categoryRow = (label, values, feedType) => {
+    const row = el("div", "detail-row");
+    row.append(el("dt", "", label));
+    const value = el("dd", "category-feed-list");
+    for (const code of values) {
+      const item = el("span", "category-feed-item");
+      item.append(el("code", "", code));
+      if (entry.version === currentVersion) {
+        const feedUrl = new URL(
+          `${feedType}/${encodeURIComponent(code)}.xml`,
+          categoryFeedBase(),
+        );
+        item.append(" ", dataLink("RSS", feedUrl));
+      }
+      value.append(item);
+    }
+    if (!values.length) value.append(el("span", "unclassified", "Not recorded for this older entry"));
+    row.append(value);
+    return row;
+  };
+  details.append(
+    categoryRow("arXiv subjects", categories.arxiv, "arxiv"),
+    categoryRow("MSC2020", categories.msc2020, "msc"),
+  );
+  section.append(details);
+  return section;
+}
+
 function solutionMetadata(entry, renderMetadata) {
   const section = el("section", "entry-solution");
   const heading = el("div", "section-heading");
@@ -637,6 +728,11 @@ async function renderEntry(
       entry.formalization.solution_path,
       pinnedSourceFileUrl(entry, entry.formalization.solution_path),
     ),
+    externalDetailRow(
+      "Formalization metadata",
+      entry.formalization.formalization_metadata_path,
+      pinnedSourceFileUrl(entry, entry.formalization.formalization_metadata_path),
+    ),
     detailRow("Challenge SHA-256", entry.verification.challenge_sha256),
     detailRow("Solution SHA-256", entry.verification.solution_sha256),
     detailRow("Lean version", entry.formalization.lean_toolchain),
@@ -732,6 +828,7 @@ async function renderEntry(
   if (notice) content.append(notice);
   content.append(
     versionHistory(entry, versions, currentVersion),
+    classificationSection(entry, currentVersion),
     challenge.section,
     evidence,
     trust,

--- a/assets/app.js
+++ b/assets/app.js
@@ -439,6 +439,7 @@ async function challengePresentation(entry, renderBase, { forceFrame = false } =
   const links = el("p", "challenge-links");
   const dependencyRecordUrl = localPageUrl("entry.html", entry);
   dependencyRecordUrl.hash = "statement-dependencies";
+  const comparatorPath = entry.formalization.comparator_config_path;
   links.append(
     externalLink(
       "View full pinned statement file (Challenge.lean)",
@@ -449,6 +450,12 @@ async function challengePresentation(entry, renderBase, { forceFrame = false } =
     internalLink(
       "Inspect statement dependencies",
       dependencyRecordUrl,
+    ),
+    " · ",
+    externalLink(
+      `View comparator configuration (${comparatorPath})`,
+      pinnedSourceFileUrl(entry, comparatorPath),
+      "comparator-source",
     ),
   );
   const inline = isInlineChallenge(entry);
@@ -463,7 +470,7 @@ async function challengePresentation(entry, renderBase, { forceFrame = false } =
     el(
       "p",
       "challenge-surface-disclosure",
-      "This formatted view shows only the declarations named in comparator.json. Comparator also checks the declarations used by their types. The full pinned Challenge.lean and the dependency record define the complete certified and reviewed statement surface.",
+      "The formatted view shows only the declarations named in this entry's comparator configuration. Comparator also checks the declarations used by their types. The full pinned Challenge.lean and dependency record expose the statement and dependency surface for inspection.",
     ),
   );
 
@@ -797,9 +804,10 @@ async function renderEntryPage() {
       versions,
       currentVersion,
     );
-    if (requestedHash === "#version-history") {
-      document.querySelector("#version-history").scrollIntoView();
-    }
+    const anchorTarget = requestedHash.startsWith("#")
+      ? document.getElementById(decodeURIComponent(requestedHash.slice(1)))
+      : null;
+    if (anchorTarget) anchorTarget.scrollIntoView();
   } catch (error) {
     status.textContent = `The registry entry could not be loaded: ${error.message}`;
     status.classList.add("error");
@@ -823,7 +831,7 @@ async function renderChallengePage() {
   }
   try {
     const { entry, renderBase } = await loadEntry(id, version);
-    document.title = `Statement — ${entry.title} — Palomar`;
+    document.title = `Named compared declarations — ${entry.title} — Palomar`;
     const heading = el("header", "entry-heading");
     heading.append(
       el("div", "entry-id", `${entry.id} · version ${entry.version}`),
@@ -834,7 +842,7 @@ async function renderChallengePage() {
     status.hidden = true;
     content.hidden = false;
   } catch (error) {
-    status.textContent = `The formatted statement could not be loaded: ${error.message}`;
+    status.textContent = `The named compared declarations could not be loaded: ${error.message}`;
     status.classList.add("error");
   }
 }

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -1,4 +1,5 @@
-export const SUPPORTED_SCHEMA_VERSION = 2;
+export const INDEX_SCHEMA_VERSION = 2;
+export const ENTRY_SCHEMA_VERSIONS = new Set([2, 3]);
 export const DEFAULT_DATABASE =
   "https://raw.githubusercontent.com/kim-em/PalomarDatabase/main/index.json";
 export const DEFAULT_RENDER_BASE = "https://kim-em.github.io/PalomarDatabase/";
@@ -10,6 +11,8 @@ const COMMIT_RE = /^[0-9a-f]{40}$/;
 const SHA256_RE = /^[0-9a-f]{64}$/;
 const POSITIVE_INTEGER_RE = /^[1-9][0-9]*$/;
 const DATE_RE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
+const ARXIV_RE = /^[a-z]+(?:-[a-z]+)*(?:\.[A-Za-z-]+)?$/;
+const MSC2020_RE = /^[0-9]{2}(?:[A-Z][0-9]{2}|-[0-9]{2})$/;
 
 function fail(message) {
   throw new Error(`invalid registry data: ${message}`);
@@ -128,7 +131,7 @@ export function safeInternalUrl(value, locationHref) {
 
 export function validateIndex(index) {
   object(index, "index");
-  if (index.schema_version !== SUPPORTED_SCHEMA_VERSION) {
+  if (index.schema_version !== INDEX_SCHEMA_VERSION) {
     fail(`unsupported index schema_version ${String(index.schema_version)}`);
   }
   const seen = new Set();
@@ -227,7 +230,7 @@ function validateCanonicalRecordLinks(entry) {
 export function validateEntry(entry, summary) {
   object(entry, "entry");
   object(summary, "entry summary");
-  if (entry.schema_version !== SUPPORTED_SCHEMA_VERSION) {
+  if (!ENTRY_SCHEMA_VERSIONS.has(entry.schema_version)) {
     fail(`unsupported entry schema_version ${String(entry.schema_version)}`);
   }
   if (entry.status !== "accepted") fail("entry status is not accepted");
@@ -247,6 +250,27 @@ export function validateEntry(entry, summary) {
 
   for (const [position, value] of array(entry.authors, "entry.authors").entries()) {
     string(object(value, `entry.authors[${position}]`).name, `entry.authors[${position}].name`);
+  }
+
+  if (entry.schema_version === 2 && entry.classification !== undefined) {
+    fail("entry.classification is not valid in schema version 2");
+  }
+  if (entry.schema_version === 3) {
+    const classification = object(entry.classification, "entry.classification");
+    const arxiv = stringArray(classification.arxiv, "entry.classification.arxiv");
+    const msc2020 = stringArray(classification.msc2020, "entry.classification.msc2020");
+    if (arxiv.length < 1 || arxiv.length > 2 || new Set(arxiv).size !== arxiv.length) {
+      fail("entry.classification.arxiv must contain one or two unique codes");
+    }
+    if (msc2020.length < 1 || msc2020.length > 8 || new Set(msc2020).size !== msc2020.length) {
+      fail("entry.classification.msc2020 must contain one to eight unique codes");
+    }
+    if (arxiv.some((code) => !ARXIV_RE.test(code))) {
+      fail("entry.classification.arxiv contains a malformed code");
+    }
+    if (msc2020.some((code) => !MSC2020_RE.test(code))) {
+      fail("entry.classification.msc2020 contains a malformed code");
+    }
   }
 
   const submission = object(entry.submission, "entry.submission");

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -316,8 +316,16 @@ export function validateEntry(entry, summary) {
     if (!['allowlisted', 'palomar-indexed'].includes(dependency.provenance)) {
       fail(`entry.trust.challenge_dependencies[${position}].provenance is unsupported`);
     }
-    if (dependency.palomar_id !== undefined && !ID_RE.test(dependency.palomar_id)) {
-      fail(`entry.trust.challenge_dependencies[${position}].palomar_id is malformed`);
+    if (dependency.provenance === "palomar-indexed") {
+      if (!ID_RE.test(dependency.palomar_id || "")) {
+        fail(
+          `entry.trust.challenge_dependencies[${position}].palomar_id is required and malformed`,
+        );
+      }
+    } else if (dependency.palomar_id !== undefined) {
+      fail(
+        `entry.trust.challenge_dependencies[${position}].palomar_id is forbidden for allowlisted provenance`,
+      );
     }
   }
   stringArray(trust.reasons, "entry.trust.reasons");

--- a/assets/style.css
+++ b/assets/style.css
@@ -214,6 +214,47 @@ button:focus-visible {
   gap: .35rem;
 }
 
+.category-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .45rem .75rem;
+  font: .8rem var(--sans);
+}
+
+.category-filters label {
+  display: flex;
+  align-items: center;
+  gap: .3rem;
+}
+
+.category-filters select {
+  min-height: 2rem;
+  max-width: 12rem;
+  border: 1px solid #777;
+  border-radius: 0;
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.category-tokens,
+.category-feed-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .3rem .5rem;
+}
+
+.category-tokens code {
+  white-space: nowrap;
+}
+
+.category-feed-item {
+  white-space: nowrap;
+}
+
+.unclassified {
+  color: var(--faint);
+}
+
 .filter {
   min-height: 2rem;
   padding: .25rem .5rem;

--- a/entry.html
+++ b/entry.html
@@ -7,6 +7,7 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; frame-src 'self' https://kim-em.github.io; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Registry entry — Palomar</title>
     <link rel="stylesheet" href="assets/style.css">
+    <link rel="alternate" type="application/rss+xml" title="Palomar accepted results" href="https://kim-em.github.io/PalomarDatabase/feed.xml">
   </head>
   <body data-page="entry">
     <a class="skip-link" href="#entry">Skip to entry</a>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <title>Palomar — Lean-verified mathematics</title>
     <link rel="stylesheet" href="assets/style.css">
     <link rel="manifest" href="site.webmanifest">
+    <link rel="alternate" type="application/rss+xml" title="Palomar accepted results" href="https://kim-em.github.io/PalomarDatabase/feed.xml">
   </head>
   <body data-page="index">
     <a class="skip-link" href="#registry">Skip to registry</a>
@@ -48,6 +49,14 @@
             <span>Search:</span>
             <input id="search" type="search" placeholder="title, author, theorem, or repository" autocomplete="off">
           </label>
+          <div class="category-filters" aria-label="Subject filters">
+            <label>arXiv:
+              <select id="arxiv-filter"><option value="">All subjects</option></select>
+            </label>
+            <label>MSC:
+              <select id="msc-filter"><option value="">All codes</option></select>
+            </label>
+          </div>
           <div class="filters" role="group" aria-label="Statement dependency filters">
             <span>Show:</span>
             <button class="filter active" type="button" data-trust="all" aria-pressed="true">All</button>
@@ -75,6 +84,7 @@
         <span> — a registry of Lean-verified results</span>
       </div>
       <div class="footer-links">
+        <a href="https://kim-em.github.io/PalomarDatabase/feed.xml">RSS</a>
         <a href="https://github.com/kim-em/PalomarPolicy">Policy</a>
         <a href="https://github.com/kim-em/PalomarDatabase">Data</a>
         <a href="https://github.com/leanprover/comparator">Comparator</a>

--- a/render.html
+++ b/render.html
@@ -5,11 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#ffffff">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; frame-src 'self' https://kim-em.github.io; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
-    <title>Formatted statement — Palomar</title>
+    <title>Named compared declarations — Palomar</title>
     <link rel="stylesheet" href="assets/style.css">
   </head>
   <body data-page="render">
-    <a class="skip-link" href="#render">Skip to formatted statement</a>
+    <a class="skip-link" href="#render">Skip to named compared declarations</a>
     <header class="site-header">
       <a class="brand" href="./">Palomar</a>
       <nav aria-label="Main navigation"><a href="./">Registry</a><a href="about.html">About</a><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit</a></nav>

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -16,8 +16,13 @@ HASH = "a" * 64
 
 def entry(identifier: str, lines: int, version: int = 1) -> dict:
     issue = int(identifier.rsplit("-", 1)[-1])
+    classification = (
+        {"arxiv": ["math.CO", "cs.DM"], "msc2020": ["05C10"]}
+        if identifier.endswith("000123")
+        else {"arxiv": ["math.NT"], "msc2020": ["11N13"]}
+    )
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "id": identifier,
         "accepted_at": "2026-07-29",
         "version": version,
@@ -25,6 +30,7 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
         "title": f"Fixture {identifier} version {version}",
         "abstract": "A browser confinement fixture.",
         "authors": [{"name": "Example"}],
+        "classification": classification,
         "submission": {
             "repository": "kim-em/PalomarSubmission",
             "issue": issue,

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -113,6 +113,23 @@ ENTRIES = {
         "PALOMAR-2026-07-29-000124", 101, 1
     ),
 }
+ENTRIES[("PALOMAR-2026-07-29-000124", 1)]["trust"].update(
+    {
+        "level": "qualified",
+        "challenge_dependencies": [
+            {
+                "repository": "leanprover-community/mathlib4",
+                "provenance": "allowlisted",
+            },
+            {
+                "repository": "example/dependency",
+                "provenance": "palomar-indexed",
+                "palomar_id": "PALOMAR-2026-07-29-000123",
+            },
+        ],
+        "reasons": ["An exact indexed source snapshot determines the statement."],
+    }
+)
 
 
 class Handler(SimpleHTTPRequestHandler):

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -249,7 +249,7 @@ test("indexed dependency provenance requires a Palomar ID", () => {
 });
 
 test("entry schema, acceptance state, verdict, and selected identity fail closed", () => {
-  assert.throws(() => validateEntry(entry({ schema_version: 3 }), summary()), /unsupported entry/);
+  assert.throws(() => validateEntry(entry({ schema_version: 4 }), summary()), /unsupported entry/);
   assert.throws(() => validateEntry(entry({ status: "draft" }), summary()), /not accepted/);
   const rejected = entry();
   rejected.review.verdict = "reject";
@@ -262,6 +262,24 @@ test("entry schema, acceptance state, verdict, and selected identity fail closed
     () => validateEntry(entry(), summary({ version: 2, path: "entries/PALOMAR-2026-07-29-000123-v2.json" })),
     /identity does not match/,
   );
+});
+
+test("schema v3 classification is required and strictly shaped", () => {
+  const valid = entry({
+    schema_version: 3,
+    classification: { arxiv: ["math.CO", "cs.DM"], msc2020: ["05C10"] },
+  });
+  assert.doesNotThrow(() => validateEntry(valid, summary()));
+
+  assert.throws(
+    () => validateEntry(entry({ schema_version: 3 }), summary()),
+    /classification must be an object/,
+  );
+  const malformed = entry({
+    schema_version: 3,
+    classification: { arxiv: ["math.NOT REAL"], msc2020: ["05C10"] },
+  });
+  assert.throws(() => validateEntry(malformed, summary()), /malformed code/);
 });
 
 test("record evidence links must agree with their canonical values", () => {

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -222,6 +222,32 @@ test("a canonical accepted record validates", () => {
   );
 });
 
+test("indexed dependency provenance requires a Palomar ID", () => {
+  const trust = {
+    ...entry().trust,
+    level: "qualified",
+    challenge_dependencies: [
+      { repository: "example/dependency", provenance: "palomar-indexed" },
+    ],
+  };
+  assert.throws(
+    () => validateEntry(entry({ trust }), summary()),
+    /palomar_id is required/,
+  );
+
+  trust.challenge_dependencies = [
+    {
+      repository: "example/dependency",
+      provenance: "allowlisted",
+      palomar_id: "PALOMAR-2026-07-29-000123",
+    },
+  ];
+  assert.throws(
+    () => validateEntry(entry({ trust }), summary()),
+    /palomar_id is forbidden/,
+  );
+});
+
 test("entry schema, acceptance state, verdict, and selected identity fail closed", () => {
   assert.throws(() => validateEntry(entry({ schema_version: 3 }), summary()), /unsupported entry/);
   assert.throws(() => validateEntry(entry({ status: "draft" }), summary()), /not accepted/);

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -28,8 +28,29 @@ test("landing cards show the acceptance date and dated identifier", async ({ pag
     "2 versions of PALOMAR-2026-07-29-000123",
   );
   await expect(page.locator(".entry-card")).toHaveCount(2);
+  await expect(first.locator(".card-subjects")).toContainText("math.CO");
+  await expect(first.locator(".card-subjects")).toContainText("MSC 05C10");
   await expect(page.getByRole("button", { name: "Mathlib only" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Additional libraries" })).toBeVisible();
+});
+
+test("registry entries can be filtered by arXiv and MSC classifications", async ({ page }) => {
+  await page.goto(`/?database=${database}`);
+  await page.locator("#arxiv-filter").selectOption("math.NT");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(1);
+  await expect(page.locator(".entry-card:visible")).toContainText("000124");
+
+  await page.locator("#arxiv-filter").selectOption("");
+  await page.locator("#msc-filter").selectOption("05C10");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(1);
+  await expect(page.locator(".entry-card:visible")).toContainText("000123");
+});
+
+test("classification filters apply from a deep link", async ({ page }) => {
+  await page.goto(`/?database=${database}&arxiv=math.NT`);
+  await expect(page.locator("#arxiv-filter")).toHaveValue("math.NT");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(1);
+  await expect(page.locator(".entry-card:visible")).toContainText("000124");
 });
 
 test("an unversioned entry link resolves to the current immutable URL", async ({ page }) => {
@@ -40,6 +61,12 @@ test("an unversioned entry link resolves to the current immutable URL", async ({
   await expect(page.locator(".entry-heading h1")).toHaveText(
     "Fixture PALOMAR-2026-07-29-000123 version 2",
   );
+  await expect(page.locator(".entry-heading .trust-badge")).toHaveText(
+    "Statement dependencies: Mathlib only",
+  );
+  await expect(page.locator(".entry-classification")).toContainText("math.CO");
+  await expect(page.locator(".entry-classification")).toContainText("05C10");
+  await expect(page.locator(".entry-classification").getByRole("link", { name: "RSS" })).toHaveCount(3);
   await expect(page).toHaveURL(/entry\.html\?id=PALOMAR-2026-07-29-000123&version=2&database=/);
   await expect(page).toHaveURL(/#version-history$/);
   await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
@@ -194,6 +221,16 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   await expect(page.getByRole("link", { name: "Solution.lean" }).first()).toHaveAttribute(
     "href",
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/Solution.lean`,
+  );
+  const sourceFiles = page.locator('.entry-evidence .detail-row a[href*="/blob/"]');
+  await expect(sourceFiles).toHaveText([
+    "Challenge.lean",
+    "Solution.lean",
+    "formalization.yaml",
+  ]);
+  await expect(sourceFiles.nth(2)).toHaveAttribute(
+    "href",
+    `https://github.com/example/challenge/blob/${"1".repeat(40)}/formalization.yaml`,
   );
   await expect(page.locator(".entry-solution .token-list code")).toHaveText("ExampleDependency");
   await page.locator(".solution-dependencies summary").click();

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -134,10 +134,22 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   );
 
   const source = page.locator(".challenge-presentation .challenge-source");
+  await expect(
+    page.getByRole("heading", { name: "Named compared declarations" }),
+  ).toBeVisible();
+  await expect(page.locator(".challenge-surface-disclosure")).toContainText(
+    "only the declarations named in comparator.json",
+  );
+  await expect(page.locator(".challenge-surface-disclosure")).toContainText(
+    "complete certified and reviewed statement surface",
+  );
   await expect(source).toHaveAttribute(
     "href",
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/Challenge.lean`,
   );
+  await expect(
+    page.getByRole("link", { name: "Inspect statement dependencies" }),
+  ).toHaveAttribute("href", /#statement-dependencies$/);
   await expect(page.getByRole("link", { name: "Open formatted statement" })).toHaveCount(0);
   const iframe = page.locator(".challenge-presentation iframe");
   await expect(iframe).toHaveAttribute("sandbox", "allow-scripts");
@@ -166,10 +178,13 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   expect(box.height).toBe(672);
   await expect(page.locator(".acceptance-callout")).toContainText("Accepted");
   await expect(page.locator(".acceptance-callout")).toContainText("29 July 2026");
-  await expect(page.locator(".acceptance-callout")).toContainText("recorded proof against the recorded statement");
+  await expect(page.locator(".acceptance-callout")).toContainText("Mechanical assurance");
   await expect(page.locator(".acceptance-callout")).toContainText(
-    "Every required check passed, so Palomar accepted the submission",
+    "Editorial assurance",
   );
+  await expect(page.locator(".acceptance-callout")).toContainText("AI-mediated review");
+  await expect(page.getByRole("link", { name: "Mechanical evidence" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Editorial evidence" })).toBeVisible();
   await expect(page.getByRole("link", { name: "Solution.lean" }).first()).toHaveAttribute(
     "href",
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/Solution.lean`,

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -138,10 +138,10 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
     page.getByRole("heading", { name: "Named compared declarations" }),
   ).toBeVisible();
   await expect(page.locator(".challenge-surface-disclosure")).toContainText(
-    "only the declarations named in comparator.json",
+    "declarations named in this entry's comparator configuration",
   );
   await expect(page.locator(".challenge-surface-disclosure")).toContainText(
-    "complete certified and reviewed statement surface",
+    "statement and dependency surface for inspection",
   );
   await expect(source).toHaveAttribute(
     "href",
@@ -150,6 +150,12 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   await expect(
     page.getByRole("link", { name: "Inspect statement dependencies" }),
   ).toHaveAttribute("href", /#statement-dependencies$/);
+  await expect(
+    page.getByRole("link", { name: "View comparator configuration (comparator.json)" }),
+  ).toHaveAttribute(
+    "href",
+    `https://github.com/example/challenge/blob/${"1".repeat(40)}/comparator.json`,
+  );
   await expect(page.getByRole("link", { name: "Open formatted statement" })).toHaveCount(0);
   const iframe = page.locator(".challenge-presentation iframe");
   await expect(iframe).toHaveAttribute("sandbox", "allow-scripts");
@@ -200,6 +206,12 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
 
 test("larger Challenge falls back to the dedicated wrapper", async ({ page }) => {
   await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000124&version=1&database=${database}`);
+  await expect(page.locator("#statement-dependencies")).toContainText(
+    "leanprover-community/mathlib4 (allowlisted)",
+  );
+  await expect(page.locator("#statement-dependencies")).toContainText(
+    "example/dependency (Palomar-indexed: PALOMAR-2026-07-29-000123)",
+  );
   await expect(page.locator(".challenge-presentation iframe")).toHaveCount(0);
   await expect(page.locator(".challenge-fallback")).toBeVisible();
   await page.getByRole("link", { name: "Open formatted statement" }).click();
@@ -212,6 +224,9 @@ test("larger Challenge falls back to the dedicated wrapper", async ({ page }) =>
     "href",
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/Challenge.lean`,
   );
+  await page.getByRole("link", { name: "Inspect statement dependencies" }).click();
+  await expect(page).toHaveURL(/entry\.html\?.*#statement-dependencies$/);
+  await expect(page.locator("#statement-dependencies")).toBeInViewport();
 });
 
 test("current HTML remains compatible with cached JavaScript from the previous deployment", async ({ page }) => {


### PR DESCRIPTION
## Summary

- label renders as named compared declarations and disclose their partial nature
- link to the full pinned Challenge, comparator configuration, and statement dependencies
- distinguish mechanical Lean/Comparator assurance from AI-mediated editorial judgment
- expose allowlisted and Palomar-indexed provenance while failing closed when an indexed dependency lacks its Palomar ID
- make asynchronously rendered dependency anchors navigate correctly

## Validation

- 19 Node security/deployment tests passed
- final hosted CI passed Node and browser presentation tests
- JavaScript syntax and git diff checks passed

## Independent review

A fresh Claude Opus review identified missing indexed-ID validation, incomplete provenance fixtures, and broken async fragment navigation. All findings were fixed and covered by tests.

Refs kim-em/PalomarSubmission#12