### PR TITLE
Allow searches for absent classifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ The site is static and deployed with GitHub Pages. It fetches `index.json` and
 entry records directly from the database repository at runtime, so publishing a
 database PR does not require a coordinated website deployment or a server.
 Registry cards display arXiv and MSC2020 classifications, and the toolbar can
-filter the current records by either taxonomy.
+filter the current records by either taxonomy. The classification fields suggest
+codes represented by current entries but also accept any exact code, so a deep
+link such as `?arxiv=math.AG` produces a useful empty result even before that
+classification has an entry.
 
 Local preview:
 

--- a/assets/app.js
+++ b/assets/app.js
@@ -233,28 +233,36 @@ async function renderIndex() {
     }
     let trust = "all";
     const search = document.querySelector("#search");
-    const arxiv = document.querySelector("#arxiv-filter");
-    const msc = document.querySelector("#msc-filter");
-    const fillCategories = (select, values) => {
-      if (!select) return;
+    // The fallback selectors keep new JavaScript compatible with cached HTML
+    // from the previous GitHub Pages deployment.
+    const arxiv = document.querySelector("#arxiv-query, #arxiv-filter");
+    const msc = document.querySelector("#msc-query, #msc-filter");
+    const fillCategories = (list, values) => {
+      if (!list) return;
       for (const value of [...values].sort()) {
         const option = el("option", "", value);
         option.value = value;
-        select.append(option);
+        list.append(option);
       }
     };
-    fillCategories(arxiv, new Set(entries.flatMap((entry) => classification(entry).arxiv)));
-    fillCategories(msc, new Set(entries.flatMap((entry) => classification(entry).msc2020)));
-    if (arxiv && [...arxiv.options].some((option) => option.value === params.get("arxiv"))) {
+    fillCategories(
+      document.querySelector("#arxiv-options"),
+      new Set(entries.flatMap((entry) => classification(entry).arxiv)),
+    );
+    fillCategories(
+      document.querySelector("#msc-options"),
+      new Set(entries.flatMap((entry) => classification(entry).msc2020)),
+    );
+    if (arxiv && params.has("arxiv")) {
       arxiv.value = params.get("arxiv");
     }
-    if (msc && [...msc.options].some((option) => option.value === params.get("msc"))) {
+    if (msc && params.has("msc")) {
       msc.value = params.get("msc");
     }
     const update = () => {
       const query = search.value.trim().toLowerCase();
-      const arxivValue = arxiv?.value || "";
-      const mscValue = msc?.value || "";
+      const arxivValue = arxiv?.value.trim() || "";
+      const mscValue = msc?.value.trim() || "";
       let shown = 0;
       for (const card of grid.children) {
         const visible =
@@ -266,11 +274,19 @@ async function renderIndex() {
         if (visible) shown += 1;
       }
       status.hidden = shown !== 0;
-      status.textContent = shown ? "" : "No registry entries match those filters.";
+      const classificationQuery = [
+        arxivValue && `arXiv ${arxivValue}`,
+        mscValue && `MSC2020 ${mscValue}`,
+      ].filter(Boolean);
+      status.textContent = shown
+        ? ""
+        : classificationQuery.length
+          ? `No registry entries match the current filters. Classification query: ${classificationQuery.join(", ")}.`
+          : "No registry entries match those filters.";
     };
     search.addEventListener("input", update);
-    arxiv?.addEventListener("change", update);
-    msc?.addEventListener("change", update);
+    arxiv?.addEventListener("input", update);
+    msc?.addEventListener("input", update);
     document.querySelectorAll(".filter").forEach((button) => {
       button.addEventListener("click", () => {
         trust = button.dataset.trust;

--- a/assets/app.js
+++ b/assets/app.js
@@ -26,6 +26,9 @@ const FEED_BASE = "https://kim-em.github.io/PalomarDatabase/feeds/";
 const params = new URLSearchParams(window.location.search);
 const PALOMAR_ID = /^PALOMAR-\d{4}-\d{2}-\d{2}-\d{6}$/;
 const VERSION_PARAMETER = /^[1-9][0-9]*$/;
+const ARXIV_FILTER_RE = /^[a-z]+(?:-[a-z]+)*(?:\.[A-Za-z-]+)?$/;
+const MSC2020_FILTER_RE = /^[0-9]{2}(?:[A-Z][0-9]{2}|-[0-9]{2})$/;
+const FILTER_UPDATE_DELAY_MS = 200;
 
 function dataSource() {
   const databaseUrl = selectDatabaseUrl(window.location.href, window.location.search);
@@ -245,30 +248,43 @@ async function renderIndex() {
         list.append(option);
       }
     };
+    const arxivOptions = document.querySelector("#arxiv-options") ||
+      (arxiv?.tagName === "SELECT" ? arxiv : null);
+    const mscOptions = document.querySelector("#msc-options") ||
+      (msc?.tagName === "SELECT" ? msc : null);
     fillCategories(
-      document.querySelector("#arxiv-options"),
+      arxivOptions,
       new Set(entries.flatMap((entry) => classification(entry).arxiv)),
     );
     fillCategories(
-      document.querySelector("#msc-options"),
+      mscOptions,
       new Set(entries.flatMap((entry) => classification(entry).msc2020)),
     );
-    if (arxiv && params.has("arxiv")) {
-      arxiv.value = params.get("arxiv");
-    }
-    if (msc && params.has("msc")) {
-      msc.value = params.get("msc");
-    }
+    const applyCategoryParameter = (control, name, maximumLength) => {
+      if (!control || !params.has(name)) return;
+      const value = params.get(name).slice(0, maximumLength);
+      if (control.tagName === "SELECT" &&
+          ![...control.options].some((option) => option.value === value)) {
+        const option = el("option", "", value);
+        option.value = value;
+        control.append(option);
+      }
+      control.value = value;
+    };
+    applyCategoryParameter(arxiv, "arxiv", 32);
+    applyCategoryParameter(msc, "msc", 5);
     const update = () => {
       const query = search.value.trim().toLowerCase();
       const arxivValue = arxiv?.value.trim() || "";
       const mscValue = msc?.value.trim() || "";
+      const arxivInvalid = Boolean(arxivValue && !ARXIV_FILTER_RE.test(arxivValue));
+      const mscInvalid = Boolean(mscValue && !MSC2020_FILTER_RE.test(mscValue));
       let shown = 0;
       for (const card of grid.children) {
         const visible =
           (trust === "all" || card.dataset.trust === trust) &&
-          (!arxivValue || card.dataset.arxiv.split(" ").includes(arxivValue)) &&
-          (!mscValue || card.dataset.msc.split(" ").includes(mscValue)) &&
+          (!arxivValue || (!arxivInvalid && card.dataset.arxiv.split(" ").includes(arxivValue))) &&
+          (!mscValue || (!mscInvalid && card.dataset.msc.split(" ").includes(mscValue))) &&
           (!query || card.dataset.search.includes(query));
         card.hidden = !visible;
         if (visible) shown += 1;
@@ -278,15 +294,29 @@ async function renderIndex() {
         arxivValue && `arXiv ${arxivValue}`,
         mscValue && `MSC2020 ${mscValue}`,
       ].filter(Boolean);
+      const invalidClassifications = [
+        arxivInvalid && "arXiv",
+        mscInvalid && "MSC2020",
+      ].filter(Boolean);
       status.textContent = shown
         ? ""
-        : classificationQuery.length
+        : invalidClassifications.length
+          ? `No registry entries match the current filters. Invalid classification code format: ${invalidClassifications.join(", ")}.`
+          : classificationQuery.length
           ? `No registry entries match the current filters. Classification query: ${classificationQuery.join(", ")}.`
           : "No registry entries match those filters.";
     };
-    search.addEventListener("input", update);
-    arxiv?.addEventListener("input", update);
-    msc?.addEventListener("input", update);
+    let updateTimer;
+    const scheduleUpdate = () => {
+      window.clearTimeout(updateTimer);
+      updateTimer = window.setTimeout(update, FILTER_UPDATE_DELAY_MS);
+    };
+    search.addEventListener("input", scheduleUpdate);
+    for (const control of [arxiv, msc]) {
+      for (const eventName of ["input", "change", "search"]) {
+        control?.addEventListener(eventName, scheduleUpdate);
+      }
+    }
     document.querySelectorAll(".filter").forEach((button) => {
       button.addEventListener("click", () => {
         trust = button.dataset.trust;

--- a/assets/style.css
+++ b/assets/style.css
@@ -203,6 +203,7 @@ h3 {
 }
 
 .search input:focus-visible,
+.category-filters input:focus-visible,
 button:focus-visible {
   outline: 2px solid var(--link);
   outline-offset: 2px;
@@ -227,13 +228,16 @@ button:focus-visible {
   gap: .3rem;
 }
 
-.category-filters select {
+.category-filters input {
   min-height: 2rem;
+  width: 9rem;
   max-width: 12rem;
+  padding: .25rem .4rem;
   border: 1px solid #777;
   border-radius: 0;
   background: var(--paper);
   color: var(--ink);
+  font: .9rem var(--sans);
 }
 
 .category-tokens,

--- a/assets/style.css
+++ b/assets/style.css
@@ -231,7 +231,6 @@ button:focus-visible {
 .category-filters input {
   min-height: 2rem;
   width: 9rem;
-  max-width: 12rem;
   padding: .25rem .4rem;
   border: 1px solid #777;
   border-radius: 0;

--- a/index.html
+++ b/index.html
@@ -49,13 +49,13 @@
             <span>Search:</span>
             <input id="search" type="search" placeholder="title, author, theorem, or repository" autocomplete="off">
           </label>
-          <div class="category-filters" aria-label="Subject filters">
+          <div class="category-filters" role="group" aria-label="Subject filters">
             <label>arXiv:
-              <input id="arxiv-query" type="search" list="arxiv-options" placeholder="e.g. math.CO" autocomplete="off" spellcheck="false">
+              <input id="arxiv-query" type="search" list="arxiv-options" maxlength="32" placeholder="e.g. math.CO" autocomplete="off" spellcheck="false">
             </label>
             <datalist id="arxiv-options"></datalist>
             <label>MSC:
-              <input id="msc-query" type="search" list="msc-options" placeholder="e.g. 05C10" autocomplete="off" spellcheck="false">
+              <input id="msc-query" type="search" list="msc-options" maxlength="5" placeholder="e.g. 05C10" autocomplete="off" spellcheck="false">
             </label>
             <datalist id="msc-options"></datalist>
           </div>

--- a/index.html
+++ b/index.html
@@ -51,11 +51,13 @@
           </label>
           <div class="category-filters" aria-label="Subject filters">
             <label>arXiv:
-              <select id="arxiv-filter"><option value="">All subjects</option></select>
+              <input id="arxiv-query" type="search" list="arxiv-options" placeholder="e.g. math.CO" autocomplete="off" spellcheck="false">
             </label>
+            <datalist id="arxiv-options"></datalist>
             <label>MSC:
-              <select id="msc-filter"><option value="">All codes</option></select>
+              <input id="msc-query" type="search" list="msc-options" placeholder="e.g. 05C10" autocomplete="off" spellcheck="false">
             </label>
+            <datalist id="msc-options"></datalist>
           </div>
           <div class="filters" role="group" aria-label="Statement dependency filters">
             <span>Show:</span>
@@ -65,7 +67,7 @@
           </div>
         </div>
 
-        <div id="status" class="status">
+        <div id="status" class="status" role="status">
           Reading the Palomar database…
           <noscript>
             <br>

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -36,21 +36,41 @@ test("landing cards show the acceptance date and dated identifier", async ({ pag
 
 test("registry entries can be filtered by arXiv and MSC classifications", async ({ page }) => {
   await page.goto(`/?database=${database}`);
-  await page.locator("#arxiv-filter").selectOption("math.NT");
+  await expect(page.locator('#arxiv-options option[value="math.NT"]')).toHaveCount(1);
+  await expect(page.locator('#msc-options option[value="05C10"]')).toHaveCount(1);
+
+  await page.locator("#arxiv-query").fill("math.NT");
   await expect(page.locator(".entry-card:visible")).toHaveCount(1);
   await expect(page.locator(".entry-card:visible")).toContainText("000124");
 
-  await page.locator("#arxiv-filter").selectOption("");
-  await page.locator("#msc-filter").selectOption("05C10");
+  await page.locator("#arxiv-query").fill("");
+  await page.locator("#msc-query").fill("05C10");
   await expect(page.locator(".entry-card:visible")).toHaveCount(1);
   await expect(page.locator(".entry-card:visible")).toContainText("000123");
 });
 
 test("classification filters apply from a deep link", async ({ page }) => {
   await page.goto(`/?database=${database}&arxiv=math.NT`);
-  await expect(page.locator("#arxiv-filter")).toHaveValue("math.NT");
+  await expect(page.locator("#arxiv-query")).toHaveValue("math.NT");
   await expect(page.locator(".entry-card:visible")).toHaveCount(1);
   await expect(page.locator(".entry-card:visible")).toContainText("000124");
+});
+
+test("absent classifications produce a useful empty result", async ({ page }) => {
+  await page.goto(`/?database=${database}&arxiv=math.AG`);
+  await expect(page.locator("#arxiv-query")).toHaveValue("math.AG");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(0);
+  await expect(page.locator("#status")).toHaveText(
+    "No registry entries match the current filters. Classification query: arXiv math.AG.",
+  );
+
+  await page.locator("#arxiv-query").fill("");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(2);
+  await expect(page.locator("#status")).toBeHidden();
+
+  await page.locator("#msc-query").fill("14Q05");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(0);
+  await expect(page.locator("#status")).toContainText("Classification query: MSC2020 14Q05.");
 });
 
 test("an unversioned entry link resolves to the current immutable URL", async ({ page }) => {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -47,6 +47,10 @@ test("registry entries can be filtered by arXiv and MSC classifications", async 
   await page.locator("#msc-query").fill("05C10");
   await expect(page.locator(".entry-card:visible")).toHaveCount(1);
   await expect(page.locator(".entry-card:visible")).toContainText("000123");
+
+  await page.locator("#arxiv-query").fill("  math.CO  ");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(1);
+  await expect(page.locator(".entry-card:visible")).toContainText("000123");
 });
 
 test("classification filters apply from a deep link", async ({ page }) => {
@@ -71,6 +75,20 @@ test("absent classifications produce a useful empty result", async ({ page }) =>
   await page.locator("#msc-query").fill("14Q05");
   await expect(page.locator(".entry-card:visible")).toHaveCount(0);
   await expect(page.locator("#status")).toContainText("Classification query: MSC2020 14Q05.");
+
+  await page.locator("#arxiv-query").fill("math.AG");
+  await expect(page.locator("#status")).toContainText(
+    "Classification query: arXiv math.AG, MSC2020 14Q05.",
+  );
+});
+
+test("malformed classification parameters are bounded and identified", async ({ page }) => {
+  await page.goto(`/?database=${database}&arxiv=${encodeURIComponent("not a code".repeat(20))}`);
+  await expect(page.locator("#arxiv-query")).toHaveValue("not a codenot a codenot a codeno");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(0);
+  await expect(page.locator("#status")).toHaveText(
+    "No registry entries match the current filters. Invalid classification code format: arXiv.",
+  );
 });
 
 test("an unversioned entry link resolves to the current immutable URL", async ({ page }) => {
@@ -164,7 +182,7 @@ test("optional metric markup cannot take down the registry", async ({ page }) =>
     "",
   );
   expect(withoutProjectMetric).not.toEqual(currentIndex);
-  await page.route("http://127.0.0.1:4173/", (route) => route.fulfill({
+  await page.route(/^http:\/\/127\.0\.0\.1:4173\/(?:\?.*)?$/, (route) => route.fulfill({
     body: withoutProjectMetric,
     contentType: "text/html; charset=utf-8",
   }));
@@ -302,14 +320,23 @@ test("current HTML remains compatible with cached JavaScript from the previous d
   await expect(page.locator("#status")).not.toContainText("could not be loaded");
 });
 
-test("current JavaScript remains compatible with cached HTML from the previous deployment", async ({ page }) => {
+test("current JavaScript preserves represented deep links with cached HTML", async ({ page }) => {
   test.skip(!previousRef, "PALOMAR_PREVIOUS_REF is only set in deployment and pull-request CI");
-  await page.route("http://127.0.0.1:4173/", (route) => route.fulfill({
-    body: fileAtPreviousDeployment("index.html"),
-    contentType: "text/html; charset=utf-8",
-  }));
+  await page.route("**/*", (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (request.resourceType() === "document" && url.pathname === "/") {
+      return route.fulfill({
+        body: fileAtPreviousDeployment("index.html"),
+        contentType: "text/html; charset=utf-8",
+      });
+    }
+    return route.continue();
+  });
 
-  await page.goto(`/?database=${database}`);
-  await expect(page.locator(".entry-card")).toHaveCount(2);
+  await page.goto(`/?database=${database}&arxiv=math.NT`);
+  await expect(page.locator("#arxiv-filter")).toHaveValue("math.NT");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(1);
+  await expect(page.locator(".entry-card:visible")).toContainText("000124");
   await expect(page.locator("#status")).not.toContainText("could not be loaded");
 });


### PR DESCRIPTION
## Summary

- replace classification dropdowns with exact-code search inputs
- retain suggestions for classifications represented by current entries
- apply absent arXiv and MSC deep-link values instead of silently ignoring them
- show accessible, classification-specific empty and invalid-format states
- bound and validate classification-shaped input without requiring full taxonomy assets
- preserve represented deep links across adjacent GitHub Pages deployments

## Why

The previous dropdowns were populated only from published entries. A valid classification with no current entry could not be selected, and a deep link for that classification was silently ignored instead of producing a useful empty result.

## User impact

Users can now type any exact arXiv or MSC2020 code. Existing classifications remain suggested, while absent classifications remain visible and produce an explicit zero-result message. Malformed values are bounded and identified separately.

## Validation

- `npm test` — 21 passed
- `PALOMAR_PREVIOUS_REF=origin/main npm run test:browser` — 15 passed using Nix Chromium, including both deployment-cache compatibility directions
- `npm run build -- --version 908d0da0c76be502ec30473b750b441f7ac16265 --output .site-test-classification` — passed

## Independent review

A fresh Claude Opus review identified input hardening, live-region churn, cross-browser input events, and a cached-HTML test-routing gap. Those findings were verified and addressed in `66d75f9`. Exact case-sensitive matching and leaving the address bar unchanged remain intentional parts of this exact-code filter design.