### PR TITLE
Link durable verification reports

### DIFF
--- a/about.html
+++ b/about.html
@@ -204,9 +204,12 @@
         <p>
           Every submission is pinned to a full 40-character commit, so the
           artifact Palomar checked cannot drift. Every verification runs in
-          public GitHub Actions, so the complete record of what was done stays
-          visible. Each entry records the SHA-256 digests of the statement and
-          proof files, the exact Lean toolchain, and the exact Comparator,
+          public GitHub Actions. Entries published under the durable-evidence
+          schema (version 5) preserve the resulting mechanical report and
+          workflow provenance with the append-only registry record. Those
+          entries record the SHA-256 digest of the report and the exact workflow
+          revision, alongside the statement and proof digests, Lean toolchain,
+          and exact Comparator,
           <a href="https://github.com/leanprover/lean4export">lean4export</a>,
           and Landrun revisions used, which together are enough to reproduce the
           run from the published record. One caveat: Mathlib’s build cache is

--- a/assets/app.js
+++ b/assets/app.js
@@ -22,6 +22,7 @@ import {
 
 const CANONICAL_WEB_BASE = "https://kim-em.github.io/PalomarWeb/";
 const FEED_BASE = "https://kim-em.github.io/PalomarDatabase/feeds/";
+const DATABASE_SOURCE_BASE = "https://github.com/kim-em/PalomarDatabase/blob/main/";
 
 const params = new URLSearchParams(window.location.search);
 const PALOMAR_ID = /^PALOMAR-\d{4}-\d{2}-\d{2}-\d{6}$/;
@@ -613,11 +614,21 @@ function acceptanceCallout(entry) {
   check.setAttribute("aria-hidden", "true");
   const copy = el("div");
   const evidenceLinks = el("p", "certificate-evidence-links");
-  evidenceLinks.append(
-    externalLink("Mechanical evidence", entry.verification.workflow_url),
-    " · ",
-    externalLink("Editorial evidence", entry.review.report_url),
-  );
+  if (entry.schema_version >= 5) {
+    evidenceLinks.append(
+      externalLink(
+        "Archived mechanical report",
+        `${DATABASE_SOURCE_BASE}${entry.verification.evidence_path}mechanical-report.json`,
+      ),
+      " · ",
+    );
+  } else {
+    evidenceLinks.append(
+      externalLink("Mechanical evidence", entry.verification.workflow_url),
+      " · ",
+    );
+  }
+  evidenceLinks.append(externalLink("Editorial evidence", entry.review.report_url));
   copy.append(
     el("strong", "", `Accepted on ${displayDate(acceptanceDate(entry))}`),
     el(
@@ -886,6 +897,17 @@ async function renderEntry(
       entry.verification.workflow_url,
     ),
   );
+  if (entry.schema_version >= 5) {
+    details.append(
+      externalDetailRow(
+        "Durable verification report",
+        entry.verification.mechanical_report_sha256,
+        `${DATABASE_SOURCE_BASE}${entry.verification.evidence_path}mechanical-report.json`,
+      ),
+      detailRow("Verification workflow commit", entry.verification.workflow_commit),
+      detailRow("Workflow run attempt", String(entry.verification.workflow_run_attempt)),
+    );
+  }
   evidence.append(details);
 
   const trust = el("section", "entry-trust");
@@ -970,7 +992,7 @@ async function renderEntry(
     versionHistory(entry, versions, currentVersion),
     classificationSection(entry, currentVersion),
   );
-  if (entry.schema_version === 4) content.append(provenanceSection(entry));
+  if (entry.schema_version >= 4) content.append(provenanceSection(entry));
   content.append(
     challenge.section,
     evidence,

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -1,5 +1,5 @@
 export const INDEX_SCHEMA_VERSION = 2;
-export const ENTRY_SCHEMA_VERSIONS = new Set([2, 3, 4]);
+export const ENTRY_SCHEMA_VERSIONS = new Set([2, 3, 4, 5]);
 export const DEFAULT_DATABASE =
   "https://raw.githubusercontent.com/kim-em/PalomarDatabase/main/index.json";
 export const DEFAULT_RENDER_BASE = "https://kim-em.github.io/PalomarDatabase/";
@@ -279,7 +279,7 @@ export function validateEntry(entry, summary) {
   string(submission.url, "entry.submission.url");
   string(submission.submitter, "entry.submission.submitter");
 
-  if (entry.schema_version === 4) {
+  if (entry.schema_version >= 4) {
     const authorization = object(submission.authorization, "entry.submission.authorization");
     if (!["maintainer", "approved", "legacy-unspecified"].includes(authorization.relationship)) {
       fail("entry.submission.authorization.relationship is not recognized");
@@ -386,6 +386,28 @@ export function validateEntry(entry, summary) {
   commit(verification.landrun_commit, "entry.verification.landrun_commit");
   digest(verification.challenge_sha256, "entry.verification.challenge_sha256");
   digest(verification.solution_sha256, "entry.verification.solution_sha256");
+  if (entry.schema_version >= 5) {
+    commit(verification.workflow_commit, "entry.verification.workflow_commit");
+    integer(verification.workflow_run_attempt, "entry.verification.workflow_run_attempt");
+    digest(verification.evidence_tree_sha256, "entry.verification.evidence_tree_sha256");
+    digest(verification.mechanical_report_sha256, "entry.verification.mechanical_report_sha256");
+    const evidencePath = string(
+      verification.evidence_path,
+      "entry.verification.evidence_path",
+    );
+    if (!evidencePath.endsWith("/")) {
+      fail("entry.verification.evidence_path must end with a slash");
+    }
+    safeRepositoryPath(
+      evidencePath.slice(0, -1),
+      "entry.verification.evidence_path",
+    );
+    const expectedEvidencePath =
+      `evidence/${entry.id}-v${entry.version}/${verification.evidence_tree_sha256}/`;
+    if (evidencePath !== expectedEvidencePath) {
+      fail(`entry.verification.evidence_path must be ${expectedEvidencePath}`);
+    }
+  }
 
   const trust = object(entry.trust, "entry.trust");
   if (!['high', 'qualified'].includes(trust.level)) fail("entry.trust.level is unsupported");

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -22,7 +22,7 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
         else {"arxiv": ["math.NT"], "msc2020": ["11N13"]}
     )
     return {
-        "schema_version": 3,
+        "schema_version": 5,
         "id": identifier,
         "accepted_at": "2026-07-29",
         "version": version,
@@ -31,11 +31,19 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
         "abstract": "A browser confinement fixture.",
         "authors": [{"name": "Example"}],
         "classification": classification,
+        "provenance": {
+            "result_origin": "original",
+            "repository_role": "substantive-development",
+            "responsible_maintainers": [{"name": "Example"}],
+            "mathematical_sources": [],
+            "related_formalizations": [],
+        },
         "submission": {
             "repository": "kim-em/PalomarSubmission",
             "issue": issue,
             "url": f"https://github.com/kim-em/PalomarSubmission/issues/{issue}",
             "submitter": "example",
+            "authorization": {"relationship": "maintainer"},
         },
         "source": {
             "repository": "example/challenge",
@@ -68,6 +76,11 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
             "challenge_sha256": "b" * 64,
             "solution_sha256": "c" * 64,
             "verified_at": "2026-07-29T08:46:32Z",
+            "workflow_commit": "9" * 40,
+            "workflow_run_attempt": 1,
+            "evidence_path": f"evidence/{identifier}-v{version}/{HASH}/",
+            "evidence_tree_sha256": HASH,
+            "mechanical_report_sha256": "d" * 64,
         },
         "trust": {
             "level": "high",

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -251,7 +251,7 @@ test("indexed dependency provenance requires a Palomar ID", () => {
 });
 
 test("entry schema, acceptance state, verdict, and selected identity fail closed", () => {
-  assert.throws(() => validateEntry(entry({ schema_version: 5 }), summary()), /unsupported entry/);
+  assert.throws(() => validateEntry(entry({ schema_version: 6 }), summary()), /unsupported entry/);
   assert.throws(() => validateEntry(entry({ status: "draft" }), summary()), /not accepted/);
   const rejected = entry();
   rejected.review.verdict = "reject";
@@ -312,6 +312,39 @@ test("schema v4 requires explicit provenance and submission authorization", () =
     () => validateEntry(wrapperWithoutTarget, summary()),
     /substantive_formalization must be an object/,
   );
+});
+
+test("schema v5 requires content-addressed durable verification evidence", () => {
+  const evidenceTree = "c".repeat(64);
+  const valid = entry({
+    schema_version: 5,
+    classification: { arxiv: ["math.CO"], msc2020: ["05C10"] },
+    provenance: {
+      result_origin: "original",
+      repository_role: "substantive-development",
+      responsible_maintainers: [{ name: "Example" }],
+      mathematical_sources: [],
+      related_formalizations: [],
+    },
+  });
+  valid.submission.authorization = { relationship: "maintainer" };
+  Object.assign(valid.verification, {
+    workflow_commit: "8".repeat(40),
+    workflow_run_attempt: 1,
+    evidence_tree_sha256: evidenceTree,
+    mechanical_report_sha256: "d".repeat(64),
+    evidence_path: `evidence/${valid.id}-v${valid.version}/${evidenceTree}/`,
+  });
+  assert.doesNotThrow(() => validateEntry(valid, summary()));
+
+  const traversal = structuredClone(valid);
+  traversal.verification.evidence_path = "../mechanical-report.json/";
+  assert.throws(() => validateEntry(traversal, summary()), /not a safe relative path/);
+
+  const wrongAddress = structuredClone(valid);
+  wrongAddress.verification.evidence_path =
+    `evidence/${valid.id}-v${valid.version}/${"e".repeat(64)}/`;
+  assert.throws(() => validateEntry(wrongAddress, summary()), /evidence_path must be/);
 });
 
 test("record evidence links must agree with their canonical values", () => {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -254,13 +254,16 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
     "Editorial assurance",
   );
   await expect(page.locator(".acceptance-callout")).toContainText("AI-mediated review");
-  await expect(page.getByRole("link", { name: "Mechanical evidence" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Archived mechanical report" })).toBeVisible();
+  await expect(page.getByText("Verification workflow commit")).toBeVisible();
   await expect(page.getByRole("link", { name: "Editorial evidence" })).toBeVisible();
   await expect(page.getByRole("link", { name: "Solution.lean" }).first()).toHaveAttribute(
     "href",
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/Solution.lean`,
   );
-  const sourceFiles = page.locator('.entry-evidence .detail-row a[href*="/blob/"]');
+  const sourceFiles = page.locator(
+    '.entry-evidence .detail-row a[href*="github.com/example/challenge/blob/"]',
+  );
   await expect(sourceFiles).toHaveText([
     "Challenge.lean",
     "Solution.lean",


### PR DESCRIPTION
## Summary\n\n- render schema v5 durable evidence on entry pages\n- link the archived mechanical report and show normalized workflow provenance\n- correct the About page language so it no longer implies Actions logs remain available\n- narrow browser assertions so source and evidence links are distinguished\n\n## Why\n\nPublic Actions runs are useful operationally, but their logs are not permanent. The site should point to the durable accepted evidence stored in PalomarDatabase.\n\n## Rollout\n\nDepends on the PalomarDatabase schema v5 PR. Merge after Database and before publishing the first v5 entry.\n\n## Checks\n\n- 22 Node unit tests\n- 11 Playwright browser tests passed\n- 2 existing cache-compatibility browser tests skipped\n- production build