### PR TITLE
Rework the FAQ around what acceptance asserts, and what it does not

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -158,7 +158,7 @@ function entryCard(entry, versionCount) {
   const top = el("div", "card-top");
   const identity = el("div", "card-identity");
   identity.append(
-    el("span", "entry-id", `${entry.id} · current version ${entry.version}`),
+    el("span", "entry-id", `${entry.id} v${entry.version} · current`),
     el("span", "entry-date", `Accepted ${displayDate(acceptanceDate(entry))}`),
   );
   top.append(identity, trustBadge(entry));
@@ -699,7 +699,7 @@ async function renderEntry(
   setCanonicalEntryPage(entry);
   const heading = el("header", "entry-heading");
   const top = el("div", "card-top");
-  top.append(el("span", "entry-id", `${entry.id} · version ${entry.version}`), trustBadge(entry));
+  top.append(el("span", "entry-id", `${entry.id} v${entry.version}`), trustBadge(entry));
   heading.append(top, el("h1", "", entry.title), el("p", "lede", entry.abstract));
   const byline = el("p", "byline", `By ${authorNames(entry)}`);
   heading.append(byline);
@@ -931,7 +931,7 @@ async function renderChallengePage() {
     document.title = `Named compared declarations — ${entry.title} — Palomar`;
     const heading = el("header", "entry-heading");
     heading.append(
-      el("div", "entry-id", `${entry.id} · version ${entry.version}`),
+      el("div", "entry-id", `${entry.id} v${entry.version}`),
       el("h1", "", entry.title),
     );
     const challenge = await challengePresentation(entry, renderBase, { forceFrame: true });

--- a/assets/style.css
+++ b/assets/style.css
@@ -413,12 +413,14 @@ footer {
 
 /* These two lists carry full paragraphs rather than short phrases. */
 .faq .assertions,
-.faq .not-list {
+.faq .not-list,
+.faq .checkers {
   margin-top: 1rem;
 }
 
 .faq .assertions li + li,
-.faq .not-list li + li {
+.faq .not-list li + li,
+.faq .checkers li + li {
   margin-top: .9rem;
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -422,8 +422,14 @@ footer {
   margin-top: .9rem;
 }
 
-.faq li > ul {
+.faq li > ul,
+.faq li > ol {
   margin-top: .35rem;
+}
+
+/* Distinguish the nested editorial-floor questions from the checks above. */
+.faq .assertions li > ol {
+  list-style-type: lower-alpha;
 }
 
 .process,

--- a/assets/style.css
+++ b/assets/style.css
@@ -411,6 +411,17 @@ footer {
   margin-top: .35rem;
 }
 
+/* These two lists carry full paragraphs rather than short phrases. */
+.faq .assertions,
+.faq .not-list {
+  margin-top: 1rem;
+}
+
+.faq .assertions li + li,
+.faq .not-list li + li {
+  margin-top: .9rem;
+}
+
 .faq li > ul {
   margin-top: .35rem;
 }

--- a/faq.html
+++ b/faq.html
@@ -57,7 +57,8 @@
         <h2>What does acceptance by Palomar mean?</h2>
         <p>
           In order for a repository version to be accepted into the Palomar
-          registry, four checks must pass:
+          registry, four checks must pass. One is performed by Lean’s kernel,
+          two by a language model, and one by a human moderator.
         </p>
         <ol class="assertions">
           <li>
@@ -91,17 +92,22 @@
             <strong>(Disclosure)</strong> The submission’s
             <code>formalization.yaml</code> states the project’s authorship,
             sources, automation methods, limitations, and review status
-            explicitly, rather than leaving them to be inferred. The editorial
-            review assesses whether that account is clear and adequately
+            explicitly, rather than leaving them to be inferred. The same
+            language model assesses whether that account is clear and adequately
             sourced.
           </li>
           <li>
-            <strong>(Moderator approval)</strong> A Palomar moderator inspects
-            the review report before it is published and approves the entry
+            <strong>(Moderator approval)</strong> A human Palomar moderator
+            inspects the review report before it is published and approves the entry
             before it appears on the site. That approval confirms the process ran
             correctly, but is not an expert reading of the mathematics.
           </li>
         </ol>
+        <p>
+          The passes the language model runs, the prompts it is given, and the
+          report it must produce are published in
+          <a href="https://github.com/kim-em/PalomarPolicy">PalomarPolicy</a>.
+        </p>
         <p>
           Acceptance records that these checks passed. It asserts nothing beyond
           them.
@@ -257,6 +263,21 @@
           describes both, along with further checkers collected in the
           <a href="https://arena.lean-lang.org/">Lean Kernel Arena</a>.
         </p>
+        <p>
+          In addition to independently checking that the formal proof proves the
+          formal statement, readers are also encouraged to compare the formal
+          statement against the informal statement, and in particular to consider
+          whether the definitions the statement relies on capture their intended
+          informal meaning, for instance by handling degenerate cases correctly.
+        </p>
+        <p>
+          To assist with such comparisons, Palomar caps the size of the formal
+          statement at 1,000 lines and 100 KiB, with imports restricted to an
+          approved set of libraries, and the language model audits those
+          definitions as part of the approval process. Each registry entry
+          displays the compared declarations, with their types available on
+          hover, and links the exact statement file at the exact commit.
+        </p>
       </section>
 
       <section id="getting-ready">
@@ -276,7 +297,7 @@
         <p>The repository root must contain:</p>
         <ul>
           <li><code>lean-toolchain</code>, pinned to a supported Lean release or release candidate;</li>
-          <li><code>lakefile.toml</code> and, preferably, a committed <code>lake-manifest.json</code>;</li>
+          <li><code>lakefile.toml</code> and a committed <code>lake-manifest.json</code> (required in practice: without it, anything importing Mathlib will fail to build);</li>
           <li><code>Challenge.lean</code>, containing the small, readable statement a mathematician should audit;</li>
           <li><code>Solution.lean</code>, connecting that statement to the completed proof;</li>
           <li><code>comparator.json</code>, naming every theorem and definition Comparator should compare; and</li>
@@ -295,11 +316,22 @@
         </p>
         <p>
           Keep <code>Challenge.lean</code> short and mathematically ordinary.
-          Its transitive imports must come from Lean core, Mathlib, Tau Ceti, or
-          a project already indexed by Palomar. A Palomar-indexed dependency is
-          accepted but displayed with a prominent warning because it enlarges
-          the statement’s trust surface. Dependencies used only by the solution
-          may be arbitrary pinned Git dependencies. Local/path dependencies and
+          1,000 lines and 100 KiB are hard limits; 300 lines and 32 KiB is the
+          surface we would rather review. Its transitive imports must resolve to
+          Lean core, Mathlib, or Tau Ceti. Importing Tau Ceti is accepted, and
+          records a wider statement dependency surface on the entry.
+        </p>
+        <p>
+          Imports from projects already indexed by Palomar are <strong>not</strong>
+          accepted in the current protocol. An earlier entry certifies one theorem
+          in a repository, not the rest of that repository’s definitions, and
+          until Palomar can reconstruct that earlier statement surface
+          independently it will not treat it as vocabulary a new statement may be
+          written in.
+        </p>
+        <p>
+          Dependencies used only by <code>Solution.lean</code> may be arbitrary
+          pinned Git dependencies. Local/path dependencies and
           <code>lakefile.lean</code> are not accepted by the current prototype.
         </p>
 

--- a/faq.html
+++ b/faq.html
@@ -412,7 +412,9 @@
           <a href="https://icarm.math.brown.edu/">ICARM</a>. The initial
           Scientific Advisory Board is Kim Morrison, Nestor Guillen, Terence Tao, Akshay
           Venkatesh, Jeremy Avigad, Bryna Kra, Ravi Vakil, Jaume de Dios, and
-          Matthew Ballard. The board, maintainer team, and project governance are expected to change as
+          Matthew Ballard. The board sets policy and standards; it does not
+          review, approve, or endorse individual submissions. The board,
+          maintainer team, and project governance are expected to change as
           the project develops. Kim Morrison is the initial point of contact.
           Questions and proposals are welcome in the
           <a href="https://leanprover.zulipchat.com/#narrow/channel/621638-Palomar">Palomar channel on the Lean Zulip</a>.

--- a/faq.html
+++ b/faq.html
@@ -387,17 +387,20 @@
           following the moderator’s instructions on the issue.
         </p>
         <p>
-          Palomar does not have an appeals or reconsideration process. After a
-          rejection, a materially revised project may be submitted as a new
-          submission after the cooldown period. The cooldown mechanism has not
-          yet been implemented; until it is, follow the moderator’s instructions
-          on the rejected issue.
+          Acceptance is not the final step. An accepted submission appears in the
+          registry once the corresponding database pull request is merged. The
+          issue is then labelled <code>status:published</code>, given a comment
+          linking its registry entry, and closed.
         </p>
         <p>
-          For accepted work, publication is complete when the corresponding
-          database pull request is merged and the result appears in the
-          registry. Corrections become new versions; earlier accepted snapshots
-          remain part of the public record.
+          Corrections are published as new versions of the same Palomar ID, and
+          every earlier version remains resolvable. A Palomar ID on its own
+          resolves to the newest version of that record, and a later version may
+          change the theorem, source, authors, or subject radically. For a stable
+          citation, name the version (e.g., PALOMAR-2026-07-29-000001 v1 instead
+          of PALOMAR-2026-07-29-000001). The entry page URL always names the
+          version you are viewing, so copying it from the address bar gives a
+          citable link.
         </p>
       </section>
 

--- a/faq.html
+++ b/faq.html
@@ -271,9 +271,10 @@
         </p>
         <p>
           To assist with such comparisons, Palomar caps the size of the formal
-          statement at 1,000 lines and 100 KiB, with imports restricted to an
-          approved set of libraries, and the language model audits those
-          definitions as part of the approval process. Each registry entry
+          statement at 1,000 lines and 100 KiB. Imports are restricted to Lean
+          core, pinned allowlisted libraries, and exact source snapshots from
+          accepted Palomar record versions; the language model audits the
+          definitions actually reached from those sources. Each registry entry
           displays the compared declarations, with their types available on
           hover, and links the exact statement file at the exact commit.
         </p>
@@ -282,16 +283,24 @@
       <section id="getting-ready">
         <h2>Getting ready to submit</h2>
         <p>
-          Start with a public GitHub repository and choose the exact commit you
-          want Palomar to review. The commit must be identified by its full
-          40-character SHA. Palomar checks that immutable snapshot; it does not
-          follow a branch or tag as it changes.
+          Start with a public GitHub repository and choose the exact
+          <a href="https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/about-commits">commit</a>
+          you want Palomar to review. The commit must be identified by its full
+          40-character SHA (the unique hash Git assigns to it). Palomar checks
+          that immutable snapshot; it does not follow a branch or tag as it
+          changes.
         </p>
         <p>
           The <a href="https://github.com/kim-em/PalomarTemplate">Palomar starter repository</a>
           provides this layout, pinned dependencies, documentation generation,
           CI checks for Lean and Comparator, and a documented
           <code>formalization.yaml</code> starting point.
+        </p>
+        <p>
+          For a complete public example, see the
+          <a href="https://github.com/kim-em/erdos-unit-distance-comparator">source repository</a>
+          for Palomar’s
+          <a href="https://kim-em.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000001&amp;version=2">first registered result</a>.
         </p>
         <p>The repository root must contain:</p>
         <ul>
@@ -316,17 +325,21 @@
         <p>
           Keep <code>Challenge.lean</code> short and mathematically ordinary.
           1,000 lines and 100 KiB are hard limits; 300 lines and 32 KiB is the
-          surface we would rather review. Its transitive imports must resolve to
-          Lean core, Mathlib, or Tau Ceti. Importing Tau Ceti is accepted, and
-          records a wider statement dependency surface on the entry.
+          surface we would rather review. Its transitive imports must resolve
+          to Lean core; the pinned, allowlisted Mathlib or Tau Ceti closure; or
+          an exact source snapshot represented by a specific accepted Palomar
+          record version. Importing Tau Ceti or an indexed Palomar source is
+          accepted and records a wider statement dependency surface on the
+          entry.
         </p>
         <p>
-          Imports from projects already indexed by Palomar are <strong>not</strong>
-          accepted in the current protocol. An earlier entry certifies one theorem
-          in a repository, not the rest of that repository’s definitions, and
-          until Palomar can reconstruct that earlier statement surface
-          independently it will not treat it as vocabulary a new statement may be
-          written in.
+          For an indexed import, Palomar independently checks out the recorded
+          repository and commit, verifies every imported source file, and
+          compiles the reached source directly with trusted Lean. This makes the
+          imported statement surface fixed and reviewable; it does not certify
+          every definition in that repository or promote the project to
+          Mathlib-level trust. The resulting entry is therefore marked as having
+          qualified statement dependencies.
         </p>
         <p>
           Dependencies used only by <code>Solution.lean</code> may be arbitrary
@@ -337,13 +350,16 @@
         <h3>What belongs in <code>formalization.yaml</code>?</h3>
         <p>
           At minimum, include the project name, authors, and license; one or two
-          arXiv classifications and one to eight MSC 2020 classifications; at
-          least one identifiable source; the automation methods used (including
-          <code>manual</code>, when appropriate); and the review status. For
-          editorial review, also give a plain-language account of every compared
-          theorem, precise bibliographic references, what is original or
-          adapted, the role of AI and human review, and any fidelity gaps, extra
-          assumptions, or scope limitations. Follow the
+          classifications from the
+          <a href="https://arxiv.org/category_taxonomy">arXiv category taxonomy</a>
+          and one to eight codes from
+          <a href="https://msc2020.org/">MSC2020</a>; at least one identifiable
+          source; the automation methods used (including <code>manual</code>,
+          when appropriate); and the review status. For editorial review, also
+          give a plain-language account of every compared theorem, precise
+          bibliographic references, what is original or adapted, the role of AI
+          and human review, and any fidelity gaps, extra assumptions, or scope
+          limitations. Follow the
           <a href="https://github.com/mathlib-initiative/formalization.yaml">formalization.yaml standard</a>
           and Palomar’s
           <a href="https://github.com/kim-em/PalomarPolicy/blob/main/CONTRIBUTING.md">submission policy</a>.

--- a/faq.html
+++ b/faq.html
@@ -34,10 +34,34 @@
           that was checked, its dependencies, the result of the proof check, and
           the findings of a documented editorial review.
         </p>
-        <p>Acceptance of a repository version by Palomar asserts two things:</p>
+      </section>
+
+      <section id="why-now">
+        <h2>Why do we need this today?</h2>
+        <p>
+          Formalized mathematics is growing quickly, but much of it remains
+          scattered across repositories, announcements, and private links. A
+          theorem that cannot be found, searched, cited, or inspected is much
+          less useful than it could be. Palomar gives worthwhile formalizations
+          a durable, indexable record organized around the mathematical result,
+          not just the repository that happens to contain it.
+        </p>
+        <p>
+          Greater output—especially AI-assisted output—also makes a clear
+          minimum standard more important. What Palomar checks, and what it does
+          not, is set out below.
+        </p>
+      </section>
+
+      <section id="what-acceptance-means">
+        <h2>What does acceptance by Palomar mean?</h2>
+        <p>
+          In order for a repository version to be accepted into the Palomar
+          registry, four checks must pass:
+        </p>
         <ol class="assertions">
           <li>
-            <strong>(Mechanical check)</strong> Lean’s kernel verified that the
+            <strong>(Mechanical check)</strong> Lean’s kernel verifies that the
             recorded formal proof proves the recorded formal statement using a
             specified version of
             <a href="https://github.com/leanprover-community/mathlib4">Mathlib</a>,
@@ -45,22 +69,42 @@
             <code>Quot.sound</code>, and <code>Classical.choice</code>. This
             verification is performed using the
             <a href="https://github.com/leanprover/comparator">Comparator</a>
-            tool.
+            tool, which holds the advertised statement apart from its proof, so
+            that a proof cannot quietly weaken the statement it claims to
+            establish.
           </li>
-          <li>
-            <strong>(Non-mechanical check)</strong> A language model judged that
+          <li id="editorial-floor">
+            <strong>(Non-mechanical check)</strong> A language model judges that
             the recorded formal statement (in <code>Challenge.lean</code>) is a
             fair rendering of the mathematical claim made in the recorded
             informal statement (in <code>formalization.yaml</code>), and that the
             submission clears Palomar’s
             <a href="https://github.com/kim-em/PalomarPolicy/blob/main/CONTRIBUTING.md">published minimum standard</a>.
+            That standard includes a floor on research interest, which requires
+            the model to judge both of these to be answered yes:
+            <ol>
+              <li>Could this result plausibly warrant a research paper or a serious research note?</li>
+              <li>Can a credible research area, and a research mathematician who would find the result relevant, be named?</li>
+            </ol>
+          </li>
+          <li>
+            <strong>(Disclosure)</strong> The submission’s
+            <code>formalization.yaml</code> states the project’s authorship,
+            sources, automation methods, limitations, and review status
+            explicitly, rather than leaving them to be inferred. The editorial
+            review assesses whether that account is clear and adequately
+            sourced.
+          </li>
+          <li>
+            <strong>(Moderator approval)</strong> A Palomar moderator inspects
+            the review report before it is published and approves the entry
+            before it appears on the site. That approval confirms the process ran
+            correctly, but is not an expert reading of the mathematics.
           </li>
         </ol>
         <p>
-          In addition, a Palomar moderator inspects the review report before it
-          is published and approves the entry before it appears on the site.
-          That approval confirms the process ran correctly, but is not an expert
-          reading of the mathematics.
+          Acceptance records that these checks passed. It asserts nothing beyond
+          them.
         </p>
         <p>
           The source, warnings, and full review of the repository are publicly
@@ -116,11 +160,10 @@
           </li>
           <li>
             <strong>Palomar is not a certificate of importance.</strong> Palomar
-            applies a minimum bar: a submission is rejected if the result could
-            not plausibly warrant a research note, or if no credible research
-            area and plausible interested reader can be named for it. However,
-            Palomar does not rank, grade, or otherwise assess how significant a
-            result is.
+            applies a <a href="#editorial-floor">minimum editorial floor</a> and
+            rejects submissions that fall below it. Clearing that floor says only
+            that a plausible research audience exists; Palomar does not rank,
+            grade, or otherwise assess how significant a result is.
           </li>
           <li>
             <strong>Palomar does not perform peer review.</strong> While a human
@@ -149,30 +192,6 @@
             formal proofs, such as Mathlib.
           </li>
         </ol>
-      </section>
-
-      <section id="why-now">
-        <h2>Why do we need this today?</h2>
-        <p>
-          Formalized mathematics is growing quickly, but much of it remains
-          scattered across repositories, announcements, and private links. A
-          theorem that cannot be found, searched, cited, or inspected is much
-          less useful than it could be. Palomar gives worthwhile formalizations
-          a durable, indexable record organized around the mathematical result,
-          not just the repository that happens to contain it.
-        </p>
-        <p>
-          Greater output—especially AI-assisted output—also makes a clear
-          minimum standard more important. Palomar combines three lightweight
-          checks: <a href="https://github.com/leanprover/comparator">Comparator</a>
-          separates the advertised statement from its solution and checks that
-          they really match; <code>formalization.yaml</code> makes authorship,
-          sources, automation, limitations, and review status explicit; and a
-          quick, public AI-assisted review checks statement fidelity,
-          definitions, provenance, significance, and clarity. The aim is to
-          exclude low-substance “slop,” misleading claims, and crackpot-style
-          work without pretending that this fast screen is expert peer review.
-        </p>
       </section>
 
       <section id="getting-ready">

--- a/faq.html
+++ b/faq.html
@@ -125,8 +125,9 @@
             still possible that the version of the Lean kernel, Mathlib cache,
             and other tooling used by Palomar contains bugs or exploits. In
             particular, Palomar’s certification does not completely remove the
-            need for independent verification of both the formal and informal
-            proofs.
+            need for
+            <a href="#check-it-yourself">independent verification</a> of both the
+            formal and informal proofs.
           </li>
           <li>
             <strong>Palomar does not guarantee complete alignment of the formal
@@ -192,6 +193,70 @@
             formal proofs, such as Mathlib.
           </li>
         </ol>
+      </section>
+
+      <section id="check-it-yourself">
+        <h2>How can I check this myself?</h2>
+        <p>
+          Every submission is pinned to a full 40-character commit, so the
+          artifact Palomar checked cannot drift. Every verification runs in
+          public GitHub Actions, so the complete record of what was done stays
+          visible. Each entry records the SHA-256 digests of the statement and
+          proof files, the exact Lean toolchain, and the exact Comparator,
+          <a href="https://github.com/leanprover/lean4export">lean4export</a>,
+          and Landrun revisions used, which together are enough to reproduce the
+          run from the published record. One caveat: Mathlib’s build cache is
+          fetched from a mutable store, so a later re-run may not retrieve
+          identical artifacts. Building Mathlib from source removes that
+          dependency.
+        </p>
+        <p>
+          <a href="https://github.com/leanprover/comparator">Comparator</a> does
+          not simply ask Lean’s elaborator whether the proof was accepted. It
+          compiles the statement and the proof in separate sandboxes, exports
+          both environments with <code>lean4export</code>, checks that the
+          declarations the statement depends on are identical in each, and then
+          replays the exported proof through Lean’s kernel from scratch. A proof
+          that survives that replay cannot have relied on a metaprogram
+          tampering with the elaborator’s state or misreporting its result.
+        </p>
+        <p>
+          Comparator also enforces that the compared theorems use no axioms
+          beyond those listed in the submission’s <code>comparator.json</code>.
+          Because that file is written by the submitter, Palomar separately
+          rejects any submission whose list extends beyond <code>propext</code>,
+          <code>Quot.sound</code>, and <code>Classical.choice</code>.
+        </p>
+        <p>
+          That replay uses Lean’s own kernel, so it is a second pass rather than
+          a second implementation: it guards against a proof that manipulated the
+          elaborator, not against a bug in the kernel itself. Comparator can
+          additionally run <code>nanoda</code>, described below, but Palomar’s
+          current runner does not enable it. We encourage readers who want
+          stronger assurance to run these tools themselves:
+        </p>
+        <ul class="checkers">
+          <li>
+            <strong><code>leanchecker</code></strong> replays every constant,
+            imported and local, into a fresh environment
+            (<code>lake env leanchecker --fresh <var>Module</var></code>). It
+            ships with every Lean toolchain Palomar supports, so it is already
+            present in the toolchain each entry names. Like Comparator’s replay,
+            it uses Lean’s own kernel.
+          </li>
+          <li>
+            <strong><a href="https://github.com/ammkrn/nanoda_lib">nanoda</a></strong>
+            is an independent kernel implementation written in Rust. It does not
+            share Lean’s kernel code, so it can catch a class of problem that
+            neither Comparator’s replay nor <code>leanchecker</code> can.
+          </li>
+        </ul>
+        <p>
+          The Lean reference manual’s
+          <a href="https://lean-lang.org/doc/reference/latest/ValidatingProofs/">guide to validating a Lean proof</a>
+          describes both, along with further checkers collected in the
+          <a href="https://arena.lean-lang.org/">Lean Kernel Arena</a>.
+        </p>
       </section>
 
       <section id="getting-ready">

--- a/faq.html
+++ b/faq.html
@@ -28,20 +28,127 @@
       <section id="what-is-palomar">
         <h2>What is Palomar?</h2>
         <p>
-          Palomar is a public, searchable registry of formally verified
-          mathematical results. Each entry points to an immutable version of a
-          public repository and records the exact statement checked, its
-          dependencies, its proof-verification result, and the findings of a
-          documented editorial review.
+          Palomar is a public, searchable registry of Lean formalizations whose
+          proofs have been machine-checked. Each entry points to an immutable
+          version of a public repository and records the exact formal statement
+          that was checked, its dependencies, the result of the proof check, and
+          the findings of a documented editorial review.
+        </p>
+        <p>Acceptance of a repository version by Palomar asserts two things:</p>
+        <ol class="assertions">
+          <li>
+            <strong>(Mechanical check)</strong> Lean’s kernel verified that the
+            recorded formal proof proves the recorded formal statement using a
+            specified version of
+            <a href="https://github.com/leanprover-community/mathlib4">Mathlib</a>,
+            and that it depends on no axioms beyond <code>propext</code>,
+            <code>Quot.sound</code>, and <code>Classical.choice</code>. This
+            verification is performed using the
+            <a href="https://github.com/leanprover/comparator">Comparator</a>
+            tool.
+          </li>
+          <li>
+            <strong>(Non-mechanical check)</strong> A language model judged that
+            the recorded formal statement (in <code>Challenge.lean</code>) is a
+            fair rendering of the mathematical claim made in the recorded
+            informal statement (in <code>formalization.yaml</code>), and that the
+            submission clears Palomar’s
+            <a href="https://github.com/kim-em/PalomarPolicy/blob/main/CONTRIBUTING.md">published minimum standard</a>.
+          </li>
+        </ol>
+        <p>
+          In addition, a Palomar moderator inspects the review report before it
+          is published and approves the entry before it appears on the site.
+          That approval confirms the process ran correctly, but is not an expert
+          reading of the mathematics.
         </p>
         <p>
-          Palomar is not a journal, peer review, a novelty certificate, or an
-          endorsement of the authors or their work. Acceptance means that the
-          recorded proof proves the recorded statement and that the submission
-          cleared Palomar’s published minimum standard. The source, warnings,
-          and review evidence remain available so readers can make their own
-          judgments.
+          The source, warnings, and full review of the repository are publicly
+          visible to help readers reach their own judgment on the work and
+          perform independent verification.
         </p>
+      </section>
+
+      <section id="what-palomar-is-not">
+        <h2>What Palomar is <em>not</em></h2>
+        <ol class="not-list">
+          <li>
+            <strong>Palomar’s formal certification is not absolute.</strong> As
+            described in
+            <a href="https://github.com/kim-em/PalomarSubmission/blob/main/SECURITY.md">SECURITY.md</a>,
+            Palomar makes its best efforts to formally verify the claimed
+            results in Lean in a secure, sandboxed environment. However, it is
+            still possible that the version of the Lean kernel, Mathlib cache,
+            and other tooling used by Palomar contains bugs or exploits. In
+            particular, Palomar’s certification does not completely remove the
+            need for independent verification of both the formal and informal
+            proofs.
+          </li>
+          <li>
+            <strong>Palomar does not guarantee complete alignment of the formal
+            and informal results claimed.</strong> The language model checks for
+            any obvious discrepancies between the formal and informal versions
+            of the result, and generates a detailed report of its findings.
+            However, the model may make mistakes or have an incomplete analysis.
+            This report is intended to assist the reader’s verification that the
+            formal statement correctly captures the meaning of the informal one,
+            but should not be viewed as a substitute for that verification.
+          </li>
+          <li>
+            <strong>Palomar does not verify informal proofs.</strong> Optionally,
+            Palomar can check whether an informal account of a proof is
+            consistent with the architecture of the formal proof, in that it does
+            not describe an unrelated argument or conceal a decisive assumption.
+            However, it does not re-derive or confirm the informal proof itself,
+            and it makes no claim that an informal proof is correct.
+          </li>
+          <li>
+            <strong>Palomar does not assess code quality.</strong> While the
+            formal statement file is audited for brevity and readability, formal
+            proofs that are verified by Palomar are not assessed to be human
+            readable, or to conform to any best practices for formal writing.
+          </li>
+          <li>
+            <strong>Palomar is not a certificate of novelty.</strong> Palomar
+            does not check whether the results claimed are genuinely novel
+            compared to what already exists in the published or unpublished
+            literature.
+          </li>
+          <li>
+            <strong>Palomar is not a certificate of importance.</strong> Palomar
+            applies a minimum bar: a submission is rejected if the result could
+            not plausibly warrant a research note, or if no credible research
+            area and plausible interested reader can be named for it. However,
+            Palomar does not rank, grade, or otherwise assess how significant a
+            result is.
+          </li>
+          <li>
+            <strong>Palomar does not perform peer review.</strong> While a human
+            moderator is needed to approve an addition of a repository to the
+            registry, this process does not include any expert review of the
+            content of the repository itself.
+          </li>
+          <li>
+            <strong>Palomar is not a journal.</strong> Registration of a
+            repository on this site should not in any way be viewed as a
+            “publication” of that repository.
+          </li>
+          <li>
+            <strong>Palomar is not a green light for journal
+            submission.</strong> Mathematical journals require their submissions
+            adhere to professional standards of exposition, accuracy, and
+            citation, and be of genuine interest to their readers. None of these
+            criteria are directly addressed by this registry, which checks
+            informal descriptions of results only for fidelity to their formal
+            counterparts.
+          </li>
+          <li>
+            <strong>Palomar is not a green light for formalized library
+            submission.</strong> Palomar verification should not be viewed as an
+            endorsement of the code for the purposes of uploading to a library of
+            formal proofs, such as Mathlib.
+          </li>
+        </ol>
       </section>
 
       <section id="why-now">

--- a/faq.html
+++ b/faq.html
@@ -109,8 +109,7 @@
           <a href="https://github.com/kim-em/PalomarPolicy">PalomarPolicy</a>.
         </p>
         <p>
-          Acceptance records that these checks passed. It asserts nothing beyond
-          them.
+          Palomar asserts nothing beyond these four checks.
         </p>
         <p>
           The source, warnings, and full review of the repository are publicly

--- a/faq.html
+++ b/faq.html
@@ -412,7 +412,7 @@
           <a href="https://icarm.math.brown.edu/">ICARM</a>. The initial
           Scientific Advisory Board is Kim Morrison, Nestor Guillen, Terence Tao, Akshay
           Venkatesh, Jeremy Avigad, Bryna Kra, Ravi Vakil, Jaume de Dios, and
-          Matthew Ballard. The board sets policy and standards; it does not
+          Matthew Ballard. The board advises on policy and standards; it does not
           review, approve, or endorse individual submissions. The board,
           maintainer team, and project governance are expected to change as
           the project develops. Kim Morrison is the initial point of contact.

--- a/faq.html
+++ b/faq.html
@@ -424,29 +424,28 @@
       <section id="other-proof-assistants">
         <h2>What about other proof assistants?</h2>
         <p>
-          We would be open to adding support for other proof assistants. Please
-          be ready to:
+          Currently, Palomar is set up to verify only proofs formalized in Lean.
+          However, we are open to expanding the registry to other proof
+          assistants. If you are interested in such an expansion, please contact
+          the maintainer team early in the
+          <a href="https://leanprover.zulipchat.com/#narrow/channel/621638-Palomar">Palomar channel on the Lean Zulip</a>.
+          We envisage that such expansions will require the following:
         </p>
         <ul>
           <li>
-            prepare pull requests that add support for the language, including:
+            pull requests adding support for the language, covering:
             <ul>
               <li>running its verification pipeline;</li>
-              <li>requiring a separation between “the statement” and “the solution”;</li>
+              <li>enforcing a separation between “the statement” and “the solution”;</li>
               <li>rendering the main result to HTML; and</li>
               <li>parsing upstream dependencies for display;</li>
             </ul>
           </li>
-          <li>work with us to make sure the implementation is secure and performant;</li>
-          <li>bring a sample of 10–100 candidate projects that could be indexed for this proof assistant;</li>
-          <li>have someone ready to join its maintainer team; and</li>
-          <li>if we are still operating on a shoestring budget, be willing to fund the additional review and CI costs for the language.</li>
+          <li>a review, carried out with us, establishing that the implementation is secure and performant;</li>
+          <li>an assessment of the resources its verification pipeline would require to run in our continuous integration;</li>
+          <li>a sample of 10–100 candidate projects that could be indexed for that proof assistant; and</li>
+          <li>someone ready to join its maintainer team.</li>
         </ul>
-        <p>
-          Please contact the maintainer team early in the
-          <a href="https://leanprover.zulipchat.com/#narrow/channel/621638-Palomar">Palomar channel on the Lean Zulip</a>
-          if you intend to pursue this.
-        </p>
       </section>
 
       <section class="cta">

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -16,7 +16,7 @@ test("landing cards show the acceptance date and dated identifier", async ({ pag
   await page.goto(`/?database=${database}`);
   const first = page.locator(".entry-card").first();
   await expect(first.locator(".entry-id")).toContainText("PALOMAR-2026-07-29-");
-  await expect(first.locator(".entry-id")).toContainText("current version 2");
+  await expect(first.locator(".entry-id")).toContainText("v2 · current");
   await expect(first.locator(".entry-date")).toHaveText("Accepted 29 July 2026");
   await expect(first.locator(".trust-badge")).toHaveText("Statement dependencies: Mathlib only");
   await expect(first.getByRole("link", { name: "2 versions" })).toHaveAttribute(


### PR DESCRIPTION
## Summary

Reworks the FAQ around the questions a skeptical reader most needs answered:

- what Palomar acceptance asserts;
- what it does not assert;
- how a reader can independently inspect and recheck an entry;
- how immutable versions should be cited;
- what the advisory board does and does not endorse; and
- how another proof-assistant community could propose support.

The FAQ now names the mechanical, editorial, disclosure, and moderator checks separately, and keeps peer review, novelty, importance, code quality, and journal-readiness outside the registry's claims.

## Protocol and documentation corrections

- Describes Palomar-indexed `Challenge.lean` imports as the implemented qualified dependency class: Palomar reconstructs the exact accepted source snapshot, verifies the imported files, and compiles the reached source directly with trusted Lean.
- Requires a committed `lake-manifest.json`.
- Includes the full `status:published` lifecycle.
- Gives stable citation guidance using an explicit Palomar version.
- Removes the former appeals/cooldown paragraph because the cooldown does not exist and appeals policy remains undecided.
- Links an explanation of Git commits and SHAs, the arXiv and MSC2020 taxonomies, the starter repository, and a complete accepted example.
- Uses `leanchecker` rather than the archived `lean4checker`.
- Distinguishes Lean-kernel replay from the independent nanoda implementation.

## Validation

- `npm test`: 20/20 passing.
- `PALOMAR_ASSET_VERSION=local npm run build`: passing.
- Local Playwright launch is unavailable because this environment lacks `libglib-2.0.so.0`; the PR workflow installs Chromium and its system dependencies and remains the authoritative browser run.

🤖 Original FAQ rewrite generated with Claude Code; protocol reconciliation and final validation completed by Codex.