### PR TITLE
Link every formalization.yaml mention

### DIFF
--- a/about.html
+++ b/about.html
@@ -77,7 +77,7 @@
             <strong>(Non-mechanical check)</strong> A language model judges that
             the recorded formal statement (in <code>Challenge.lean</code>) is a
             fair rendering of the mathematical claim made in the recorded
-            informal statement (in <code>formalization.yaml</code>), and that the
+            informal statement (in <a href="https://github.com/mathlib-initiative/formalization.yaml"><code>formalization.yaml</code></a>), and that the
             submission clears Palomar’s
             <a href="https://github.com/kim-em/PalomarPolicy/blob/main/CONTRIBUTING.md">published minimum standard</a>.
             That standard includes a floor on research interest, which requires
@@ -89,7 +89,7 @@
           </li>
           <li>
             <strong>(Disclosure)</strong> The submission’s
-            <code>formalization.yaml</code> states the project’s authorship,
+            <a href="https://github.com/mathlib-initiative/formalization.yaml"><code>formalization.yaml</code></a> states the project’s authorship,
             mathematical origin, any sources or prior formalizations, automation
             methods, limitations, and review status explicitly, rather than
             leaving them to be inferred. The same language model assesses
@@ -307,7 +307,7 @@
           The <a href="https://github.com/kim-em/PalomarTemplate">Palomar starter repository</a>
           provides this layout, pinned dependencies, documentation generation,
           CI checks for Lean and Comparator, and a documented
-          <code>formalization.yaml</code> starting point.
+          <a href="https://github.com/mathlib-initiative/formalization.yaml"><code>formalization.yaml</code></a> starting point.
         </p>
         <p>
           For a complete public example, see the
@@ -322,7 +322,7 @@
           <li><code>Challenge.lean</code>, containing the small, readable statement a mathematician should audit;</li>
           <li><code>Solution.lean</code>, connecting that statement to the completed proof;</li>
           <li><code>comparator.json</code>, naming every theorem and definition Comparator should compare; and</li>
-          <li><code>formalization.yaml</code>, describing the project, result, sources, authorship, automation, review, and known limitations.</li>
+          <li><a href="https://github.com/mathlib-initiative/formalization.yaml"><code>formalization.yaml</code></a>, describing the project, result, sources, authorship, automation, review, and known limitations.</li>
         </ul>
 
         <h3 id="comparator-requirements">What does Comparator require?</h3>
@@ -360,7 +360,7 @@
           <code>lakefile.lean</code> are not accepted by the current prototype.
         </p>
 
-        <h3 id="formalization-yaml">What belongs in <code>formalization.yaml</code>?</h3>
+        <h3 id="formalization-yaml">What belongs in <a href="https://github.com/mathlib-initiative/formalization.yaml"><code>formalization.yaml</code></a>?</h3>
         <p>
           At minimum, include the project name, authors, license, and responsible
           maintainers; say whether the result is original or source-based and

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -50,12 +50,21 @@ test("about headings expose hoverable links that copy their section URL", async 
 test("every formalization.yaml mention on the About page links to its standard", async ({ page }) => {
   await page.goto("/about.html");
   const standard = "https://github.com/mathlib-initiative/formalization.yaml";
-  const codeMentions = page.locator("main code", { hasText: /^formalization\.yaml$/ });
-  await expect(codeMentions).toHaveCount(5);
-  for (const mention of await codeMentions.all()) {
-    await expect(mention.locator("xpath=parent::a")).toHaveAttribute("href", standard);
-  }
-  await expect(page.locator(`main a[href="${standard}"]`)).toHaveCount(6);
+  const result = await page.locator("main").evaluate((main, expected) => {
+    const walker = document.createTreeWalker(main, NodeFilter.SHOW_TEXT);
+    const unlinked = [];
+    let mentions = 0;
+    for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+      const count = node.textContent.split("formalization.yaml").length - 1;
+      mentions += count;
+      if (count && node.parentElement.closest("a")?.href !== expected) {
+        unlinked.push(node.textContent.trim());
+      }
+    }
+    return { mentions, unlinked };
+  }, standard);
+  expect(result.mentions).toBeGreaterThan(0);
+  expect(result.unlinked).toEqual([]);
 });
 
 test("landing cards show the acceptance date and dated identifier", async ({ page }) => {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -47,6 +47,17 @@ test("about headings expose hoverable links that copy their section URL", async 
   );
 });
 
+test("every formalization.yaml mention on the About page links to its standard", async ({ page }) => {
+  await page.goto("/about.html");
+  const standard = "https://github.com/mathlib-initiative/formalization.yaml";
+  const codeMentions = page.locator("main code", { hasText: /^formalization\.yaml$/ });
+  await expect(codeMentions).toHaveCount(5);
+  for (const mention of await codeMentions.all()) {
+    await expect(mention.locator("xpath=parent::a")).toHaveAttribute("href", standard);
+  }
+  await expect(page.locator(`main a[href="${standard}"]`)).toHaveCount(6);
+});
+
 test("landing cards show the acceptance date and dated identifier", async ({ page }) => {
   await page.route("**/entries/PALOMAR-2026-07-29-000123-v1.json", (route) => route.abort());
   await page.goto(`/?database=${database}`);


### PR DESCRIPTION
## Summary

- link every reader-facing `formalization.yaml` mention on the About page to the upstream standard
- keep the existing dedicated standard link
- add a browser regression test covering all six links

## Why

`formalization.yaml` is not yet a widely familiar convention, so readers should be able to reach its explanation from every occurrence rather than only from the dedicated metadata section.

## Validation

- `npm test` (22 passed)
- `PALOMAR_ASSET_VERSION=test npm run build`
- Browser tests are configured in CI; the local Chromium binary could not start because this host lacks `libglib-2.0.so.0`.