### PR TITLE
Display mathematical provenance

### DIFF
--- a/about.html
+++ b/about.html
@@ -90,10 +90,10 @@
           <li>
             <strong>(Disclosure)</strong> The submission’s
             <code>formalization.yaml</code> states the project’s authorship,
-            sources, automation methods, limitations, and review status
-            explicitly, rather than leaving them to be inferred. The same
-            language model assesses whether that account is clear and adequately
-            sourced.
+            mathematical origin, any sources or prior formalizations, automation
+            methods, limitations, and review status explicitly, rather than
+            leaving them to be inferred. The same language model assesses
+            whether that account is clear and adequately supported.
           </li>
           <li>
             <strong>(Moderator approval)</strong> A human Palomar moderator
@@ -348,12 +348,14 @@
 
         <h3>What belongs in <code>formalization.yaml</code>?</h3>
         <p>
-          At minimum, include the project name, authors, and license; one or two
+          At minimum, include the project name, authors, license, and responsible
+          maintainers; say whether the result is original or source-based and
+          whether the repository is the substantive development or a thin
+          Comparator wrapper; include one or two
           classifications from the
           <a href="https://arxiv.org/category_taxonomy">arXiv category taxonomy</a>
           and one to eight codes from
-          <a href="https://msc2020.org/">MSC2020</a>; at least one identifiable
-          source; the automation methods used (including <code>manual</code>,
+          <a href="https://msc2020.org/">MSC2020</a>; the automation methods used (including <code>manual</code>,
           when appropriate); and the review status. For editorial review, also
           give a plain-language account of every compared theorem, precise
           bibliographic references, what is original or adapted, the role of AI
@@ -363,13 +365,30 @@
           and Palomar’s
           <a href="https://github.com/kim-em/PalomarPolicy/blob/main/CONTRIBUTING.md">submission policy</a>.
         </p>
+        <p>
+          A source may be a book, journal article, non-arXiv preprint, web
+          discussion, private communication, or folklore; give the most stable
+          reference available. A formalization that first presents a new result
+          may have no source at all. If sources exist, state whether the project
+          formalizes, adapts, independently proves, or merely uses each as
+          background. Record prior formalizations separately. A thin wrapper must
+          identify the substantive formalization repository at an immutable
+          commit.
+        </p>
+        <p>
+          Submit only if you are a responsible author or maintainer of the
+          substantive formalization, or have approval from one. For a thin
+          wrapper this means the people responsible for the underlying
+          formalization, not merely the wrapper repository. The submission form
+          asks which applies; a link or note documenting approval is optional.
+        </p>
       </section>
 
       <section id="how-to-submit">
         <h2>How to submit</h2>
         <ol>
           <li>Push the final snapshot to a public GitHub repository and copy its full 40-character commit SHA.</li>
-          <li><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Open the short submission form</a>. Enter the repository URL and commit SHA, confirm the required acknowledgements, and, for a correction to an existing entry, enter its Palomar ID.</li>
+          <li><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Open the short submission form</a>. Enter the repository URL and commit SHA, record whether you maintain the substantive formalization or have approval from someone who does, confirm the required acknowledgements, and, for a correction to an existing entry, enter its Palomar ID.</li>
           <li>Submit the issue and watch it for status labels and comments. The issue is the public home for verification and review.</li>
         </ol>
         <p>

--- a/assets/app.js
+++ b/assets/app.js
@@ -627,6 +627,100 @@ function classificationSection(entry, currentVersion) {
   return section;
 }
 
+function provenanceSection(entry) {
+  const provenance = entry.provenance;
+  const section = el("section", "entry-provenance");
+  const heading = el("div", "section-heading");
+  const title = el("div");
+  title.append(el("div", "eyebrow", "Provenance"), el("h2", "", "Mathematical origin"));
+  heading.append(title);
+  section.append(heading);
+
+  const details = el("dl", "details provenance-details");
+  details.append(
+    detailRow(
+      "Result origin",
+      provenance.result_origin === "original"
+        ? "Original result first presented by this formalization"
+        : "Formalization of or response to existing mathematical work",
+    ),
+    detailRow(
+      "Repository role",
+      provenance.repository_role === "thin-wrapper"
+        ? "Thin Comparator wrapper around another formalization repository"
+        : "Substantive formalization development",
+    ),
+    detailRow(
+      "Responsible maintainers",
+      provenance.responsible_maintainers.map((person) => person.name).join(", "),
+    ),
+    detailRow(
+      "Submission basis",
+      {
+        maintainer: "Submitted by a responsible author or maintainer",
+        approved: "Submitted with approval from a responsible author or maintainer",
+        "legacy-unspecified": "Not recorded by the earlier submission form",
+      }[entry.submission.authorization.relationship],
+    ),
+  );
+  if (provenance.repository_role === "thin-wrapper") {
+    const substantive = provenance.substantive_formalization;
+    details.append(
+      externalDetailRow(
+        "Substantive formalization",
+        `${substantive.repository}@${substantive.commit.slice(0, 12)}`,
+        substantive.tree_url,
+      ),
+    );
+  }
+  if (entry.submission.authorization.evidence) {
+    details.append(detailRow("Authorization evidence", entry.submission.authorization.evidence));
+  }
+  section.append(details);
+
+  if (provenance.mathematical_sources.length) {
+    section.append(el("h3", "", "Mathematical sources"));
+    const sources = el("ul", "plain-list provenance-sources");
+    for (const source of provenance.mathematical_sources) {
+      const item = el("li");
+      const label = source.authors.length
+        ? `${source.authors.map((author) => author.name).join(", ")}: ${source.title}`
+        : source.title;
+      if (source.identifier?.startsWith("https://")) {
+        item.append(externalLink(label, source.identifier));
+      } else {
+        item.append(el("span", "", label));
+      }
+      item.append(el("span", "source-relationship", ` — ${source.relationship}`));
+      if (source.identifier && !source.identifier.startsWith("https://")) {
+        item.append(el("code", "", source.identifier));
+      }
+      sources.append(item);
+    }
+    section.append(sources);
+  } else {
+    section.append(el("p", "no-sources", "No prior mathematical source is recorded."));
+  }
+
+  if (provenance.related_formalizations.length) {
+    section.append(el("h3", "", "Related formalizations"));
+    const related = el("ul", "plain-list related-formalizations");
+    for (const formalization of provenance.related_formalizations) {
+      const item = el("li");
+      if (formalization.identifier.startsWith("https://")) {
+        item.append(externalLink(formalization.identifier, formalization.identifier));
+      } else {
+        item.append(el("code", "", formalization.identifier));
+      }
+      item.append(` — ${formalization.relationship}`);
+      if (formalization.note) item.append(`: ${formalization.note}`);
+      related.append(item);
+    }
+    section.append(related);
+  }
+  return section;
+}
+
 function solutionMetadata(entry, renderMetadata) {
   const section = el("section", "entry-solution");
   const heading = el("div", "section-heading");
@@ -829,6 +923,9 @@ async function renderEntry(
   content.append(
     versionHistory(entry, versions, currentVersion),
     classificationSection(entry, currentVersion),
+  );
+  if (entry.schema_version === 4) content.append(provenanceSection(entry));
+  content.append(
     challenge.section,
     evidence,
     trust,

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -1,5 +1,5 @@
 export const INDEX_SCHEMA_VERSION = 2;
-export const ENTRY_SCHEMA_VERSIONS = new Set([2, 3]);
+export const ENTRY_SCHEMA_VERSIONS = new Set([2, 3, 4]);
 export const DEFAULT_DATABASE =
   "https://raw.githubusercontent.com/kim-em/PalomarDatabase/main/index.json";
 export const DEFAULT_RENDER_BASE = "https://kim-em.github.io/PalomarDatabase/";
@@ -255,7 +255,7 @@ export function validateEntry(entry, summary) {
   if (entry.schema_version === 2 && entry.classification !== undefined) {
     fail("entry.classification is not valid in schema version 2");
   }
-  if (entry.schema_version === 3) {
+  if (entry.schema_version >= 3) {
     const classification = object(entry.classification, "entry.classification");
     const arxiv = stringArray(classification.arxiv, "entry.classification.arxiv");
     const msc2020 = stringArray(classification.msc2020, "entry.classification.msc2020");
@@ -278,6 +278,69 @@ export function validateEntry(entry, summary) {
   integer(submission.issue, "entry.submission.issue");
   string(submission.url, "entry.submission.url");
   string(submission.submitter, "entry.submission.submitter");
+
+  if (entry.schema_version === 4) {
+    const authorization = object(submission.authorization, "entry.submission.authorization");
+    if (!["maintainer", "approved", "legacy-unspecified"].includes(authorization.relationship)) {
+      fail("entry.submission.authorization.relationship is not recognized");
+    }
+    if (authorization.evidence !== undefined) {
+      string(authorization.evidence, "entry.submission.authorization.evidence");
+    }
+
+    const provenance = object(entry.provenance, "entry.provenance");
+    if (!["original", "source-based"].includes(provenance.result_origin)) {
+      fail("entry.provenance.result_origin is not recognized");
+    }
+    if (!["substantive-development", "thin-wrapper"].includes(provenance.repository_role)) {
+      fail("entry.provenance.repository_role is not recognized");
+    }
+    const maintainers = array(
+      provenance.responsible_maintainers,
+      "entry.provenance.responsible_maintainers",
+    );
+    if (!maintainers.length) fail("entry.provenance.responsible_maintainers must not be empty");
+    for (const [position, maintainer] of maintainers.entries()) {
+      string(
+        object(maintainer, `entry.provenance.responsible_maintainers[${position}]`).name,
+        `entry.provenance.responsible_maintainers[${position}].name`,
+      );
+    }
+    const substantiveRelationships = new Set(["formalizes", "adapts", "independently-proves"]);
+    const sources = array(provenance.mathematical_sources, "entry.provenance.mathematical_sources");
+    for (const [position, sourceRecord] of sources.entries()) {
+      const item = object(sourceRecord, `entry.provenance.mathematical_sources[${position}]`);
+      string(item.title, `entry.provenance.mathematical_sources[${position}].title`);
+      array(item.authors, `entry.provenance.mathematical_sources[${position}].authors`);
+      if (![...substantiveRelationships, "background", "other"].includes(item.relationship)) {
+        fail(`entry.provenance.mathematical_sources[${position}].relationship is not recognized`);
+      }
+    }
+    if (provenance.result_origin === "source-based" &&
+        !sources.some((item) => substantiveRelationships.has(item.relationship))) {
+      fail("source-based provenance lacks a substantive mathematical source");
+    }
+    if (provenance.result_origin === "original" &&
+        sources.some((item) => substantiveRelationships.has(item.relationship))) {
+      fail("original provenance claims a substantive source relationship");
+    }
+    array(provenance.related_formalizations, "entry.provenance.related_formalizations");
+    if (provenance.repository_role === "thin-wrapper") {
+      const substantive = object(
+        provenance.substantive_formalization,
+        "entry.provenance.substantive_formalization",
+      );
+      if (!REPOSITORY_RE.test(substantive.repository) || !COMMIT_RE.test(substantive.commit)) {
+        fail("entry.provenance.substantive_formalization is malformed");
+      }
+      const repositoryUrl = `https://github.com/${substantive.repository}`;
+      if (substantive.repository_url !== repositoryUrl ||
+          substantive.tree_url !== `${repositoryUrl}/tree/${substantive.commit}`) {
+        fail("entry.provenance.substantive_formalization is not canonical");
+      }
+      safeExternalUrl(substantive.tree_url);
+    }
+  }
 
   const source = object(entry.source, "entry.source");
   string(source.repository, "entry.source.repository");

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -251,7 +251,7 @@ test("indexed dependency provenance requires a Palomar ID", () => {
 });
 
 test("entry schema, acceptance state, verdict, and selected identity fail closed", () => {
-  assert.throws(() => validateEntry(entry({ schema_version: 4 }), summary()), /unsupported entry/);
+  assert.throws(() => validateEntry(entry({ schema_version: 5 }), summary()), /unsupported entry/);
   assert.throws(() => validateEntry(entry({ status: "draft" }), summary()), /not accepted/);
   const rejected = entry();
   rejected.review.verdict = "reject";
@@ -282,6 +282,36 @@ test("schema v3 classification is required and strictly shaped", () => {
     classification: { arxiv: ["math.NOT REAL"], msc2020: ["05C10"] },
   });
   assert.throws(() => validateEntry(malformed, summary()), /malformed code/);
+});
+
+test("schema v4 requires explicit provenance and submission authorization", () => {
+  const valid = entry({
+    schema_version: 4,
+    classification: { arxiv: ["math.CO"], msc2020: ["05C10"] },
+    provenance: {
+      result_origin: "original",
+      repository_role: "substantive-development",
+      responsible_maintainers: [{ name: "Example" }],
+      mathematical_sources: [],
+      related_formalizations: [],
+    },
+  });
+  valid.submission.authorization = { relationship: "maintainer" };
+  assert.doesNotThrow(() => validateEntry(valid, summary()));
+
+  const sourceBasedWithoutSource = structuredClone(valid);
+  sourceBasedWithoutSource.provenance.result_origin = "source-based";
+  assert.throws(
+    () => validateEntry(sourceBasedWithoutSource, summary()),
+    /lacks a substantive mathematical source/,
+  );
+
+  const wrapperWithoutTarget = structuredClone(valid);
+  wrapperWithoutTarget.provenance.repository_role = "thin-wrapper";
+  assert.throws(
+    () => validateEntry(wrapperWithoutTarget, summary()),
+    /substantive_formalization must be an object/,
+  );
 });
 
 test("record evidence links must agree with their canonical values", () => {


### PR DESCRIPTION
## What changed

Accepts schema v4 records and displays result origin, repository role, responsible maintainers, authorization basis, sources, and related formalizations. Updates About with the same source-free and thin-wrapper policy.

## Why

Readers need to see what mathematical work a record formalizes and where the substantive formalization lives.

## Checks

- 21 Node tests passed
- Production site build passed