### PR TITLE
refactor: drop Palomar-indexed Challenge imports

### DIFF
--- a/about.html
+++ b/about.html
@@ -288,8 +288,7 @@
         <p>
           To assist with such comparisons, Palomar caps the size of the formal
           statement at 1,000 lines and 100 KiB. Imports are restricted to Lean
-          core, pinned allowlisted libraries, and exact source snapshots from
-          accepted Palomar record versions; the language model audits the
+          core and pinned allowlisted libraries; the language model audits the
           definitions actually reached from those sources. Each registry entry
           displays the compared declarations, with their types available on
           hover, and links the exact statement file at the exact commit.
@@ -381,20 +380,12 @@
           Keep the Challenge source short and mathematically ordinary.
           1,000 lines and 100 KiB are hard limits; 300 lines and 32 KiB is the
           surface we would rather review. Its transitive imports must resolve
-          to Lean core; the pinned, allowlisted Mathlib or Tau Ceti closure; or
-          an exact source snapshot represented by a specific accepted Palomar
-          record version. Importing Tau Ceti or an indexed Palomar source is
-          accepted and records a wider statement dependency surface on the
-          entry.
-        </p>
-        <p>
-          For an indexed import, Palomar independently checks out the recorded
-          repository and commit, verifies every imported source file, and
-          compiles the reached source directly with trusted Lean. This makes the
-          imported statement surface fixed and reviewable; it does not certify
-          every definition in that repository or promote the project to
-          Mathlib-level trust. The resulting entry is therefore marked as having
-          qualified statement dependencies.
+          to Lean core or the pinned, allowlisted Mathlib or Tau Ceti closure,
+          and to nothing else. Importing Tau Ceti is accepted and marks the
+          entry as having qualified statement dependencies. A project Palomar
+          has already accepted is not importable on that basis: an entry fixes a
+          reviewable snapshot of its own statement, not a library for later
+          submissions.
         </p>
         <p>
           Dependencies used only by the Solution may be arbitrary pinned Git

--- a/assets/app.js
+++ b/assets/app.js
@@ -1000,10 +1000,7 @@ async function renderEntry(
     trust.append(el("h3", "", "Source repositories"));
     const dependencies = el("ul", "plain-list");
     for (const dependency of entry.trust.challenge_dependencies) {
-      const provenance = dependency.provenance === "palomar-indexed"
-        ? `Palomar-indexed: ${dependency.palomar_id}`
-        : "allowlisted";
-      dependencies.append(el("li", "", `${dependency.repository} (${provenance})`));
+      dependencies.append(el("li", "", dependency.repository));
     }
     trust.append(dependencies);
   }

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -518,16 +518,10 @@ export function validateEntry(entry, summary) {
     if (!REPOSITORY_RE.test(dependency.repository)) {
       fail(`entry.trust.challenge_dependencies[${position}].repository is malformed`);
     }
-    if (!['allowlisted', 'palomar-indexed'].includes(dependency.provenance)) {
+    if (dependency.provenance !== 'allowlisted') {
       fail(`entry.trust.challenge_dependencies[${position}].provenance is unsupported`);
     }
-    if (dependency.provenance === "palomar-indexed") {
-      if (!ID_RE.test(dependency.palomar_id || "")) {
-        fail(
-          `entry.trust.challenge_dependencies[${position}].palomar_id is required and malformed`,
-        );
-      }
-    } else if (dependency.palomar_id !== undefined) {
+    if (dependency.palomar_id !== undefined) {
       fail(
         `entry.trust.challenge_dependencies[${position}].palomar_id is forbidden for allowlisted provenance`,
       );

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -167,12 +167,11 @@ ENTRIES[("PALOMAR-2026-07-29-000124", 1)]["trust"].update(
                 "provenance": "allowlisted",
             },
             {
-                "repository": "example/dependency",
-                "provenance": "palomar-indexed",
-                "palomar_id": "PALOMAR-2026-07-29-000123",
+                "repository": "TauCetiProject/TauCeti",
+                "provenance": "allowlisted",
             },
         ],
-        "reasons": ["An exact indexed source snapshot determines the statement."],
+        "reasons": ["Challenge imports Tau Ceti"],
     }
 )
 class Handler(SimpleHTTPRequestHandler):

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -226,7 +226,7 @@ test("a canonical accepted record validates", () => {
   );
 });
 
-test("indexed dependency provenance requires a Palomar ID", () => {
+test("withdrawn palomar-indexed provenance is rejected", () => {
   const trust = {
     ...entry().trust,
     level: "qualified",
@@ -236,7 +236,7 @@ test("indexed dependency provenance requires a Palomar ID", () => {
   };
   assert.throws(
     () => validateEntry(entry({ trust }), summary()),
-    /palomar_id is required/,
+    /provenance is unsupported/,
   );
 
   trust.challenge_dependencies = [

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -369,10 +369,10 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
 test("larger Challenge falls back to the dedicated wrapper", async ({ page }) => {
   await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000124&version=1&database=${database}`);
   await expect(page.locator("#statement-dependencies")).toContainText(
-    "leanprover-community/mathlib4 (allowlisted)",
+    "leanprover-community/mathlib4",
   );
   await expect(page.locator("#statement-dependencies")).toContainText(
-    "example/dependency (Palomar-indexed: PALOMAR-2026-07-29-000123)",
+    "TauCetiProject/TauCeti",
   );
   await expect(page.locator(".challenge-presentation iframe")).toHaveCount(0);
   await expect(page.locator(".challenge-fallback")).toBeVisible();


### PR DESCRIPTION
This PR removes the Palomar-indexed statement dependency from the public
explanation and from record validation. The About page now states that a
Challenge's transitive imports must resolve to Lean core or the pinned
Mathlib/Tau Ceti closure and nothing else, and that a project Palomar has
already accepted is not importable on that basis.

Client-side record validation accepts only `allowlisted` provenance, and the
entry page no longer annotates each source repository with a provenance label
that now carries no information. The qualified/high trust distinction is
unchanged, since Tau Ceti still produces qualified statement dependencies.

🤖 Prepared with Claude Code