### PR TITLE
Add anchor links to About sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent notes
+
+- This repository is commonly developed on NixOS. If Playwright's bundled
+  Chromium fails to launch because a shared library such as
+  `libglib-2.0.so.0` is unavailable, do not leave the browser suite unrun. Use
+  the Nixpkgs browser instead:
+
+  ```sh
+  nix shell nixpkgs#chromium -c bash -lc \
+    'export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=$(command -v chromium); npm run test:browser'
+  ```

--- a/about.html
+++ b/about.html
@@ -325,7 +325,7 @@
           <li><code>formalization.yaml</code>, describing the project, result, sources, authorship, automation, review, and known limitations.</li>
         </ul>
 
-        <h3>What does Comparator require?</h3>
+        <h3 id="comparator-requirements">What does Comparator require?</h3>
         <p>
           <code>Challenge.lean</code> states the result independently, normally
           with <code>sorry</code>; <code>Solution.lean</code> supplies the proved
@@ -360,7 +360,7 @@
           <code>lakefile.lean</code> are not accepted by the current prototype.
         </p>
 
-        <h3>What belongs in <code>formalization.yaml</code>?</h3>
+        <h3 id="formalization-yaml">What belongs in <code>formalization.yaml</code>?</h3>
         <p>
           At minimum, include the project name, authors, license, and responsible
           maintainers; say whether the result is original or source-based and
@@ -495,15 +495,17 @@
         </ul>
       </section>
 
-      <section class="cta">
+      <section id="ready-to-submit" class="cta">
         <div><h2>Ready to submit?</h2><p>The form asks for a repository and one fixed commit.</p></div>
         <a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Open the submission form</a>
       </section>
+      <span id="anchor-status" class="visually-hidden" role="status"></span>
     </main>
 
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
       <div class="footer-links"><a href="https://github.com/kim-em/PalomarPolicy">Policy</a><a href="https://github.com/kim-em/PalomarDatabase">Data</a><a href="https://github.com/kim-em/PalomarWeb">Source</a></div>
     </footer>
+    <script type="module" src="assets/about.js"></script>
   </body>
 </html>

--- a/assets/about.js
+++ b/assets/about.js
@@ -1,0 +1,99 @@
+const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
+const RESET_DELAY_MS = 1600;
+
+function linkIcon() {
+  const svg = document.createElementNS(SVG_NAMESPACE, "svg");
+  svg.setAttribute("aria-hidden", "true");
+  svg.setAttribute("viewBox", "0 0 16 16");
+  svg.setAttribute("width", "16");
+  svg.setAttribute("height", "16");
+
+  const path = document.createElementNS(SVG_NAMESPACE, "path");
+  path.setAttribute(
+    "d",
+    "M7.775 3.275a.75.75 0 0 0 1.06 1.06l1.25-1.25a2 2 0 1 1 2.83 2.83l-2.5 2.5a2 2 0 0 1-2.83 0 .75.75 0 0 0-1.06 1.06 3.5 3.5 0 0 0 4.95 0l2.5-2.5a3.5 3.5 0 0 0-4.95-4.95l-1.25 1.25Zm.45 9.45a.75.75 0 0 0-1.06-1.06l-1.25 1.25a2 2 0 1 1-2.83-2.83l2.5-2.5a2 2 0 0 1 2.83 0 .75.75 0 0 0 1.06-1.06 3.5 3.5 0 0 0-4.95 0l-2.5 2.5a3.5 3.5 0 0 0 4.95 4.95l1.25-1.25Z",
+  );
+  svg.append(path);
+  return svg;
+}
+
+function fallbackCopy(text) {
+  const previousFocus = document.activeElement;
+  const input = document.createElement("textarea");
+  input.value = text;
+  input.className = "clipboard-fallback";
+  document.body.append(input);
+  input.select();
+  input.setSelectionRange(0, text.length);
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    input.remove();
+    previousFocus?.focus();
+  }
+}
+
+async function copyText(text) {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // The fallback supports browsers that expose but deny the Clipboard API.
+    }
+  }
+  return fallbackCopy(text);
+}
+
+function anchorTarget(heading) {
+  if (heading.id) return heading.id;
+  return heading.closest("section[id]")?.id;
+}
+
+const status = document.querySelector("#anchor-status");
+
+function announce(message) {
+  status.textContent = "";
+  window.requestAnimationFrame(() => {
+    status.textContent = message;
+  });
+}
+
+for (const heading of document.querySelectorAll("main.about h2, main.about h3")) {
+  const target = anchorTarget(heading);
+  if (!target) continue;
+
+  const label = heading.textContent.replace(/\s+/g, " ").trim();
+  const anchor = document.createElement("a");
+  anchor.className = "heading-anchor";
+  anchor.href = `#${encodeURIComponent(target)}`;
+  anchor.setAttribute("aria-label", `Copy link to ${label}`);
+  anchor.title = "Copy link to this section";
+  anchor.append(linkIcon());
+  heading.classList.add("anchored-heading");
+  heading.append(anchor);
+
+  let resetTimer;
+  anchor.addEventListener("click", async () => {
+    const copied = await copyText(anchor.href);
+    window.clearTimeout(resetTimer);
+    if (!copied) {
+      anchor.classList.remove("copied");
+      anchor.title = "Could not copy link";
+      announce(`Could not copy link to ${label}`);
+      resetTimer = window.setTimeout(() => {
+        anchor.title = "Copy link to this section";
+      }, RESET_DELAY_MS);
+      return;
+    }
+    anchor.classList.add("copied");
+    anchor.title = "Copied!";
+    announce(`Copied link to ${label}`);
+    resetTimer = window.setTimeout(() => {
+      anchor.classList.remove("copied");
+      anchor.title = "Copy link to this section";
+    }, RESET_DELAY_MS);
+  });
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -410,6 +410,73 @@ footer {
   margin-bottom: .35rem;
 }
 
+.faq .anchored-heading {
+  width: fit-content;
+}
+
+.heading-anchor {
+  display: inline-flex;
+  margin-left: .4rem;
+  color: var(--muted);
+  opacity: 0;
+  text-decoration: none;
+  vertical-align: -.1em;
+  transition: opacity .12s ease-in-out;
+}
+
+.heading-anchor svg {
+  fill: currentColor;
+}
+
+.heading-anchor:visited {
+  color: var(--muted);
+}
+
+.faq h2:hover .heading-anchor,
+.faq h3:hover .heading-anchor,
+.heading-anchor:focus,
+.heading-anchor:focus-visible {
+  opacity: 1;
+}
+
+.heading-anchor:hover,
+.heading-anchor:focus-visible {
+  color: var(--link);
+}
+
+.heading-anchor.copied {
+  color: #176f2c;
+  opacity: 1;
+}
+
+.visually-hidden {
+  position: fixed;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.clipboard-fallback {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  border: 0;
+  opacity: 0;
+}
+
+@media (hover: none) {
+  .heading-anchor {
+    opacity: 1;
+  }
+}
+
 .faq li + li {
   margin-top: .35rem;
 }

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 const root = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 export const htmlFiles = ["404.html", "about.html", "entry.html", "index.html", "render.html"];
 const publicFiles = [...htmlFiles, "site.webmanifest"];
-const assetFiles = ["app.js", "rendering.js", "security.mjs", "style.css"];
+const assetFiles = ["about.js", "app.js", "rendering.js", "security.mjs", "style.css"];
 
 function options(args) {
   const result = {
@@ -51,6 +51,7 @@ export async function buildSite({ output, version }) {
     const source = await readFile(target, "utf8");
     const versioned = source
       .replaceAll('href="assets/style.css"', `href="assets/style.css?v=${version}"`)
+      .replaceAll('src="assets/about.js"', `src="assets/about.js?v=${version}"`)
       .replaceAll('src="assets/app.js"', `src="assets/app.js?v=${version}"`);
     await writeFile(target, versioned);
   }

--- a/tests/build-site.test.js
+++ b/tests/build-site.test.js
@@ -19,6 +19,8 @@ test("deployment build versions coupled browser assets", async () => {
     assert.match(index, /assets\/style\.css\?v=0123456789abcdef/);
     assert.match(index, /assets\/app\.js\?v=0123456789abcdef/);
     assert.match(about, /assets\/style\.css\?v=0123456789abcdef/);
+    assert.match(about, /assets\/about\.js\?v=0123456789abcdef/);
+    await readFile(path.join(destination, "assets", "about.js"), "utf8");
     assert.match(app, /\.\/rendering\.js\?v=0123456789abcdef/);
     assert.match(app, /\.\/security\.mjs\?v=0123456789abcdef/);
     await readFile(path.join(destination, "assets", "security.mjs"), "utf8");

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -11,6 +11,42 @@ function fileAtPreviousDeployment(path) {
   return execFileSync("git", ["show", `${previousRef}:${path}`], { encoding: "utf8" });
 }
 
+test("about headings expose hoverable links that copy their section URL", async ({ context, page }) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await page.goto("/about.html");
+
+  const sectionHeading = page.locator("#what-is-palomar h2");
+  const sectionAnchor = sectionHeading.getByRole("link", { name: "Copy link to What is Palomar?" });
+  await expect(sectionAnchor).toHaveCSS("opacity", "0");
+  await sectionAnchor.focus();
+  await expect(sectionAnchor).toHaveCSS("opacity", "1");
+  await page.locator("body").click({ position: { x: 0, y: 0 } });
+  await expect(sectionAnchor).toHaveCSS("opacity", "0");
+  await sectionHeading.hover();
+  await expect(sectionAnchor).toHaveCSS("opacity", "1");
+
+  await sectionAnchor.click();
+  await expect(page).toHaveURL(/about\.html#what-is-palomar$/);
+  await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toMatch(
+    /about\.html#what-is-palomar$/,
+  );
+  await expect(page.getByRole("status")).toHaveText("Copied link to What is Palomar?");
+  await expect(sectionAnchor).toHaveClass(/copied/);
+  await expect(sectionAnchor.locator("path")).toHaveCSS("fill", "rgb(23, 111, 44)");
+
+  const headings = page.locator("main.about h2, main.about h3");
+  await expect(page.locator("main.about .heading-anchor")).toHaveCount(await headings.count());
+
+  await expect(page.locator("#formalization-yaml .heading-anchor")).toHaveAttribute(
+    "href",
+    "#formalization-yaml",
+  );
+  await expect(page.locator("#ready-to-submit .heading-anchor")).toHaveAttribute(
+    "href",
+    "#ready-to-submit",
+  );
+});
+
 test("landing cards show the acceptance date and dated identifier", async ({ page }) => {
   await page.route("**/entries/PALOMAR-2026-07-29-000123-v1.json", (route) => route.abort());
   await page.goto(`/?database=${database}`);


### PR DESCRIPTION
## What changed

- add stable permalink icons to every About page section and subsection
- copy the full section URL on activation, with visible and screen-reader feedback
- support hover, keyboard focus, touch devices, and a focus-preserving clipboard fallback
- version the new browser asset in deployment builds
- document the NixOS Chromium command for running Playwright reliably

## Why

Long About pages need durable deep links that readers can copy and share directly, using the familiar GitHub heading-link interaction.

## Validation

- `npm test` — 22 passed
- `nix shell nixpkgs#chromium -c bash -lc 'export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=$(command -v chromium); npm run test:browser'` — 14 passed, 2 conditional skips
- independent second-opinion review completed; validated findings were addressed before publishing
