### PR TITLE
Explain how to find a commit SHA

### DIFF
--- a/about.html
+++ b/about.html
@@ -285,9 +285,13 @@
           Start with a public GitHub repository and choose the exact
           <a href="https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/about-commits">commit</a>
           you want Palomar to review. The commit must be identified by its full
-          40-character SHA (the unique hash Git assigns to it). Palomar checks
-          that immutable snapshot; it does not follow a branch or tag as it
-          changes.
+          40-character SHA (the unique hash Git assigns to it). To find it with
+          Git, check out the version you want to submit and run
+          <code>git rev-parse HEAD</code> in the repository; copy the entire
+          40-character result. On GitHub, open the repository’s commit history,
+          select the commit you want, and use the “Copy full SHA” button next to
+          its hash. Palomar checks that immutable snapshot; it does not follow a
+          branch or tag as it changes.
         </p>
         <p>
           The <a href="https://github.com/kim-em/PalomarTemplate">Palomar starter repository</a>

--- a/about.html
+++ b/about.html
@@ -285,13 +285,21 @@
           Start with a public GitHub repository and choose the exact
           <a href="https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/about-commits">commit</a>
           you want Palomar to review. The commit must be identified by its full
-          40-character SHA (the unique hash Git assigns to it). To find it with
-          Git, check out the version you want to submit and run
-          <code>git rev-parse HEAD</code> in the repository; copy the entire
-          40-character result. On GitHub, open the repository’s commit history,
-          select the commit you want, and use the “Copy full SHA” button next to
-          its hash. Palomar checks that immutable snapshot; it does not follow a
-          branch or tag as it changes.
+          40-character SHA (the unique hash Git assigns to it).
+        </p>
+        <p>
+          If you use Git on your computer, first commit every change you want
+          included and push that commit to GitHub. Then open a terminal in the
+          repository folder, run <code>git rev-parse HEAD</code>, and copy the
+          entire 40-character result. Uncommitted changes are not included.
+        </p>
+        <p>
+          If you use the GitHub website, open the repository’s main page and
+          click the commits link above the file list. Find the commit you want,
+          then click the clipboard icon beside its shortened hash; the icon is
+          labelled “Copy the full SHA.” Palomar can fetch only commits that have
+          been pushed to the public repository. It checks that immutable
+          snapshot and does not follow a branch or tag as it changes.
         </p>
         <p>
           The <a href="https://github.com/kim-em/PalomarTemplate">Palomar starter repository</a>

--- a/about.html
+++ b/about.html
@@ -288,18 +288,17 @@
           40-character SHA (the unique hash Git assigns to it).
         </p>
         <p>
-          If you use Git on your computer, first commit every change you want
-          included and push that commit to GitHub. Then open a terminal in the
-          repository folder, run <code>git rev-parse HEAD</code>, and copy the
-          entire 40-character result. Uncommitted changes are not included.
+          Using Git, commit and push every change you want included. In a
+          terminal in the repository folder, run <code>git rev-parse HEAD</code>
+          and copy the entire 40-character result. Uncommitted changes are
+          excluded.
         </p>
         <p>
-          If you use the GitHub website, open the repository’s main page and
-          click the commits link above the file list. Find the commit you want,
-          then click the clipboard icon beside its shortened hash; the icon is
-          labelled “Copy the full SHA.” Palomar can fetch only commits that have
-          been pushed to the public repository. It checks that immutable
-          snapshot and does not follow a branch or tag as it changes.
+          Using GitHub, click the commits link above the repository’s file list.
+          Find the commit and click the clipboard icon beside its shortened hash
+          (“Copy the full SHA”). Palomar can fetch only commits pushed to the
+          public repository. It checks that immutable snapshot, not a branch or
+          tag that can change.
         </p>
         <p>
           The <a href="https://github.com/kim-em/PalomarTemplate">Palomar starter repository</a>

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -335,7 +335,7 @@ test("current JavaScript preserves represented deep links with cached HTML", asy
   });
 
   await page.goto(`/?database=${database}&arxiv=math.NT`);
-  await expect(page.locator("#arxiv-filter")).toHaveValue("math.NT");
+  await expect(page.locator("#arxiv-query, #arxiv-filter")).toHaveValue("math.NT");
   await expect(page.locator(".entry-card:visible")).toHaveCount(1);
   await expect(page.locator(".entry-card:visible")).toContainText("000124");
   await expect(page.locator("#status")).not.toContainText("could not be loaded");


### PR DESCRIPTION
## Summary

- explain how to obtain the full 40-character commit SHA from Git or GitHub
- warn that local changes must be committed and pushed before submission
- keep the instructions compact and distinguish immutable commits from moving branches or tags
- make the cached-HTML browser assertion accept both generations of the classification control

## Why

The submission guide required a full SHA but assumed readers already knew how to find one. This makes the instruction actionable for people unfamiliar with Git. The compatibility-selector adjustment fixes a deterministic CI failure introduced when PR #25 renamed the classification control.

## Validation

- `npm test` (21 tests passed)
- `git diff --check`
- hosted Playwright suite (required before merge)