### PR TITLE
Display nested Lean project metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ honored only when the site itself runs on localhost or another loopback address.
 The deployed site always reads the canonical database and render origins.
 
 Entry pages embed a rendered Challenge when the comparator names exactly one
-declaration and `Challenge.lean` is at most 100 lines and 32 KiB. Larger
+declaration and the recorded Challenge source is at most 100 lines and 32 KiB. Larger
 Challenges link to a dedicated rendered view. The pinned GitHub source link is
 always present. Rendered HTML is loaded in a fixed-height iframe with
 `sandbox="allow-scripts"` (deliberately without `allow-same-origin`) and no

--- a/about.html
+++ b/about.html
@@ -243,7 +243,7 @@
         </p>
         <p>
           Comparator also enforces that the compared theorems use no axioms
-          beyond those listed in the submission’s <code>comparator.json</code>.
+          beyond those listed in the configured Comparator JSON file.
           Because that file is written by the submitter, Palomar separately
           rejects any submission whose list extends beyond <code>propext</code>,
           <code>Quot.sound</code>, and <code>Classical.choice</code>.
@@ -340,17 +340,23 @@
         <p>The selected project directory must contain:</p>
         <ul>
           <li>exactly one of <code>lakefile.toml</code> or <code>lakefile.lean</code>, with a committed <code>lake-manifest.json</code> required for <code>lakefile.lean</code> projects;</li>
-          <li><code>lean-toolchain</code>, pinned to a supported Lean release or release candidate (a repository-root file may be shared by a nested project);</li>
+          <li><code>lean-toolchain</code>, pinned to a supported Lean release or release candidate (a repository-root file may be shared by a nested project, but a project-local file takes precedence);</li>
           <li>a small, readable Challenge module a mathematician should audit, conventionally <code>Challenge.lean</code>;</li>
           <li>a proved Solution module, conventionally <code>Solution.lean</code>;</li>
-          <li>a Comparator JSON configuration, conventionally <code>comparator.json</code>, naming every theorem and definition Comparator should compare; and</li>
-          <li><a href="https://github.com/mathlib-initiative/formalization.yaml"><code>formalization.yaml</code></a>, describing the project, result, sources, authorship, automation, review, and known limitations.</li>
+          <li>a Comparator JSON configuration, conventionally <code>comparator.json</code>, naming every theorem and definition Comparator should compare.</li>
         </ul>
+        <p>
+          The required <a href="https://github.com/mathlib-initiative/formalization.yaml"><code>formalization.yaml</code></a>
+          describes the project, result, sources, authorship, automation, review,
+          and known limitations. An explicit repository-relative path may keep it
+          outside a selected nested Comparator project.
+        </p>
         <p>
           A committed manifest is strongly recommended. For a
           <code>lakefile.toml</code> project without one, Palomar can construct
           a trusted manifest only from contained path dependencies whose targets
-          have committed manifests; other layouts must commit the selected
+          have committed manifests and no further path dependencies; other
+          layouts must commit the selected
           project's <code>lake-manifest.json</code>.
         </p>
         <p>

--- a/about.html
+++ b/about.html
@@ -77,7 +77,7 @@
           </li>
           <li id="editorial-floor">
             <strong>(Non-mechanical check)</strong> A language model judges that
-            the recorded formal statement (in <code>Challenge.lean</code>) is a
+            the recorded formal statement (conventionally <code>Challenge.lean</code>) is a
             fair rendering of the mathematical claim made in the recorded
             informal statement (in <a href="https://github.com/mathlib-initiative/formalization.yaml"><code>formalization.yaml</code></a>), and that the
             submission clears Palomar’s
@@ -329,20 +329,42 @@
           for Palomar’s
           <a href="https://kim-em.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000001&amp;version=2">first registered result</a>.
         </p>
-        <p>The repository root must contain:</p>
+        <p>
+          The repository root is the default project directory, so the usual
+          layout requires no path settings. If the Lean project lives in a
+          subdirectory, enter that repository-relative project path on the
+          submission form. You may also enter paths for a non-default Comparator
+          configuration or <a href="https://github.com/mathlib-initiative/formalization.yaml"><code>formalization.yaml</code></a>; omitted fields keep
+          the conventional defaults inside the selected project.
+        </p>
+        <p>The selected project directory must contain:</p>
         <ul>
-          <li><code>lean-toolchain</code>, pinned to a supported Lean release or release candidate;</li>
-          <li><code>lakefile.toml</code> and a committed <code>lake-manifest.json</code> (required in practice: without it, anything importing Mathlib will fail to build);</li>
-          <li><code>Challenge.lean</code>, containing the small, readable statement a mathematician should audit;</li>
-          <li><code>Solution.lean</code>, connecting that statement to the completed proof;</li>
-          <li><code>comparator.json</code>, naming every theorem and definition Comparator should compare; and</li>
+          <li>exactly one of <code>lakefile.toml</code> or <code>lakefile.lean</code>, with a committed <code>lake-manifest.json</code> required for <code>lakefile.lean</code> projects;</li>
+          <li><code>lean-toolchain</code>, pinned to a supported Lean release or release candidate (a repository-root file may be shared by a nested project);</li>
+          <li>a small, readable Challenge module a mathematician should audit, conventionally <code>Challenge.lean</code>;</li>
+          <li>a proved Solution module, conventionally <code>Solution.lean</code>;</li>
+          <li>a Comparator JSON configuration, conventionally <code>comparator.json</code>, naming every theorem and definition Comparator should compare; and</li>
           <li><a href="https://github.com/mathlib-initiative/formalization.yaml"><code>formalization.yaml</code></a>, describing the project, result, sources, authorship, automation, review, and known limitations.</li>
         </ul>
+        <p>
+          A committed manifest is strongly recommended. For a
+          <code>lakefile.toml</code> project without one, Palomar can construct
+          a trusted manifest only from contained path dependencies whose targets
+          have committed manifests; other layouts must commit the selected
+          project's <code>lake-manifest.json</code>.
+        </p>
+        <p>
+          Comparator may name safe dotted Challenge and Solution modules, and
+          Palomar resolves their source files through the selected Lake project.
+          The one conventional licence file remains at repository root even for
+          a nested project, because the recorded licence covers the submitted
+          repository snapshot.
+        </p>
 
         <h3 id="comparator-requirements">What does Comparator require?</h3>
         <p>
-          <code>Challenge.lean</code> states the result independently, normally
-          with <code>sorry</code>; <code>Solution.lean</code> supplies the proved
+          The Challenge module states the result independently, normally with
+          <code>sorry</code>; the Solution module supplies the proved
           version. Their compared declarations must have the same names and
           types. Comparator rebuilds and compares them, checks the permitted
           axioms, and verifies the proof. Palomar currently permits only
@@ -350,7 +372,7 @@
           <code>Classical.choice</code>.
         </p>
         <p>
-          Keep <code>Challenge.lean</code> short and mathematically ordinary.
+          Keep the Challenge source short and mathematically ordinary.
           1,000 lines and 100 KiB are hard limits; 300 lines and 32 KiB is the
           surface we would rather review. Its transitive imports must resolve
           to Lean core; the pinned, allowlisted Mathlib or Tau Ceti closure; or
@@ -369,9 +391,10 @@
           qualified statement dependencies.
         </p>
         <p>
-          Dependencies used only by <code>Solution.lean</code> may be arbitrary
-          pinned Git dependencies. Local/path dependencies and
-          <code>lakefile.lean</code> are not accepted by the current prototype.
+          Dependencies used only by the Solution may be arbitrary pinned Git
+          dependencies. Local/path dependencies are also accepted when their
+          targets remain within the same pinned repository checkout. Neither
+          kind relaxes the stricter transitive Challenge-import rule.
         </p>
 
         <h3 id="formalization-yaml">What belongs in <a href="https://github.com/mathlib-initiative/formalization.yaml"><code>formalization.yaml</code></a>?</h3>
@@ -416,7 +439,7 @@
         <h2>How to submit</h2>
         <ol>
           <li>Push the final snapshot to a public GitHub repository and copy its full 40-character commit SHA.</li>
-          <li><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Open the short submission form</a>. Enter the repository URL and commit SHA, record whether you maintain the substantive formalization or have approval from someone who does, confirm the required acknowledgements, and, for a correction to an existing entry, enter its Palomar ID.</li>
+          <li><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Open the short submission form</a>. Enter the repository URL and commit SHA. Leave the optional project, Comparator-config, and metadata paths blank for the normal root layout; fill them only for a nested or non-default layout. Record whether you maintain the substantive formalization or have approval from someone who does, confirm the required acknowledgements, and, for a correction to an existing entry, enter its Palomar ID.</li>
           <li>Submit the issue and watch it for status labels and comments. The issue is the public home for verification and review.</li>
         </ol>
         <p>

--- a/assets/app.js
+++ b/assets/app.js
@@ -8,6 +8,7 @@ import {
   databaseBaseFor,
   entryRecordUrl,
   isLoopbackHostname,
+  pinnedSourceDirectoryUrl,
   pinnedSourceFileUrl,
   reportIssueNumber,
   safeDataUrl,
@@ -91,6 +92,10 @@ function theoremNames(entry) {
   return entry.formalization.theorem_names.join(", ");
 }
 
+function pathBasename(path) {
+  return path.split("/").at(-1);
+}
+
 function classification(entry) {
   return {
     arxiv: Array.isArray(entry.classification?.arxiv) ? entry.classification.arxiv : [],
@@ -154,6 +159,7 @@ function entryCard(entry, versionCount) {
     authorNames(entry),
     theoremNames(entry),
     entry.source.repository,
+    entry.source.project_path || "",
     entry.id,
     ...categories.arxiv,
     ...categories.msc2020,
@@ -177,6 +183,14 @@ function entryCard(entry, versionCount) {
   const subjects = el("div", "card-subjects");
   subjects.append(el("small", "", "Subjects"), categoryTokens(entry));
   meta.append(authors, theorems, subjects);
+  if (entry.source.project_path) {
+    const project = el("div", "card-project");
+    project.append(
+      el("small", "", "Project directory"),
+      el("span", "", entry.source.project_path),
+    );
+    meta.append(project);
+  }
   const footer = el("div", "card-footer");
   const historyUrl = new URL(localPageUrl("entry.html", entry));
   historyUrl.hash = "version-history";
@@ -541,9 +555,11 @@ async function challengePresentation(entry, renderBase, { forceFrame = false } =
   const dependencyRecordUrl = localPageUrl("entry.html", entry);
   dependencyRecordUrl.hash = "statement-dependencies";
   const comparatorPath = entry.formalization.comparator_config_path;
+  const challengePath = entry.formalization.challenge_path;
+  const challengeFilename = pathBasename(challengePath);
   links.append(
     externalLink(
-      "View full pinned statement file (Challenge.lean)",
+      `View full pinned statement file (${challengeFilename})`,
       challengeSourceUrl(entry),
       "challenge-source",
     ),
@@ -554,7 +570,7 @@ async function challengePresentation(entry, renderBase, { forceFrame = false } =
     ),
     " · ",
     externalLink(
-      `View comparator configuration (${comparatorPath})`,
+      `View comparator configuration (${pathBasename(comparatorPath)})`,
       pinnedSourceFileUrl(entry, comparatorPath),
       "comparator-source",
     ),
@@ -571,7 +587,7 @@ async function challengePresentation(entry, renderBase, { forceFrame = false } =
     el(
       "p",
       "challenge-surface-disclosure",
-      "The formatted view shows only the declarations named in this entry's comparator configuration. Comparator also checks the declarations used by their types. The full pinned Challenge.lean and dependency record expose the statement and dependency surface for inspection.",
+      `The formatted view shows only the declarations named in this entry's comparator configuration. Comparator also checks the declarations used by their types. The full pinned ${challengeFilename} and dependency record expose the statement and dependency surface for inspection.`,
     ),
   );
 
@@ -818,19 +834,29 @@ function solutionMetadata(entry, renderMetadata) {
     el(
       "summary",
       "",
-      `${dependencies.length} source repositories used by the proof`,
+      `${dependencies.length} project dependencies used by the proof`,
     ),
   );
   const list = el("ul", "dependency-list");
   for (const dependency of dependencies) {
     const item = el("li");
-    item.append(
-      externalLink(
-        dependency.repository,
-        `https://github.com/${dependency.repository}/tree/${dependency.revision}`,
-      ),
-      el("code", "", dependency.revision.slice(0, 12)),
-    );
+    if (dependency.path !== undefined) {
+      item.append(
+        externalLink(
+          dependency.name,
+          pinnedSourceDirectoryUrl(entry, dependency.path),
+        ),
+        el("code", "", dependency.path),
+      );
+    } else {
+      item.append(
+        externalLink(
+          dependency.repository,
+          `https://github.com/${dependency.repository}/tree/${dependency.revision}`,
+        ),
+        el("code", "", dependency.revision.slice(0, 12)),
+      );
+    }
     list.append(item);
   }
   closure.append(list);
@@ -870,6 +896,11 @@ async function renderEntry(
     ),
     externalDetailRow("Fixed source version", `${entry.source.repository}@${entry.source.commit.slice(0, 12)}`, entry.source.tree_url),
     externalDetailRow(
+      "Project directory",
+      entry.source.project_path || "Repository root",
+      entry.source.tree_url,
+    ),
+    externalDetailRow(
       "Statement file",
       entry.formalization.challenge_path,
       pinnedSourceFileUrl(entry, entry.formalization.challenge_path),
@@ -897,6 +928,15 @@ async function renderEntry(
       entry.verification.workflow_url,
     ),
   );
+  if (entry.schema_version >= 6) {
+    details.append(
+      externalDetailRow(
+        "Lakefile",
+        entry.formalization.lakefile_path,
+        pinnedSourceFileUrl(entry, entry.formalization.lakefile_path),
+      ),
+    );
+  }
   details.append(detailRow("NanoDa commit", entry.verification.nanoda_commit));
   if (entry.schema_version >= 5) {
     details.append(

--- a/assets/app.js
+++ b/assets/app.js
@@ -16,6 +16,7 @@ import {
   safeInternalUrl,
   selectDatabaseUrl,
   selectRenderBase,
+  supportsProjectPaths,
   validateEntry,
   validateIndex,
   workflowRunId,
@@ -159,7 +160,7 @@ function entryCard(entry, versionCount) {
     authorNames(entry),
     theoremNames(entry),
     entry.source.repository,
-    entry.source.project_path || "",
+    supportsProjectPaths(entry) ? entry.source.project_path || "" : "",
     entry.id,
     ...categories.arxiv,
     ...categories.msc2020,
@@ -183,7 +184,7 @@ function entryCard(entry, versionCount) {
   const subjects = el("div", "card-subjects");
   subjects.append(el("small", "", "Subjects"), categoryTokens(entry));
   meta.append(authors, theorems, subjects);
-  if (entry.source.project_path) {
+  if (supportsProjectPaths(entry) && entry.source.project_path) {
     const project = el("div", "card-project");
     project.append(
       el("small", "", "Project directory"),
@@ -195,7 +196,11 @@ function entryCard(entry, versionCount) {
   const historyUrl = new URL(localPageUrl("entry.html", entry));
   historyUrl.hash = "version-history";
   footer.append(
-    externalLink(entry.source.repository, entry.source.tree_url, "repo-link"),
+    externalLink(
+      entry.source.repository,
+      `${entry.source.repository_url}/tree/${entry.source.commit}`,
+      "repo-link",
+    ),
     internalLink("View record", localPageUrl("entry.html", entry)),
   );
   if (versionCount > 1) {
@@ -840,7 +845,7 @@ function solutionMetadata(entry, renderMetadata) {
   const list = el("ul", "dependency-list");
   for (const dependency of dependencies) {
     const item = el("li");
-    if (dependency.path !== undefined) {
+    if (supportsProjectPaths(entry) && dependency.path !== undefined) {
       item.append(
         externalLink(
           dependency.name,
@@ -894,10 +899,14 @@ async function renderEntry(
       "Lean verification date",
       displayDate(entry.verification.verified_at.slice(0, 10)),
     ),
-    externalDetailRow("Fixed source version", `${entry.source.repository}@${entry.source.commit.slice(0, 12)}`, entry.source.tree_url),
+    externalDetailRow(
+      "Fixed source version",
+      `${entry.source.repository}@${entry.source.commit.slice(0, 12)}`,
+      `${entry.source.repository_url}/tree/${entry.source.commit}`,
+    ),
     externalDetailRow(
       "Project directory",
-      entry.source.project_path || "Repository root",
+      supportsProjectPaths(entry) ? entry.source.project_path || "Repository root" : "Repository root",
       entry.source.tree_url,
     ),
     externalDetailRow(
@@ -928,7 +937,7 @@ async function renderEntry(
       entry.verification.workflow_url,
     ),
   );
-  if (entry.schema_version >= 6) {
+  if (supportsProjectPaths(entry)) {
     details.append(
       externalDetailRow(
         "Lakefile",

--- a/assets/rendering.js
+++ b/assets/rendering.js
@@ -6,6 +6,26 @@ const SHA = /^[0-9a-f]{40}$/;
 const SHA256 = /^[0-9a-f]{64}$/;
 const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 
+function safeSourcePath(value) {
+  if (typeof value !== "string" || !value) return null;
+  const segments = value.split("/");
+  if (
+    value.startsWith("/") ||
+    value.includes("\\") ||
+    value.includes("?") ||
+    value.includes("#") ||
+    /[\u0000-\u001f\u007f]/u.test(value) ||
+    segments.some((segment) => !segment || segment === "." || segment === "..") ||
+    segments[0].includes(":")
+  ) return null;
+  return segments
+    .map((segment) => encodeURIComponent(segment).replace(
+      /[!'()*]/g,
+      (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+    ))
+    .join("/");
+}
+
 export function isInlineChallenge(entry) {
   const formalization = entry?.formalization;
   const trust = entry?.trust;
@@ -28,15 +48,16 @@ export function challengeSourceUrl(entry) {
   const repositoryUrl = entry?.source?.repository_url?.replace(/\/+$/, "");
   const commit = entry?.source?.commit;
   const challengePath = entry?.formalization?.challenge_path;
+  const encodedPath = safeSourcePath(challengePath);
   if (
     !REPOSITORY.test(repository || "") ||
     repositoryUrl !== `https://github.com/${repository}` ||
     !SHA.test(commit || "") ||
-    challengePath !== "Challenge.lean"
+    !encodedPath
   ) {
     throw new Error("entry has invalid canonical Challenge source metadata");
   }
-  return `${repositoryUrl}/blob/${commit}/Challenge.lean`;
+  return `${repositoryUrl}/blob/${commit}/${encodedPath}`;
 }
 
 export function challengeArtifactUrl(entry, renderBase) {

--- a/assets/rendering.js
+++ b/assets/rendering.js
@@ -6,26 +6,6 @@ const SHA = /^[0-9a-f]{40}$/;
 const SHA256 = /^[0-9a-f]{64}$/;
 const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 
-function safeSourcePath(value) {
-  if (typeof value !== "string" || !value) return null;
-  const segments = value.split("/");
-  if (
-    value.startsWith("/") ||
-    value.includes("\\") ||
-    value.includes("?") ||
-    value.includes("#") ||
-    /[\u0000-\u001f\u007f]/u.test(value) ||
-    segments.some((segment) => !segment || segment === "." || segment === "..") ||
-    segments[0].includes(":")
-  ) return null;
-  return segments
-    .map((segment) => encodeURIComponent(segment).replace(
-      /[!'()*]/g,
-      (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
-    ))
-    .join("/");
-}
-
 export function isInlineChallenge(entry) {
   const formalization = entry?.formalization;
   const trust = entry?.trust;
@@ -48,13 +28,16 @@ export function challengeSourceUrl(entry) {
   const repositoryUrl = entry?.source?.repository_url?.replace(/\/+$/, "");
   const commit = entry?.source?.commit;
   const challengePath = entry?.formalization?.challenge_path;
-  const encodedPath = safeSourcePath(challengePath);
-  if (
-    !REPOSITORY.test(repository || "") ||
-    repositoryUrl !== `https://github.com/${repository}` ||
-    !SHA.test(commit || "") ||
-    !encodedPath
-  ) {
+  let encodedPath;
+  try {
+    safeRepositoryPath(challengePath, "Challenge source path");
+    encodedPath = encodedRepositoryPath(challengePath);
+  } catch {
+    throw new Error("entry has invalid canonical Challenge source metadata");
+  }
+  if (!REPOSITORY.test(repository || "") ||
+      repositoryUrl !== `https://github.com/${repository}` ||
+      !SHA.test(commit || "")) {
     throw new Error("entry has invalid canonical Challenge source metadata");
   }
   return `${repositoryUrl}/blob/${commit}/${encodedPath}`;
@@ -95,3 +78,4 @@ export function entryRecordPath(id, version, path) {
   }
   return expected;
 }
+import { encodedRepositoryPath, safeRepositoryPath } from "./security.mjs";

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -1,5 +1,5 @@
 export const INDEX_SCHEMA_VERSION = 2;
-export const ENTRY_SCHEMA_VERSIONS = new Set([2, 3, 4, 5]);
+export const ENTRY_SCHEMA_VERSIONS = new Set([2, 3, 4, 5, 6]);
 export const DEFAULT_DATABASE =
   "https://raw.githubusercontent.com/kim-em/PalomarDatabase/main/index.json";
 export const DEFAULT_RENDER_BASE = "https://kim-em.github.io/PalomarDatabase/";
@@ -178,11 +178,27 @@ export function safeRepositoryPath(value, field = "repository path") {
     value.includes("?") ||
     value.includes("#") ||
     segments.some((segment) => !segment || segment === "." || segment === "..") ||
-    segments[0].includes(":")
+    segments[0].includes(":") ||
+    [...value].some((character) => character.charCodeAt(0) < 32 || character.charCodeAt(0) === 127)
   ) {
     fail(`${field} is not a safe relative path`);
   }
   return value;
+}
+
+function encodedRepositoryPath(path) {
+  return path
+    .split("/")
+    .map((segment) => encodeURIComponent(segment).replace(
+      /[!'()*]/g,
+      (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+    ))
+    .join("/");
+}
+
+function safeDependencyPath(value, field) {
+  if (value === ".") return value;
+  return safeRepositoryPath(value, field);
 }
 
 function validateCanonicalRecordLinks(entry) {
@@ -204,7 +220,12 @@ function validateCanonicalRecordLinks(entry) {
   if (!COMMIT_RE.test(source.commit)) fail("source.commit is not a full lowercase commit");
   const repositoryUrl = `https://github.com/${source.repository}`;
   if (source.repository_url !== repositoryUrl) fail("source.repository_url is not canonical");
-  if (source.tree_url !== `${repositoryUrl}/tree/${source.commit}`) {
+  let expectedTreeUrl = `${repositoryUrl}/tree/${source.commit}`;
+  if (entry.schema_version === 6 && source.project_path !== undefined) {
+    safeRepositoryPath(source.project_path, "entry.source.project_path");
+    expectedTreeUrl += `/${encodedRepositoryPath(source.project_path)}`;
+  }
+  if (source.tree_url !== expectedTreeUrl) {
     fail("source.tree_url is not derived from source repository and commit");
   }
   safeExternalUrl(source.tree_url);
@@ -379,23 +400,63 @@ export function validateEntry(entry, summary) {
     formalization.formalization_metadata_path,
     "entry.formalization.formalization_metadata_path",
   );
+  if (entry.schema_version === 6) {
+    safeRepositoryPath(formalization.lakefile_path, "entry.formalization.lakefile_path");
+    const prefix = source.project_path ? `${source.project_path}/` : "";
+    for (const [field, value] of [
+      ["challenge_path", formalization.challenge_path],
+      ["solution_path", formalization.solution_path],
+      ["comparator_config_path", formalization.comparator_config_path],
+      ["lakefile_path", formalization.lakefile_path],
+    ]) {
+      if (!value.startsWith(prefix)) {
+        fail(`entry.formalization.${field} is outside entry.source.project_path`);
+      }
+    }
+    if (![`${prefix}lakefile.toml`, `${prefix}lakefile.lean`].includes(formalization.lakefile_path)) {
+      fail("entry.formalization.lakefile_path is not the selected project's Lakefile");
+    }
+  }
   string(formalization.lean_toolchain, "entry.formalization.lean_toolchain");
   stringArray(formalization.theorem_names, "entry.formalization.theorem_names");
   stringArray(formalization.definition_names, "entry.formalization.definition_names");
   stringArray(formalization.permitted_axioms, "entry.formalization.permitted_axioms");
+  const dependencyNames = new Set();
+  const dependencyPaths = new Set();
   for (const [position, value] of array(
     formalization.project_dependencies,
     "entry.formalization.project_dependencies",
   ).entries()) {
     const dependency = object(value, `entry.formalization.project_dependencies[${position}]`);
-    string(dependency.name, `entry.formalization.project_dependencies[${position}].name`);
-    if (!REPOSITORY_RE.test(dependency.repository)) {
-      fail(`entry.formalization.project_dependencies[${position}].repository is malformed`);
-    }
-    commit(
-      dependency.revision,
-      `entry.formalization.project_dependencies[${position}].revision`,
+    const dependencyName = string(
+      dependency.name,
+      `entry.formalization.project_dependencies[${position}].name`,
     );
+    if (entry.schema_version === 6 && dependencyNames.has(dependencyName)) {
+      fail(`entry.formalization.project_dependencies[${position}].name is duplicated`);
+    }
+    dependencyNames.add(dependencyName);
+    if (entry.schema_version === 6 && dependency.path !== undefined) {
+      const path = safeDependencyPath(
+        dependency.path,
+        `entry.formalization.project_dependencies[${position}].path`,
+      );
+      if (dependency.repository !== undefined || dependency.revision !== undefined) {
+        fail(`entry.formalization.project_dependencies[${position}] mixes path and Git fields`);
+      }
+      if (dependencyPaths.has(path)) {
+        fail(`entry.formalization.project_dependencies[${position}].path is duplicated`);
+      }
+      dependencyPaths.add(path);
+    } else {
+      if (!REPOSITORY_RE.test(dependency.repository)) {
+        fail(`entry.formalization.project_dependencies[${position}].repository is malformed`);
+      }
+      commit(
+        dependency.revision,
+        `entry.formalization.project_dependencies[${position}].revision`,
+      );
+    }
   }
 
   const verification = object(entry.verification, "entry.verification");
@@ -498,8 +559,21 @@ export function pinnedSourceFileUrl(entry, path) {
   ) {
     fail("source file link lacks canonical repository evidence");
   }
-  const encodedPath = path.split("/").map(encodeURIComponent).join("/");
+  const encodedPath = encodedRepositoryPath(path);
   return safeExternalUrl(`${expectedRepository}/blob/${entry.source.commit}/${encodedPath}`);
+}
+
+export function pinnedSourceDirectoryUrl(entry, path) {
+  safeDependencyPath(path, "source directory path");
+  const expectedRepository = `https://github.com/${entry.source.repository}`;
+  if (
+    entry.source.repository_url !== expectedRepository ||
+    !COMMIT_RE.test(entry.source.commit)
+  ) {
+    fail("source directory link lacks canonical repository evidence");
+  }
+  const suffix = path === "." ? "" : `/${encodedRepositoryPath(path)}`;
+  return safeExternalUrl(`${expectedRepository}/tree/${entry.source.commit}${suffix}`);
 }
 
 export function workflowRunId(workflowUrl) {

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -4,6 +4,10 @@ export const DEFAULT_DATABASE =
   "https://raw.githubusercontent.com/kim-em/PalomarDatabase/main/index.json";
 export const DEFAULT_RENDER_BASE = "https://kim-em.github.io/PalomarDatabase/";
 
+export function supportsProjectPaths(entry) {
+  return entry?.schema_version === 6;
+}
+
 const SUBMISSION_REPOSITORY = "kim-em/PalomarSubmission";
 const ID_RE = /^PALOMAR-([0-9]{4}-[0-9]{2}-[0-9]{2})-([0-9]{6})$/;
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
@@ -179,6 +183,7 @@ export function safeRepositoryPath(value, field = "repository path") {
     value.includes("#") ||
     segments.some((segment) => !segment || segment === "." || segment === "..") ||
     segments[0].includes(":") ||
+    /[\uD800-\uDFFF]/u.test(value) ||
     [...value].some((character) => character.charCodeAt(0) < 32 || character.charCodeAt(0) === 127)
   ) {
     fail(`${field} is not a safe relative path`);
@@ -186,7 +191,7 @@ export function safeRepositoryPath(value, field = "repository path") {
   return value;
 }
 
-function encodedRepositoryPath(path) {
+export function encodedRepositoryPath(path) {
   return path
     .split("/")
     .map((segment) => encodeURIComponent(segment).replace(
@@ -221,7 +226,10 @@ function validateCanonicalRecordLinks(entry) {
   const repositoryUrl = `https://github.com/${source.repository}`;
   if (source.repository_url !== repositoryUrl) fail("source.repository_url is not canonical");
   let expectedTreeUrl = `${repositoryUrl}/tree/${source.commit}`;
-  if (entry.schema_version === 6 && source.project_path !== undefined) {
+  if (!supportsProjectPaths(entry) && source.project_path !== undefined) {
+    fail("source.project_path is not supported by this entry schema");
+  }
+  if (supportsProjectPaths(entry) && source.project_path !== undefined) {
     safeRepositoryPath(source.project_path, "entry.source.project_path");
     expectedTreeUrl += `/${encodedRepositoryPath(source.project_path)}`;
   }
@@ -400,7 +408,10 @@ export function validateEntry(entry, summary) {
     formalization.formalization_metadata_path,
     "entry.formalization.formalization_metadata_path",
   );
-  if (entry.schema_version === 6) {
+  if (!supportsProjectPaths(entry) && formalization.lakefile_path !== undefined) {
+    fail("entry.formalization.lakefile_path is not supported by this entry schema");
+  }
+  if (supportsProjectPaths(entry)) {
     safeRepositoryPath(formalization.lakefile_path, "entry.formalization.lakefile_path");
     const prefix = source.project_path ? `${source.project_path}/` : "";
     for (const [field, value] of [
@@ -432,11 +443,14 @@ export function validateEntry(entry, summary) {
       dependency.name,
       `entry.formalization.project_dependencies[${position}].name`,
     );
-    if (entry.schema_version === 6 && dependencyNames.has(dependencyName)) {
+    if (supportsProjectPaths(entry) && dependencyNames.has(dependencyName)) {
       fail(`entry.formalization.project_dependencies[${position}].name is duplicated`);
     }
     dependencyNames.add(dependencyName);
-    if (entry.schema_version === 6 && dependency.path !== undefined) {
+    if (!supportsProjectPaths(entry) && dependency.path !== undefined) {
+      fail(`entry.formalization.project_dependencies[${position}].path is not supported`);
+    }
+    if (supportsProjectPaths(entry) && dependency.path !== undefined) {
       const path = safeDependencyPath(
         dependency.path,
         `entry.formalization.project_dependencies[${position}].path`,
@@ -554,6 +568,7 @@ export function pinnedSourceFileUrl(entry, path) {
   safeRepositoryPath(path, "source file path");
   const expectedRepository = `https://github.com/${entry.source.repository}`;
   if (
+    !REPOSITORY_RE.test(entry.source.repository) ||
     entry.source.repository_url !== expectedRepository ||
     !COMMIT_RE.test(entry.source.commit)
   ) {
@@ -567,6 +582,7 @@ export function pinnedSourceDirectoryUrl(entry, path) {
   safeDependencyPath(path, "source directory path");
   const expectedRepository = `https://github.com/${entry.source.repository}`;
   if (
+    !REPOSITORY_RE.test(entry.source.repository) ||
     entry.source.repository_url !== expectedRepository ||
     !COMMIT_RE.test(entry.source.commit)
   ) {

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -21,7 +21,7 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
         if identifier.endswith("000123")
         else {"arxiv": ["math.NT"], "msc2020": ["11N13"]}
     )
-    return {
+    record = {
         "schema_version": 5,
         "id": identifier,
         "accepted_at": "2026-07-29",
@@ -126,6 +126,25 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
             "rendered_at": "2026-07-29T09:00:00Z",
         },
     }
+    if identifier.endswith("000123"):
+        project = "project"
+        record["schema_version"] = 6
+        record["source"]["project_path"] = project
+        record["source"]["tree_url"] += f"/{project}"
+        record["formalization"].update(
+            {
+                "challenge_path": f"{project}/Comparator/Task.lean",
+                "solution_path": f"{project}/Comparator/Answer.lean",
+                "comparator_config_path": f"{project}/Comparator/settings.json",
+                "formalization_metadata_path": f"{project}/formalization.yaml",
+                "lakefile_path": f"{project}/lakefile.lean",
+                "project_dependencies": [
+                    {"name": "shared", "path": "shared"},
+                    *record["formalization"]["project_dependencies"],
+                ],
+            }
+        )
+    return record
 
 
 ENTRIES = {

--- a/tests/rendering.test.js
+++ b/tests/rendering.test.js
@@ -71,6 +71,21 @@ test("source URL is always the immutable canonical GitHub file", () => {
   const moving = entry();
   moving.source.commit = "main";
   assert.throws(() => challengeSourceUrl(moving), /canonical/);
+
+  const nested = entry();
+  nested.formalization.challenge_path = "project/Comparator/Task.lean";
+  assert.equal(
+    challengeSourceUrl(nested),
+    `https://github.com/example/challenge/blob/${"1".repeat(40)}/project/Comparator/Task.lean`,
+  );
+
+  const traversal = entry();
+  traversal.formalization.challenge_path = "../Task.lean";
+  assert.throws(() => challengeSourceUrl(traversal), /canonical/);
+
+  const controlCharacter = entry();
+  controlCharacter.formalization.challenge_path = "project/Task\n.lean";
+  assert.throws(() => challengeSourceUrl(controlCharacter), /canonical/);
 });
 
 test("index paths cannot redirect entry fetching", () => {

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -10,6 +10,7 @@ import {
   databaseBaseFor,
   entryRecordUrl,
   isLoopbackHostname,
+  pinnedSourceDirectoryUrl,
   pinnedSourceFileUrl,
   safeDataUrl,
   safeExternalUrl,
@@ -252,7 +253,7 @@ test("indexed dependency provenance requires a Palomar ID", () => {
 });
 
 test("entry schema, acceptance state, verdict, and selected identity fail closed", () => {
-  assert.throws(() => validateEntry(entry({ schema_version: 6 }), summary()), /unsupported entry/);
+  assert.throws(() => validateEntry(entry({ schema_version: 7 }), summary()), /unsupported entry/);
   assert.throws(() => validateEntry(entry({ status: "draft" }), summary()), /not accepted/);
   const rejected = entry();
   rejected.review.verdict = "reject";
@@ -369,6 +370,71 @@ test("schema v5 requires content-addressed durable verification evidence", () =>
   assert.throws(() => validateEntry(wrongAddress, summary()), /evidence_path must be/);
 });
 
+test("schema v6 accepts and canonically links a nested project and path dependency", () => {
+  const evidenceTree = "c".repeat(64);
+  const projectPath = "examples/Sharp Smoothing";
+  const valid = entry({
+    schema_version: 6,
+    classification: { arxiv: ["math.CO"], msc2020: ["05C10"] },
+    provenance: {
+      result_origin: "original",
+      repository_role: "substantive-development",
+      responsible_maintainers: [{ name: "Example" }],
+      mathematical_sources: [],
+      related_formalizations: [],
+    },
+  });
+  valid.submission.authorization = { relationship: "maintainer" };
+  valid.source.project_path = projectPath;
+  valid.source.tree_url =
+    `https://github.com/example/challenge/tree/${COMMIT}/examples/Sharp%20Smoothing`;
+  valid.source.license = {
+    path: "LICENSE",
+    sha256: DIGEST,
+    declared_identifier: "Apache-2.0",
+    detected_identifier: "Apache-2.0",
+  };
+  Object.assign(valid.formalization, {
+    challenge_path: `${projectPath}/Comparator/Task.lean`,
+    solution_path: `${projectPath}/Comparator/Answer.lean`,
+    comparator_config_path: `${projectPath}/Comparator/settings.json`,
+    formalization_metadata_path: `${projectPath}/formalization.yaml`,
+    lakefile_path: `${projectPath}/lakefile.lean`,
+    project_dependencies: [
+      { name: "local", path: "." },
+      { name: "mathlib", repository: "leanprover-community/mathlib4", revision: COMMIT },
+    ],
+  });
+  Object.assign(valid.verification, {
+    workflow_commit: "8".repeat(40),
+    workflow_run_attempt: 1,
+    evidence_tree_sha256: evidenceTree,
+    mechanical_report_sha256: "d".repeat(64),
+    evidence_path: `evidence/${valid.id}-v${valid.version}/${evidenceTree}/`,
+  });
+  assert.doesNotThrow(() => validateEntry(valid, summary()));
+  assert.equal(
+    pinnedSourceFileUrl(valid, valid.formalization.challenge_path).href,
+    `https://github.com/example/challenge/blob/${COMMIT}/examples/Sharp%20Smoothing/Comparator/Task.lean`,
+  );
+  assert.equal(
+    pinnedSourceDirectoryUrl(valid, ".").href,
+    `https://github.com/example/challenge/tree/${COMMIT}`,
+  );
+
+  const wrongTree = structuredClone(valid);
+  wrongTree.source.tree_url = `https://github.com/example/challenge/tree/${COMMIT}`;
+  assert.throws(() => validateEntry(wrongTree, summary()), /tree_url is not derived/);
+
+  const escape = structuredClone(valid);
+  escape.formalization.project_dependencies[0].path = "../outside";
+  assert.throws(() => validateEntry(escape, summary()), /not a safe relative path/);
+
+  const misplacedLakefile = structuredClone(valid);
+  misplacedLakefile.formalization.lakefile_path = `${projectPath}/nested/lakefile.toml`;
+  assert.throws(() => validateEntry(misplacedLakefile, summary()), /selected project's Lakefile/);
+});
+
 test("record evidence links must agree with their canonical values", () => {
   const wrongDate = entry({ accepted_at: "2026-07-30" });
   assert.throws(() => validateEntry(wrongDate, summary()), /ID date does not match/);
@@ -434,4 +500,6 @@ test("About states the repository licence boundary", async () => {
   const about = await readFile(new URL("../about.html", import.meta.url), "utf8");
   assert.match(about, /root licence file, SPDX identifier, and checksum/);
   assert.match(about, /reused formalizations, and\s+dependencies retain their own licences/);
+  assert.match(about, /repository root is the default project directory/);
+  assert.match(about, /licence file remains at repository root/);
 });

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -435,6 +435,45 @@ test("schema v6 accepts and canonically links a nested project and path dependen
   assert.throws(() => validateEntry(misplacedLakefile, summary()), /selected project's Lakefile/);
 });
 
+test("schema v6 keeps the repository-root layout as the natural default", () => {
+  const evidenceTree = "c".repeat(64);
+  const valid = entry({
+    schema_version: 6,
+    classification: { arxiv: ["math.CO"], msc2020: ["05C10"] },
+    provenance: {
+      result_origin: "original",
+      repository_role: "substantive-development",
+      responsible_maintainers: [{ name: "Example" }],
+      mathematical_sources: [],
+      related_formalizations: [],
+    },
+  });
+  valid.submission.authorization = { relationship: "maintainer" };
+  valid.source.license = {
+    path: "LICENSE",
+    sha256: DIGEST,
+    declared_identifier: "Apache-2.0",
+    detected_identifier: "Apache-2.0",
+  };
+  valid.formalization.lakefile_path = "lakefile.toml";
+  Object.assign(valid.verification, {
+    workflow_commit: "8".repeat(40),
+    workflow_run_attempt: 1,
+    evidence_tree_sha256: evidenceTree,
+    mechanical_report_sha256: "d".repeat(64),
+    evidence_path: `evidence/${valid.id}-v${valid.version}/${evidenceTree}/`,
+  });
+  assert.doesNotThrow(() => validateEntry(valid, summary()));
+
+  const misplacedLakefile = structuredClone(valid);
+  misplacedLakefile.formalization.lakefile_path = "src/lakefile.toml";
+  assert.throws(() => validateEntry(misplacedLakefile, summary()), /selected project's Lakefile/);
+
+  const legacyWithProjectPath = entry();
+  legacyWithProjectPath.source.project_path = "project";
+  assert.throws(() => validateEntry(legacyWithProjectPath, summary()), /not supported/);
+});
+
 test("record evidence links must agree with their canonical values", () => {
   const wrongDate = entry({ accepted_at: "2026-07-30" });
   assert.throws(() => validateEntry(wrongDate, summary()), /ID date does not match/);

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -86,6 +86,8 @@ test("landing cards show the acceptance date and dated identifier", async ({ pag
   await expect(page.locator(".entry-card")).toHaveCount(2);
   await expect(first.locator(".card-subjects")).toContainText("math.CO");
   await expect(first.locator(".card-subjects")).toContainText("MSC 05C10");
+  await expect(first.locator(".card-project")).toContainText("Project directory");
+  await expect(first.locator(".card-project")).toContainText("project");
   await expect(page.getByRole("button", { name: "Mathlib only" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Additional libraries" })).toBeVisible();
 });
@@ -283,16 +285,17 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   );
   await expect(source).toHaveAttribute(
     "href",
-    `https://github.com/example/challenge/blob/${"1".repeat(40)}/Challenge.lean`,
+    `https://github.com/example/challenge/blob/${"1".repeat(40)}/project/Comparator/Task.lean`,
   );
+  await expect(source).toHaveText("View full pinned statement file (Task.lean)");
   await expect(
     page.getByRole("link", { name: "Inspect statement dependencies" }),
   ).toHaveAttribute("href", /#statement-dependencies$/);
   await expect(
-    page.getByRole("link", { name: "View comparator configuration (comparator.json)" }),
+    page.getByRole("link", { name: "View comparator configuration (settings.json)" }),
   ).toHaveAttribute(
     "href",
-    `https://github.com/example/challenge/blob/${"1".repeat(40)}/comparator.json`,
+    `https://github.com/example/challenge/blob/${"1".repeat(40)}/project/Comparator/settings.json`,
   );
   await expect(page.getByRole("link", { name: "Open formatted statement" })).toHaveCount(0);
   const iframe = page.locator(".challenge-presentation iframe");
@@ -330,26 +333,33 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   await expect(page.getByRole("link", { name: "Archived mechanical report" })).toBeVisible();
   await expect(page.getByText("Verification workflow commit")).toBeVisible();
   await expect(page.getByRole("link", { name: "Editorial evidence" })).toBeVisible();
-  await expect(page.getByRole("link", { name: "Solution.lean" }).first()).toHaveAttribute(
+  await expect(page.getByRole("link", { name: "project/Comparator/Answer.lean" }).first()).toHaveAttribute(
     "href",
-    `https://github.com/example/challenge/blob/${"1".repeat(40)}/Solution.lean`,
+    `https://github.com/example/challenge/blob/${"1".repeat(40)}/project/Comparator/Answer.lean`,
   );
   const sourceFiles = page.locator(
     '.entry-evidence .detail-row a[href*="github.com/example/challenge/blob/"]',
   );
   await expect(sourceFiles).toHaveText([
-    "Challenge.lean",
-    "Solution.lean",
-    "formalization.yaml",
+    "project/Comparator/Task.lean",
+    "project/Comparator/Answer.lean",
+    "project/formalization.yaml",
+    "project/lakefile.lean",
     "LICENSE.md",
   ]);
   await expect(sourceFiles.nth(2)).toHaveAttribute(
     "href",
-    `https://github.com/example/challenge/blob/${"1".repeat(40)}/formalization.yaml`,
+    `https://github.com/example/challenge/blob/${"1".repeat(40)}/project/formalization.yaml`,
   );
+  await expect(page.locator(".entry-evidence")).toContainText("Project directory");
+  await expect(page.locator(".entry-evidence")).toContainText("project");
   await expect(page.locator(".entry-solution .token-list code")).toHaveText("ExampleDependency");
   await page.locator(".solution-dependencies summary").click();
   await expect(page.locator(".dependency-list")).toContainText("example/dependency");
+  await expect(page.getByRole("link", { name: "shared" })).toHaveAttribute(
+    "href",
+    `https://github.com/example/challenge/tree/${"1".repeat(40)}/shared`,
+  );
   await iframe.hover();
   await page.mouse.wheel(0, 2000);
   await expect.poll(() => rendered.locator("html").evaluate((node) => node.scrollTop)).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

- validate and display registry schema v6 nested project metadata
- link recorded Challenge, Solution, Comparator, Lakefile, and contained path dependencies at immutable commits
- show project directories naturally on cards, search results, and entry details
- explain the root-default and nested-project submission model on About

## Validation

- 25 unit tests passed
- production build passed
- 16 browser tests passed, 2 skipped
- git diff --check passed

## Independent review

An isolated second review was completed. Its blocking and high-severity findings were addressed, including consistent schema-version gating, centralized path validation, and canonical source links.

## Rollout

Merge after Database schema v6 and before schema-v6 records are published.