### PR TITLE
Display repository licence evidence

### DIFF
--- a/about.html
+++ b/about.html
@@ -56,18 +56,20 @@
         <h2>What does acceptance by Palomar mean?</h2>
         <p>
           In order for a repository version to be accepted into the Palomar
-          registry, four checks must pass. One is performed by Lean’s kernel,
-          two by a language model, and one by a human moderator.
+          registry, four checks must pass. One is mechanical and requires both
+          Lean’s kernel and the independent NanoDa kernel, two are performed by
+          a language model, and one by a human moderator.
         </p>
         <ol class="assertions">
           <li>
-            <strong>(Mechanical check)</strong> Lean’s kernel verifies that the
+            <strong>(Mechanical check)</strong> Comparator verifies that the
             recorded formal proof proves the recorded formal statement using a
             specified version of
             <a href="https://github.com/leanprover-community/mathlib4">Mathlib</a>,
             and that it depends on no axioms beyond <code>propext</code>,
             <code>Quot.sound</code>, and <code>Classical.choice</code>. This
-            verification is performed using the
+            exported proof is replayed through both Lean’s kernel and the
+            independent NanoDa kernel. The comparison is performed using the
             <a href="https://github.com/leanprover/comparator">Comparator</a>
             tool, which holds the advertised statement apart from its proof, so
             that a proof cannot quietly weaken the statement it claims to

--- a/about.html
+++ b/about.html
@@ -119,6 +119,16 @@
         </p>
       </section>
 
+      <section id="licences">
+        <h2>What does the licence check cover?</h2>
+        <p>
+          Palomar records the root licence file, SPDX identifier, and checksum
+          for the submitted repository at its pinned commit. This is not legal
+          or ownership verification: cited papers, reused formalizations, and
+          dependencies retain their own licences.
+        </p>
+      </section>
+
       <section id="what-palomar-is-not">
         <h2>What Palomar is <em>not</em></h2>
         <ol class="not-list">

--- a/assets/app.js
+++ b/assets/app.js
@@ -634,7 +634,7 @@ function acceptanceCallout(entry) {
     el(
       "p",
       "",
-      "Mechanical assurance: Lean and Comparator checked that the recorded Solution proves the recorded formal Challenge under the listed axiom and dependency rules.",
+      "Mechanical assurance: Comparator checked that the recorded Solution proves the recorded formal Challenge under the listed axiom and dependency rules, and both Lean's kernel and NanoDa accepted the exported proof.",
     ),
     el(
       "p",
@@ -897,6 +897,7 @@ async function renderEntry(
       entry.verification.workflow_url,
     ),
   );
+  details.append(detailRow("NanoDa commit", entry.verification.nanoda_commit));
   if (entry.schema_version >= 5) {
     details.append(
       externalDetailRow(

--- a/assets/app.js
+++ b/assets/app.js
@@ -897,7 +897,9 @@ async function renderEntry(
       entry.verification.workflow_url,
     ),
   );
-  details.append(detailRow("NanoDa commit", entry.verification.nanoda_commit));
+  if (entry.schema_version >= 4) {
+    details.append(detailRow("NanoDa commit", entry.verification.nanoda_commit));
+  }
   if (entry.schema_version >= 5) {
     details.append(
       externalDetailRow(
@@ -907,9 +909,26 @@ async function renderEntry(
       ),
       detailRow("Verification workflow commit", entry.verification.workflow_commit),
       detailRow("Workflow run attempt", String(entry.verification.workflow_run_attempt)),
+      externalDetailRow(
+        "Repository licence file",
+        entry.source.license.path,
+        pinnedSourceFileUrl(entry, entry.source.license.path),
+      ),
+      detailRow("Declared repository licence", entry.source.license.declared_identifier),
+      detailRow("Detected SPDX licence", entry.source.license.detected_identifier),
+      detailRow("Licence file SHA-256", entry.source.license.sha256),
     );
   }
   evidence.append(details);
+  if (entry.schema_version >= 5) {
+    evidence.append(
+      el(
+        "p",
+        "licence-boundary",
+        "This licence evidence covers the submitted repository snapshot only. Cited papers, reused formalizations, and dependencies retain their own licences.",
+      ),
+    );
+  }
 
   const trust = el("section", "entry-trust");
   trust.id = "statement-dependencies";

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -13,6 +13,7 @@ const POSITIVE_INTEGER_RE = /^[1-9][0-9]*$/;
 const DATE_RE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
 const ARXIV_RE = /^[a-z]+(?:-[a-z]+)*(?:\.[A-Za-z-]+)?$/;
 const MSC2020_RE = /^[0-9]{2}(?:[A-Z][0-9]{2}|-[0-9]{2})$/;
+const LICENSE_PATH_RE = /^(?:licen[cs]e|copying|unlicense|ofl)(?:\.(?:md|markdown|txt))?$/i;
 
 function fail(message) {
   throw new Error(`invalid registry data: ${message}`);
@@ -347,6 +348,25 @@ export function validateEntry(entry, summary) {
   string(source.repository_url, "entry.source.repository_url");
   string(source.commit, "entry.source.commit");
   string(source.tree_url, "entry.source.tree_url");
+  if (entry.schema_version >= 5) {
+    const license = object(source.license, "entry.source.license");
+    const licensePath = string(license.path, "entry.source.license.path");
+    if (!LICENSE_PATH_RE.test(licensePath)) {
+      fail("entry.source.license.path is not a conventional root licence filename");
+    }
+    digest(license.sha256, "entry.source.license.sha256");
+    const declared = string(
+      license.declared_identifier,
+      "entry.source.license.declared_identifier",
+    );
+    const detected = string(
+      license.detected_identifier,
+      "entry.source.license.detected_identifier",
+    );
+    if (declared !== detected) {
+      fail("entry.source.license declared and detected identifiers disagree");
+    }
+  }
 
   const formalization = object(entry.formalization, "entry.formalization");
   safeRepositoryPath(formalization.challenge_path, "entry.formalization.challenge_path");
@@ -384,7 +404,9 @@ export function validateEntry(entry, summary) {
   commit(verification.comparator_commit, "entry.verification.comparator_commit");
   commit(verification.lean4export_commit, "entry.verification.lean4export_commit");
   commit(verification.landrun_commit, "entry.verification.landrun_commit");
-  commit(verification.nanoda_commit, "entry.verification.nanoda_commit");
+  if (entry.schema_version >= 4) {
+    commit(verification.nanoda_commit, "entry.verification.nanoda_commit");
+  }
   digest(verification.challenge_sha256, "entry.verification.challenge_sha256");
   digest(verification.solution_sha256, "entry.verification.solution_sha256");
   if (entry.schema_version >= 5) {

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -384,6 +384,7 @@ export function validateEntry(entry, summary) {
   commit(verification.comparator_commit, "entry.verification.comparator_commit");
   commit(verification.lean4export_commit, "entry.verification.lean4export_commit");
   commit(verification.landrun_commit, "entry.verification.landrun_commit");
+  commit(verification.nanoda_commit, "entry.verification.nanoda_commit");
   digest(verification.challenge_sha256, "entry.verification.challenge_sha256");
   digest(verification.solution_sha256, "entry.verification.solution_sha256");
   if (entry.schema_version >= 5) {

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -72,6 +72,7 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
             "comparator_commit": "2" * 40,
             "lean4export_commit": "3" * 40,
             "landrun_commit": "4" * 40,
+            "nanoda_commit": "9" * 40,
             "workflow_url": "https://github.com/kim-em/PalomarSubmission/actions/runs/12345",
             "challenge_sha256": "b" * 64,
             "solution_sha256": "c" * 64,

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -50,6 +50,12 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
             "repository_url": "https://github.com/example/challenge",
             "commit": "1" * 40,
             "tree_url": f"https://github.com/example/challenge/tree/{'1' * 40}",
+            "license": {
+                "path": "LICENSE.md",
+                "sha256": "d" * 64,
+                "declared_identifier": "Apache-2.0",
+                "detected_identifier": "Apache-2.0",
+            },
         },
         "formalization": {
             "challenge_path": "Challenge.lean",
@@ -150,8 +156,6 @@ ENTRIES[("PALOMAR-2026-07-29-000124", 1)]["trust"].update(
         "reasons": ["An exact indexed source snapshot determines the statement."],
     }
 )
-
-
 class Handler(SimpleHTTPRequestHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=str(ROOT), **kwargs)

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -77,6 +77,7 @@ function entry(overrides = {}) {
       comparator_commit: "2".repeat(40),
       lean4export_commit: "3".repeat(40),
       landrun_commit: "4".repeat(40),
+      nanoda_commit: "9".repeat(40),
       verified_at: "2026-07-29T08:46:32Z",
       workflow_url: "https://github.com/kim-em/PalomarSubmission/actions/runs/12345",
       challenge_sha256: DIGEST,
@@ -381,6 +382,20 @@ test("unsafe source paths and malformed displayed digests fail closed", () => {
   const badDigest = entry();
   badDigest.verification.challenge_sha256 = "not a digest";
   assert.throws(() => validateEntry(badDigest, summary()), /challenge_sha256 is not a SHA-256/);
+
+  const badNanodaPin = entry();
+  badNanodaPin.verification.nanoda_commit = "not a commit";
+  assert.throws(
+    () => validateEntry(badNanodaPin, summary()),
+    /nanoda_commit is not a full lowercase commit/,
+  );
+
+  const missingNanodaPin = entry();
+  delete missingNanodaPin.verification.nanoda_commit;
+  assert.throws(
+    () => validateEntry(missingNanodaPin, summary()),
+    /nanoda_commit is not a full lowercase commit/,
+  );
 });
 
 test("every HTML entry point carries the restrictive CSP", async () => {

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -77,7 +77,6 @@ function entry(overrides = {}) {
       comparator_commit: "2".repeat(40),
       lean4export_commit: "3".repeat(40),
       landrun_commit: "4".repeat(40),
-      nanoda_commit: "9".repeat(40),
       verified_at: "2026-07-29T08:46:32Z",
       workflow_url: "https://github.com/kim-em/PalomarSubmission/actions/runs/12345",
       challenge_sha256: DIGEST,
@@ -298,6 +297,7 @@ test("schema v4 requires explicit provenance and submission authorization", () =
     },
   });
   valid.submission.authorization = { relationship: "maintainer" };
+  valid.verification.nanoda_commit = "9".repeat(40);
   assert.doesNotThrow(() => validateEntry(valid, summary()));
 
   const sourceBasedWithoutSource = structuredClone(valid);
@@ -313,6 +313,7 @@ test("schema v4 requires explicit provenance and submission authorization", () =
     () => validateEntry(wrapperWithoutTarget, summary()),
     /substantive_formalization must be an object/,
   );
+
 });
 
 test("schema v5 requires content-addressed durable verification evidence", () => {
@@ -329,6 +330,13 @@ test("schema v5 requires content-addressed durable verification evidence", () =>
     },
   });
   valid.submission.authorization = { relationship: "maintainer" };
+  valid.verification.nanoda_commit = "9".repeat(40);
+  valid.source.license = {
+    path: "LICENSE",
+    sha256: DIGEST,
+    declared_identifier: "Apache-2.0",
+    detected_identifier: "Apache-2.0",
+  };
   Object.assign(valid.verification, {
     workflow_commit: "8".repeat(40),
     workflow_run_attempt: 1,
@@ -337,6 +345,18 @@ test("schema v5 requires content-addressed durable verification evidence", () =>
     evidence_path: `evidence/${valid.id}-v${valid.version}/${evidenceTree}/`,
   });
   assert.doesNotThrow(() => validateEntry(valid, summary()));
+
+  const disagreement = structuredClone(valid);
+  disagreement.source.license.detected_identifier = "MIT";
+  assert.throws(() => validateEntry(disagreement, summary()), /identifiers disagree/);
+
+  const nestedLicense = structuredClone(valid);
+  nestedLicense.source.license.path = "licenses/LICENSE";
+  assert.throws(() => validateEntry(nestedLicense, summary()), /conventional root/);
+
+  const badLicenseDigest = structuredClone(valid);
+  badLicenseDigest.source.license.sha256 = "not a digest";
+  assert.throws(() => validateEntry(badLicenseDigest, summary()), /not a SHA-256/);
 
   const traversal = structuredClone(valid);
   traversal.verification.evidence_path = "../mechanical-report.json/";
@@ -384,13 +404,23 @@ test("unsafe source paths and malformed displayed digests fail closed", () => {
   assert.throws(() => validateEntry(badDigest, summary()), /challenge_sha256 is not a SHA-256/);
 
   const badNanodaPin = entry();
+  badNanodaPin.schema_version = 4;
+  badNanodaPin.classification = { arxiv: ["math.CO"], msc2020: ["05C10"] };
+  badNanodaPin.provenance = {
+    result_origin: "original",
+    repository_role: "substantive-development",
+    responsible_maintainers: [{ name: "Example" }],
+    mathematical_sources: [],
+    related_formalizations: [],
+  };
+  badNanodaPin.submission.authorization = { relationship: "maintainer" };
   badNanodaPin.verification.nanoda_commit = "not a commit";
   assert.throws(
     () => validateEntry(badNanodaPin, summary()),
     /nanoda_commit is not a full lowercase commit/,
   );
 
-  const missingNanodaPin = entry();
+  const missingNanodaPin = structuredClone(badNanodaPin);
   delete missingNanodaPin.verification.nanoda_commit;
   assert.throws(
     () => validateEntry(missingNanodaPin, summary()),
@@ -407,4 +437,10 @@ test("every HTML entry point carries the restrictive CSP", async () => {
     assert.match(html, /frame-src 'self' https:\/\/kim-em\.github\.io/);
     assert.match(html, /object-src 'none'/);
   }
+});
+
+test("About states the repository licence boundary", async () => {
+  const about = await readFile(new URL("../about.html", import.meta.url), "utf8");
+  assert.match(about, /root licence file, SPDX identifier, and checksum/);
+  assert.match(about, /reused formalizations, and\s+dependencies retain their own licences/);
 });

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -216,6 +216,23 @@ test("a single current version has no supersession treatment", async ({ page }) 
   await expect(page.locator("#version-history li")).toHaveCount(1);
 });
 
+test("schema v5 entries display repository licence evidence and its boundary", async ({ page }) => {
+  await page.goto(
+    `/entry.html?id=PALOMAR-2026-07-29-000124&version=1&database=${database}`,
+  );
+
+  const evidence = page.locator(".entry-evidence");
+  await expect(evidence).toContainText("Repository licence file");
+  await expect(evidence.getByRole("link", { name: "LICENSE.md" })).toHaveAttribute(
+    "href",
+    `https://github.com/example/challenge/blob/${"1".repeat(40)}/LICENSE.md`,
+  );
+  await expect(evidence).toContainText("Declared repository licence");
+  await expect(evidence).toContainText("Detected SPDX licence");
+  await expect(evidence).toContainText("Apache-2.0");
+  await expect(evidence).toContainText("Cited papers, reused formalizations, and dependencies retain their own licences");
+});
+
 test("entry version parameters use canonical positive-integer spelling", async ({ page }) => {
   await page.goto(
     `/entry.html?id=PALOMAR-2026-07-29-000123&version=2.0&database=${database}`,
@@ -324,6 +341,7 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
     "Challenge.lean",
     "Solution.lean",
     "formalization.yaml",
+    "LICENSE.md",
   ]);
   await expect(sourceFiles.nth(2)).toHaveAttribute(
     "href",


### PR DESCRIPTION
## What changed

- retain the pending NanoDa record validation from the superseded draft
- validate schema-v5 repository licence evidence
- display the pinned licence file, SHA-256, declared identifier, and detected SPDX identifier
- add a concise licence-boundary explanation to About and entry evidence

## Why

Readers should be able to inspect the licence evidence preserved by the registry without mistaking it for licensing of cited or reused work.

## Validation

- `npm test` — 23 passed
- Playwright licence/display checks and the affected source-link flow passed
- JavaScript and Python syntax checks

Part of the coordinated repository-licence rollout; supersedes the older NanoDa-only draft PR.
