### PR TITLE
Remove generic About process panel

### DIFF
--- a/about.html
+++ b/about.html
@@ -52,32 +52,6 @@
         </p>
       </section>
 
-      <section class="process" aria-labelledby="process-heading">
-        <h2 id="process-heading">From snapshot to record</h2>
-        <ol>
-          <li>
-            <span>1.</span>
-            <div><h3>Fixed source files</h3><p>Each submission points to an exact version of a public repository, so the files that Palomar checked cannot later change.</p></div>
-          </li>
-          <li>
-            <span>2.</span>
-            <div><h3>Readable statement file</h3><p><code>Challenge.lean</code> states the advertised result. Its transitive imports may come only from Lean core, pinned allowlisted libraries, or exact source snapshots represented by accepted Palomar record versions.</p></div>
-          </li>
-          <li>
-            <span>3.</span>
-            <div><h3>Independent proof check</h3><p>Lean and Comparator mechanically check that the recorded Solution proves the recorded formal Challenge under the listed axiom and dependency rules.</p></div>
-          </li>
-          <li>
-            <span>4.</span>
-            <div><h3>Documented review</h3><p>A separate AI-mediated editorial review judges whether the formal Challenge matches the written mathematical claim and examines its definitions, prior literature, significance, and clarity.</p></div>
-          </li>
-          <li>
-            <span>5.</span>
-            <div><h3>Permanent record</h3><p>An accepted result becomes an immutable, versioned JSON record. Later versions are appended rather than changing what an earlier version means.</p></div>
-          </li>
-        </ol>
-      </section>
-
       <section id="what-acceptance-means">
         <h2>What does acceptance by Palomar mean?</h2>
         <p>

--- a/assets/style.css
+++ b/assets/style.css
@@ -434,37 +434,11 @@ footer {
   list-style-type: lower-alpha;
 }
 
-.process,
 .meaning-grid,
 .cta {
   margin-top: 2.5rem;
   padding-top: 1.5rem;
   border-top: 1px solid var(--line);
-}
-
-.process ol {
-  margin: 1rem 0 0;
-  padding: 0;
-  list-style: none;
-}
-
-.process li {
-  display: grid;
-  grid-template-columns: 2rem 1fr;
-  padding: .9rem 0;
-  border-top: 1px dotted var(--line);
-}
-
-.process li > span {
-  font-weight: bold;
-}
-
-.process h3 {
-  margin-bottom: .2rem;
-}
-
-.process p {
-  margin-bottom: 0;
 }
 
 .meaning-grid article + article {


### PR DESCRIPTION
## Summary

- remove the “From snapshot to record” panel from About
- remove its now-unused layout rules

## Why

The numbered panel repeats information explained more precisely immediately below it, adds promotional-sounding copy, and formats poorly for the intended mathematical audience. The substantive acceptance and verification sections remain unchanged.

## Validation

- `npm test` — 20 passed
- `PALOMAR_ASSET_VERSION=local npm run build`
- `git diff --check`