### PR TITLE
Require NanoDa verification records

### DIFF
--- a/about.html
+++ b/about.html
@@ -56,18 +56,20 @@
         <h2>What does acceptance by Palomar mean?</h2>
         <p>
           In order for a repository version to be accepted into the Palomar
-          registry, four checks must pass. One is performed by Lean’s kernel,
-          two by a language model, and one by a human moderator.
+          registry, four checks must pass. One is mechanical and requires both
+          Lean’s kernel and the independent NanoDa kernel, two are performed by
+          a language model, and one by a human moderator.
         </p>
         <ol class="assertions">
           <li>
-            <strong>(Mechanical check)</strong> Lean’s kernel verifies that the
+            <strong>(Mechanical check)</strong> Comparator verifies that the
             recorded formal proof proves the recorded formal statement using a
             specified version of
             <a href="https://github.com/leanprover-community/mathlib4">Mathlib</a>,
             and that it depends on no axioms beyond <code>propext</code>,
             <code>Quot.sound</code>, and <code>Classical.choice</code>. This
-            verification is performed using the
+            exported proof is replayed through both Lean’s kernel and the
+            independent NanoDa kernel. The comparison is performed using the
             <a href="https://github.com/leanprover/comparator">Comparator</a>
             tool, which holds the advertised statement apart from its proof, so
             that a proof cannot quietly weaken the statement it claims to

--- a/assets/app.js
+++ b/assets/app.js
@@ -623,7 +623,7 @@ function acceptanceCallout(entry) {
     el(
       "p",
       "",
-      "Mechanical assurance: Lean and Comparator checked that the recorded Solution proves the recorded formal Challenge under the listed axiom and dependency rules.",
+      "Mechanical assurance: Comparator checked that the recorded Solution proves the recorded formal Challenge under the listed axiom and dependency rules, and both Lean's kernel and NanoDa accepted the exported proof.",
     ),
     el(
       "p",
@@ -886,6 +886,7 @@ async function renderEntry(
       entry.verification.workflow_url,
     ),
   );
+  details.append(detailRow("NanoDa commit", entry.verification.nanoda_commit));
   evidence.append(details);
 
   const trust = el("section", "entry-trust");

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -384,6 +384,7 @@ export function validateEntry(entry, summary) {
   commit(verification.comparator_commit, "entry.verification.comparator_commit");
   commit(verification.lean4export_commit, "entry.verification.lean4export_commit");
   commit(verification.landrun_commit, "entry.verification.landrun_commit");
+  commit(verification.nanoda_commit, "entry.verification.nanoda_commit");
   digest(verification.challenge_sha256, "entry.verification.challenge_sha256");
   digest(verification.solution_sha256, "entry.verification.solution_sha256");
 

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -64,6 +64,7 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
             "comparator_commit": "2" * 40,
             "lean4export_commit": "3" * 40,
             "landrun_commit": "4" * 40,
+            "nanoda_commit": "9" * 40,
             "workflow_url": "https://github.com/kim-em/PalomarSubmission/actions/runs/12345",
             "challenge_sha256": "b" * 64,
             "solution_sha256": "c" * 64,

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -77,6 +77,7 @@ function entry(overrides = {}) {
       comparator_commit: "2".repeat(40),
       lean4export_commit: "3".repeat(40),
       landrun_commit: "4".repeat(40),
+      nanoda_commit: "9".repeat(40),
       verified_at: "2026-07-29T08:46:32Z",
       workflow_url: "https://github.com/kim-em/PalomarSubmission/actions/runs/12345",
       challenge_sha256: DIGEST,
@@ -348,6 +349,20 @@ test("unsafe source paths and malformed displayed digests fail closed", () => {
   const badDigest = entry();
   badDigest.verification.challenge_sha256 = "not a digest";
   assert.throws(() => validateEntry(badDigest, summary()), /challenge_sha256 is not a SHA-256/);
+
+  const badNanodaPin = entry();
+  badNanodaPin.verification.nanoda_commit = "not a commit";
+  assert.throws(
+    () => validateEntry(badNanodaPin, summary()),
+    /nanoda_commit is not a full lowercase commit/,
+  );
+
+  const missingNanodaPin = entry();
+  delete missingNanodaPin.verification.nanoda_commit;
+  assert.throws(
+    () => validateEntry(missingNanodaPin, summary()),
+    /nanoda_commit is not a full lowercase commit/,
+  );
 });
 
 test("every HTML entry point carries the restrictive CSP", async () => {


### PR DESCRIPTION
## Summary
- require every displayed database record to include a pinned NanoDa commit
- describe dual-kernel verification on the About page
- cover the requirement in browser-security fixtures and tests

## Validation
- npm test (21 tests passed)

Kept as a draft until the existing submission records are refreshed from dual-kernel runs.