### PR TITLE
Require NanoDa for every displayed record

### DIFF
--- a/about.html
+++ b/about.html
@@ -234,10 +234,12 @@
           not simply ask Lean’s elaborator whether the proof was accepted. It
           compiles the statement and the proof in separate sandboxes, exports
           both environments with <code>lean4export</code>, checks that the
-          declarations the statement depends on are identical in each, and then
-          replays the exported proof through Lean’s kernel from scratch. A proof
-          that survives that replay cannot have relied on a metaprogram
-          tampering with the elaborator’s state or misreporting its result.
+          declarations the statement depends on are identical in each. Palomar
+          then requires the exported proof to be accepted from scratch by both
+          Lean’s kernel and <code>nanoda</code>, an independent kernel
+          implementation. A proof that survives those checks cannot have relied
+          on a metaprogram tampering with the elaborator’s state or misreporting
+          its result.
         </p>
         <p>
           Comparator also enforces that the compared theorems use no axioms
@@ -247,12 +249,12 @@
           <code>Quot.sound</code>, and <code>Classical.choice</code>.
         </p>
         <p>
-          That replay uses Lean’s own kernel, so it is a second pass rather than
-          a second implementation: it guards against a proof that manipulated the
-          elaborator, not against a bug in the kernel itself. Comparator can
-          additionally run <code>nanoda</code>, described below, but Palomar’s
-          current runner does not enable it. We encourage readers who want
-          stronger assurance to run these tools themselves:
+          Lean’s replay is a second pass rather than a second implementation: it
+          guards against a proof that manipulated the elaborator, not against a
+          bug in Lean’s kernel itself. Palomar therefore always enables
+          <code>nanoda</code> as a genuinely independent check and publishes the
+          exact NanoDa commit with every registry entry. We encourage readers to
+          reproduce either check themselves:
         </p>
         <ul class="checkers">
           <li>

--- a/assets/app.js
+++ b/assets/app.js
@@ -897,9 +897,7 @@ async function renderEntry(
       entry.verification.workflow_url,
     ),
   );
-  if (entry.schema_version >= 4) {
-    details.append(detailRow("NanoDa commit", entry.verification.nanoda_commit));
-  }
+  details.append(detailRow("NanoDa commit", entry.verification.nanoda_commit));
   if (entry.schema_version >= 5) {
     details.append(
       externalDetailRow(

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -404,9 +404,7 @@ export function validateEntry(entry, summary) {
   commit(verification.comparator_commit, "entry.verification.comparator_commit");
   commit(verification.lean4export_commit, "entry.verification.lean4export_commit");
   commit(verification.landrun_commit, "entry.verification.landrun_commit");
-  if (entry.schema_version >= 4) {
-    commit(verification.nanoda_commit, "entry.verification.nanoda_commit");
-  }
+  commit(verification.nanoda_commit, "entry.verification.nanoda_commit");
   digest(verification.challenge_sha256, "entry.verification.challenge_sha256");
   digest(verification.solution_sha256, "entry.verification.solution_sha256");
   if (entry.schema_version >= 5) {

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -77,6 +77,7 @@ function entry(overrides = {}) {
       comparator_commit: "2".repeat(40),
       lean4export_commit: "3".repeat(40),
       landrun_commit: "4".repeat(40),
+      nanoda_commit: "9".repeat(40),
       verified_at: "2026-07-29T08:46:32Z",
       workflow_url: "https://github.com/kim-em/PalomarSubmission/actions/runs/12345",
       challenge_sha256: DIGEST,
@@ -404,16 +405,6 @@ test("unsafe source paths and malformed displayed digests fail closed", () => {
   assert.throws(() => validateEntry(badDigest, summary()), /challenge_sha256 is not a SHA-256/);
 
   const badNanodaPin = entry();
-  badNanodaPin.schema_version = 4;
-  badNanodaPin.classification = { arxiv: ["math.CO"], msc2020: ["05C10"] };
-  badNanodaPin.provenance = {
-    result_origin: "original",
-    repository_role: "substantive-development",
-    responsible_maintainers: [{ name: "Example" }],
-    mathematical_sources: [],
-    related_formalizations: [],
-  };
-  badNanodaPin.submission.authorization = { relationship: "maintainer" };
   badNanodaPin.verification.nanoda_commit = "not a commit";
   assert.throws(
     () => validateEntry(badNanodaPin, summary()),


### PR DESCRIPTION
Makes the site fail closed unless every registry record includes a pinned NanoDa commit, regardless of its historical schema version. The entry page now always displays that pin, and the About page accurately states that Palomar requires both Lean and NanoDa acceptance.\n\nTested: `npm test` (23 passed).