### PR TITLE
chore: repoint the site at PalomarRegistry

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#ffffff">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; frame-src 'self' https://kim-em.github.io; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; frame-src 'self' https://palomarregistry.github.io; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Not found — Palomar</title>
     <link rel="stylesheet" href="assets/style.css">
   </head>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Palomar Web
 
 The read-only human view of
-[`kim-em/PalomarDatabase`](https://github.com/kim-em/PalomarDatabase).
+[`PalomarRegistry/PalomarDatabase`](https://github.com/PalomarRegistry/PalomarDatabase).
 
 The site is static and deployed with GitHub Pages. It fetches `index.json` and
 entry records directly from the database repository at runtime, so publishing a
@@ -55,7 +55,7 @@ history when older snapshots exist.
 An entry URL with both `id` and `version` identifies one immutable snapshot:
 
 ```text
-https://kim-em.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000001&version=1
+https://palomarregistry.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000001&version=1
 ```
 
 Its HTML canonical link points to that same official, explicit version,

--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="About Palomar and submitting machine-checked formal mathematics.">
     <meta name="theme-color" content="#ffffff">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; frame-src 'self' https://kim-em.github.io; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; frame-src 'self' https://palomarregistry.github.io; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>About — Palomar</title>
     <link rel="stylesheet" href="assets/style.css">
   </head>
@@ -16,7 +16,7 @@
       <nav aria-label="Main navigation">
         <a href="./">Registry</a>
         <a class="active" href="about.html" aria-current="page">About</a>
-        <a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit</a>
+        <a href="https://github.com/PalomarRegistry/PalomarSubmission/issues/new?template=submit.yml">Submit</a>
       </nav>
     </header>
 
@@ -81,7 +81,7 @@
             fair rendering of the mathematical claim made in the recorded
             informal statement (in <a href="https://github.com/mathlib-initiative/formalization.yaml"><code>formalization.yaml</code></a>), and that the
             submission clears Palomar’s
-            <a href="https://github.com/kim-em/PalomarPolicy/blob/main/CONTRIBUTING.md">published minimum standard</a>.
+            <a href="https://github.com/PalomarRegistry/PalomarPolicy/blob/main/CONTRIBUTING.md">published minimum standard</a>.
             That standard includes a floor on research interest, which requires
             the model to judge both of these to be answered yes:
             <ol>
@@ -101,7 +101,7 @@
         <p>
           The passes the language model runs, the prompts it is given, and the
           report it must produce are published in
-          <a href="https://github.com/kim-em/PalomarPolicy">PalomarPolicy</a>.
+          <a href="https://github.com/PalomarRegistry/PalomarPolicy">PalomarPolicy</a>.
         </p>
         <p>
           All three checks run automatically, and a submission that passes them
@@ -134,7 +134,7 @@
           <li>
             <strong>Palomar’s formal certification is not absolute.</strong> As
             described in
-            <a href="https://github.com/kim-em/PalomarSubmission/blob/main/SECURITY.md">SECURITY.md</a>,
+            <a href="https://github.com/PalomarRegistry/PalomarSubmission/blob/main/SECURITY.md">SECURITY.md</a>,
             Palomar makes its best efforts to formally verify the claimed
             results in Lean in a secure, sandboxed environment. However, it is
             still possible that the version of the Lean kernel, Mathlib cache,
@@ -317,7 +317,7 @@
           tag that can change.
         </p>
         <p>
-          The <a href="https://github.com/kim-em/PalomarTemplate">Palomar starter repository</a>
+          The <a href="https://github.com/PalomarRegistry/PalomarTemplate">Palomar starter repository</a>
           provides this layout, pinned dependencies, documentation generation,
           CI checks for Lean and Comparator, and a documented
           <a href="https://github.com/mathlib-initiative/formalization.yaml"><code>formalization.yaml</code></a> starting point.
@@ -326,7 +326,7 @@
           For a complete public example, see the
           <a href="https://github.com/kim-em/erdos-unit-distance-comparator">source repository</a>
           for Palomar’s
-          <a href="https://kim-em.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000001&amp;version=2">first registered result</a>.
+          <a href="https://palomarregistry.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000001&amp;version=2">first registered result</a>.
         </p>
         <p>
           The repository root is the default project directory, so the usual
@@ -411,7 +411,7 @@
           limitations. Follow the
           <a href="https://github.com/mathlib-initiative/formalization.yaml">formalization.yaml standard</a>
           and Palomar’s
-          <a href="https://github.com/kim-em/PalomarPolicy/blob/main/CONTRIBUTING.md">submission policy</a>.
+          <a href="https://github.com/PalomarRegistry/PalomarPolicy/blob/main/CONTRIBUTING.md">submission policy</a>.
         </p>
         <p>
           A source may be a book, journal article, non-arXiv preprint, web
@@ -436,7 +436,7 @@
         <h2>How to submit</h2>
         <ol>
           <li>Push the final snapshot to a public GitHub repository and copy its full 40-character commit SHA.</li>
-          <li><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Open the short submission form</a>. Enter the repository URL and commit SHA. Leave the optional project, Comparator-config, and metadata paths blank for the normal root layout; fill them only for a nested or non-default layout. Record whether you maintain the substantive formalization or have approval from someone who does, confirm the required acknowledgements, and, for a correction to an existing entry, enter its Palomar ID.</li>
+          <li><a href="https://github.com/PalomarRegistry/PalomarSubmission/issues/new?template=submit.yml">Open the short submission form</a>. Enter the repository URL and commit SHA. Leave the optional project, Comparator-config, and metadata paths blank for the normal root layout; fill them only for a nested or non-default layout. Record whether you maintain the substantive formalization or have approval from someone who does, confirm the required acknowledgements, and, for a correction to an existing entry, enter its Palomar ID.</li>
           <li>Submit the issue and watch it for status labels and comments. The issue is the public home for verification and review.</li>
         </ol>
         <p>
@@ -531,14 +531,14 @@
 
       <section id="ready-to-submit" class="cta">
         <div><h2>Ready to submit?</h2><p>The form asks for a repository and one fixed commit.</p></div>
-        <a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Open the submission form</a>
+        <a href="https://github.com/PalomarRegistry/PalomarSubmission/issues/new?template=submit.yml">Open the submission form</a>
       </section>
       <span id="anchor-status" class="visually-hidden" role="status"></span>
     </main>
 
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/kim-em/PalomarPolicy">Policy</a><a href="https://github.com/kim-em/PalomarDatabase">Data</a><a href="https://github.com/kim-em/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="https://github.com/PalomarRegistry/PalomarDatabase">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/about.js"></script>
   </body>

--- a/assets/app.js
+++ b/assets/app.js
@@ -22,9 +22,9 @@ import {
   workflowRunId,
 } from "./security.mjs";
 
-const CANONICAL_WEB_BASE = "https://kim-em.github.io/PalomarWeb/";
-const FEED_BASE = "https://kim-em.github.io/PalomarDatabase/feeds/";
-const DATABASE_SOURCE_BASE = "https://github.com/kim-em/PalomarDatabase/blob/main/";
+const CANONICAL_WEB_BASE = "https://palomarregistry.github.io/PalomarWeb/";
+const FEED_BASE = "https://palomarregistry.github.io/PalomarDatabase/feeds/";
+const DATABASE_SOURCE_BASE = "https://github.com/PalomarRegistry/PalomarDatabase/blob/main/";
 
 const params = new URLSearchParams(window.location.search);
 const PALOMAR_ID = /^PALOMAR-\d{4}-\d{2}-\d{2}-\d{6}$/;

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -1,14 +1,22 @@
 export const INDEX_SCHEMA_VERSION = 2;
 export const ENTRY_SCHEMA_VERSIONS = new Set([2, 3, 4, 5, 6]);
 export const DEFAULT_DATABASE =
-  "https://raw.githubusercontent.com/kim-em/PalomarDatabase/main/index.json";
-export const DEFAULT_RENDER_BASE = "https://kim-em.github.io/PalomarDatabase/";
+  "https://raw.githubusercontent.com/PalomarRegistry/PalomarDatabase/main/index.json";
+export const DEFAULT_RENDER_BASE = "https://palomarregistry.github.io/PalomarDatabase/";
 
 export function supportsProjectPaths(entry) {
   return entry?.schema_version === 6;
 }
 
-const SUBMISSION_REPOSITORY = "kim-em/PalomarSubmission";
+// Palomar moved from a personal account to the PalomarRegistry organisation on
+// 2026-08-04. Records published before the move name the old repository and are
+// immutable, so both are canonical forever. A record must still be internally
+// consistent: every derived URL below comes from the repository the record
+// itself names, and that repository must be one of these.
+const SUBMISSION_REPOSITORIES = new Set([
+  "kim-em/PalomarSubmission",
+  "PalomarRegistry/PalomarSubmission",
+]);
 const ID_RE = /^PALOMAR-([0-9]{4}-[0-9]{2}-[0-9]{2})-([0-9]{6})$/;
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const COMMIT_RE = /^[0-9a-f]{40}$/;
@@ -211,10 +219,11 @@ function validateCanonicalRecordLinks(entry) {
   if (identifier[1] !== entry.accepted_at) fail("entry ID date does not match accepted_at");
   const issue = Number(identifier[2]);
   const submission = entry.submission;
+  const submissionRepository = submission.repository;
   if (
-    submission.repository !== SUBMISSION_REPOSITORY ||
+    !SUBMISSION_REPOSITORIES.has(submissionRepository) ||
     submission.issue !== issue ||
-    submission.url !== `https://github.com/${SUBMISSION_REPOSITORY}/issues/${issue}`
+    submission.url !== `https://github.com/${submissionRepository}/issues/${issue}`
   ) {
     fail("submission evidence does not match the Palomar ID and canonical issue");
   }
@@ -238,7 +247,7 @@ function validateCanonicalRecordLinks(entry) {
   }
   safeExternalUrl(source.tree_url);
 
-  const runPrefix = `https://github.com/${SUBMISSION_REPOSITORY}/actions/runs/`;
+  const runPrefix = `https://github.com/${submissionRepository}/actions/runs/`;
   const runId = entry.verification.workflow_url.slice(runPrefix.length);
   if (
     !entry.verification.workflow_url.startsWith(runPrefix) ||
@@ -248,7 +257,7 @@ function validateCanonicalRecordLinks(entry) {
   }
 
   const reportPrefix =
-    `https://github.com/${SUBMISSION_REPOSITORY}/issues/${issue}#issuecomment-`;
+    `https://github.com/${submissionRepository}/issues/${issue}#issuecomment-`;
   const commentId = entry.review.report_url.slice(reportPrefix.length);
   if (!entry.review.report_url.startsWith(reportPrefix) || !POSITIVE_INTEGER_RE.test(commentId)) {
     fail("review.report_url is not a canonical report comment for this Palomar ID");

--- a/entry.html
+++ b/entry.html
@@ -4,16 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#ffffff">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; frame-src 'self' https://kim-em.github.io; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; frame-src 'self' https://palomarregistry.github.io; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Registry entry — Palomar</title>
     <link rel="stylesheet" href="assets/style.css">
-    <link rel="alternate" type="application/rss+xml" title="Palomar accepted results" href="https://kim-em.github.io/PalomarDatabase/feed.xml">
+    <link rel="alternate" type="application/rss+xml" title="Palomar accepted results" href="https://palomarregistry.github.io/PalomarDatabase/feed.xml">
   </head>
   <body data-page="entry">
     <a class="skip-link" href="#entry">Skip to entry</a>
     <header class="site-header">
       <a class="brand" href="./">Palomar</a>
-      <nav aria-label="Main navigation"><a href="./">Registry</a><a href="about.html">About</a><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit</a></nav>
+      <nav aria-label="Main navigation"><a href="./">Registry</a><a href="about.html">About</a><a href="https://github.com/PalomarRegistry/PalomarSubmission/issues/new?template=submit.yml">Submit</a></nav>
     </header>
     <main id="entry" class="entry-page">
       <div id="status" class="status">
@@ -22,14 +22,14 @@
           <br>
           Entry pages require JavaScript because they read immutable records from
           PalomarDatabase at runtime. You can instead
-          <a href="https://github.com/kim-em/PalomarDatabase/tree/main/entries">browse the JSON records directly</a>.
+          <a href="https://github.com/PalomarRegistry/PalomarDatabase/tree/main/entries">browse the JSON records directly</a>.
         </noscript>
       </div>
       <article id="entry-content" hidden></article>
     </main>
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/kim-em/PalomarPolicy">Policy</a><a href="https://github.com/kim-em/PalomarDatabase">Data</a><a href="https://github.com/kim-em/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="https://github.com/PalomarRegistry/PalomarDatabase">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/app.js"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -5,11 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="A public registry of Lean-verified mathematical results.">
     <meta name="theme-color" content="#ffffff">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; frame-src 'self' https://kim-em.github.io; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; frame-src 'self' https://palomarregistry.github.io; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Palomar — Lean-verified mathematics</title>
     <link rel="stylesheet" href="assets/style.css">
     <link rel="manifest" href="site.webmanifest">
-    <link rel="alternate" type="application/rss+xml" title="Palomar accepted results" href="https://kim-em.github.io/PalomarDatabase/feed.xml">
+    <link rel="alternate" type="application/rss+xml" title="Palomar accepted results" href="https://palomarregistry.github.io/PalomarDatabase/feed.xml">
   </head>
   <body data-page="index">
     <a class="skip-link" href="#registry">Skip to registry</a>
@@ -18,7 +18,7 @@
       <nav aria-label="Main navigation">
         <a class="active" href="./" aria-current="page">Registry</a>
         <a href="about.html">About</a>
-        <a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit</a>
+        <a href="https://github.com/PalomarRegistry/PalomarSubmission/issues/new?template=submit.yml">Submit</a>
       </nav>
     </header>
 
@@ -39,7 +39,7 @@
       <section class="registry-section" id="registry" aria-labelledby="registry-heading">
         <div class="section-heading">
           <h2 id="registry-heading">Accepted results</h2>
-          <a class="data-link" href="https://github.com/kim-em/PalomarDatabase">
+          <a class="data-link" href="https://github.com/PalomarRegistry/PalomarDatabase">
             Raw data and schema
           </a>
         </div>
@@ -73,7 +73,7 @@
             <br>
             The registry requires JavaScript because it reads PalomarDatabase at
             runtime. You can instead
-            <a href="https://github.com/kim-em/PalomarDatabase/tree/main/entries">browse the JSON records directly</a>.
+            <a href="https://github.com/PalomarRegistry/PalomarDatabase/tree/main/entries">browse the JSON records directly</a>.
           </noscript>
         </div>
         <div id="entry-grid" class="entry-grid" aria-live="polite"></div>
@@ -86,11 +86,11 @@
         <span> — a registry of Lean-verified results</span>
       </div>
       <div class="footer-links">
-        <a href="https://kim-em.github.io/PalomarDatabase/feed.xml">RSS</a>
-        <a href="https://github.com/kim-em/PalomarPolicy">Policy</a>
-        <a href="https://github.com/kim-em/PalomarDatabase">Data</a>
+        <a href="https://palomarregistry.github.io/PalomarDatabase/feed.xml">RSS</a>
+        <a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a>
+        <a href="https://github.com/PalomarRegistry/PalomarDatabase">Data</a>
         <a href="https://github.com/leanprover/comparator">Comparator</a>
-        <a href="https://github.com/kim-em/PalomarWeb">Source</a>
+        <a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a>
       </div>
     </footer>
     <script type="module" src="assets/app.js"></script>

--- a/render.html
+++ b/render.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#ffffff">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; frame-src 'self' https://kim-em.github.io; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; frame-src 'self' https://palomarregistry.github.io; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Named compared declarations — Palomar</title>
     <link rel="stylesheet" href="assets/style.css">
   </head>
@@ -12,7 +12,7 @@
     <a class="skip-link" href="#render">Skip to named compared declarations</a>
     <header class="site-header">
       <a class="brand" href="./">Palomar</a>
-      <nav aria-label="Main navigation"><a href="./">Registry</a><a href="about.html">About</a><a href="https://github.com/kim-em/PalomarSubmission/issues/new?template=submit.yml">Submit</a></nav>
+      <nav aria-label="Main navigation"><a href="./">Registry</a><a href="about.html">About</a><a href="https://github.com/PalomarRegistry/PalomarSubmission/issues/new?template=submit.yml">Submit</a></nav>
     </header>
     <main id="render" class="entry-page render-page">
       <div id="status" class="status">Reading registry entry…</div>
@@ -20,7 +20,7 @@
     </main>
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/kim-em/PalomarPolicy">Policy</a><a href="https://github.com/kim-em/PalomarDatabase">Data</a><a href="https://github.com/kim-em/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="https://github.com/PalomarRegistry/PalomarDatabase">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/app.js"></script>
   </body>

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -39,9 +39,9 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
             "related_formalizations": [],
         },
         "submission": {
-            "repository": "kim-em/PalomarSubmission",
+            "repository": "PalomarRegistry/PalomarSubmission",
             "issue": issue,
-            "url": f"https://github.com/kim-em/PalomarSubmission/issues/{issue}",
+            "url": f"https://github.com/PalomarRegistry/PalomarSubmission/issues/{issue}",
             "submitter": "example",
             "authorization": {"relationship": "maintainer"},
         },
@@ -79,7 +79,7 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
             "lean4export_commit": "3" * 40,
             "landrun_commit": "4" * 40,
             "nanoda_commit": "9" * 40,
-            "workflow_url": "https://github.com/kim-em/PalomarSubmission/actions/runs/12345",
+            "workflow_url": "https://github.com/PalomarRegistry/PalomarSubmission/actions/runs/12345",
             "challenge_sha256": "b" * 64,
             "solution_sha256": "c" * 64,
             "verified_at": "2026-07-29T08:46:32Z",
@@ -111,7 +111,7 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
             },
             "warnings": [],
             "report_url": (
-                "https://github.com/kim-em/PalomarSubmission/issues/"
+                "https://github.com/PalomarRegistry/PalomarSubmission/issues/"
                 f"{issue}#issuecomment-456"
             ),
         },

--- a/tests/rendering.test.js
+++ b/tests/rendering.test.js
@@ -48,8 +48,8 @@ test("inline policy includes both size limits and exactly one declaration", () =
 
 test("artifact URL is derived only from the content-addressed registry fields", () => {
   assert.equal(
-    challengeArtifactUrl(entry(), "https://kim-em.github.io/PalomarDatabase/").href,
-    `https://kim-em.github.io/PalomarDatabase/renders/PALOMAR-2026-07-29-000123-v1/${"a".repeat(64)}/Challenge/index.html`,
+    challengeArtifactUrl(entry(), "https://palomarregistry.github.io/PalomarDatabase/").href,
+    `https://palomarregistry.github.io/PalomarDatabase/renders/PALOMAR-2026-07-29-000123-v1/${"a".repeat(64)}/Challenge/index.html`,
   );
   const traversal = entry();
   traversal.challenge_render.artifact_path = "renders/../../attacker/";
@@ -58,8 +58,8 @@ test("artifact URL is derived only from the content-addressed registry fields", 
 
 test("artifact metadata URL stays inside the content-addressed bundle", () => {
   assert.equal(
-    challengeMetadataUrl(entry(), "https://kim-em.github.io/PalomarDatabase/").href,
-    `https://kim-em.github.io/PalomarDatabase/renders/PALOMAR-2026-07-29-000123-v1/${"a".repeat(64)}/challenge-metadata.json`,
+    challengeMetadataUrl(entry(), "https://palomarregistry.github.io/PalomarDatabase/").href,
+    `https://palomarregistry.github.io/PalomarDatabase/renders/PALOMAR-2026-07-29-000123-v1/${"a".repeat(64)}/challenge-metadata.json`,
   );
 });
 

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -50,9 +50,9 @@ function entry(overrides = {}) {
     abstract: "A security fixture.",
     authors: [{ name: "Example" }],
     submission: {
-      repository: "kim-em/PalomarSubmission",
+      repository: "PalomarRegistry/PalomarSubmission",
       issue: 123,
-      url: "https://github.com/kim-em/PalomarSubmission/issues/123",
+      url: "https://github.com/PalomarRegistry/PalomarSubmission/issues/123",
       submitter: "example",
     },
     source: {
@@ -80,7 +80,7 @@ function entry(overrides = {}) {
       landrun_commit: "4".repeat(40),
       nanoda_commit: "9".repeat(40),
       verified_at: "2026-07-29T08:46:32Z",
-      workflow_url: "https://github.com/kim-em/PalomarSubmission/actions/runs/12345",
+      workflow_url: "https://github.com/PalomarRegistry/PalomarSubmission/actions/runs/12345",
       challenge_sha256: DIGEST,
       solution_sha256: "b".repeat(64),
     },
@@ -97,7 +97,7 @@ function entry(overrides = {}) {
       policy_commit: "5".repeat(40),
       verdict: "accept",
       report_url:
-        "https://github.com/kim-em/PalomarSubmission/issues/123#issuecomment-456",
+        "https://github.com/PalomarRegistry/PalomarSubmission/issues/123#issuecomment-456",
       scores: { clarity: 5 },
       reviewer_models: ["fixture:model"],
       warnings: [],
@@ -124,7 +124,7 @@ test("production ignores every database query override", () => {
   ]) {
     assert.equal(
       selectDatabaseUrl(
-        "https://kim-em.github.io/PalomarWeb/",
+        "https://palomarregistry.github.io/PalomarWeb/",
         `?database=${encodeURIComponent(override)}`,
       ).href,
       DEFAULT_DATABASE,
@@ -135,7 +135,7 @@ test("production ignores every database query override", () => {
 test("production also pins the rendered-Challenge origin", () => {
   assert.equal(
     selectRenderBase(
-      "https://kim-em.github.io/PalomarWeb/",
+      "https://palomarregistry.github.io/PalomarWeb/",
       "?render-base=https://attacker.invalid/",
       "https://attacker.invalid/database/",
     ).href,
@@ -480,7 +480,7 @@ test("record evidence links must agree with their canonical values", () => {
 
   const wrongSubmission = entry();
   wrongSubmission.submission.url =
-    "https://github.com/kim-em/PalomarSubmission/issues/999";
+    "https://github.com/PalomarRegistry/PalomarSubmission/issues/999";
   assert.throws(
     () => validateEntry(wrongSubmission, summary()),
     /submission evidence does not match/,
@@ -496,7 +496,7 @@ test("record evidence links must agree with their canonical values", () => {
 
   const wrongReview = entry();
   wrongReview.review.report_url =
-    "https://github.com/kim-em/PalomarSubmission/issues/999#issuecomment-456";
+    "https://github.com/PalomarRegistry/PalomarSubmission/issues/999#issuecomment-456";
   assert.throws(() => validateEntry(wrongReview, summary()), /report_url is not a canonical/);
 });
 
@@ -530,7 +530,7 @@ test("every HTML entry point carries the restrictive CSP", async () => {
     assert.match(html, /Content-Security-Policy/);
     assert.match(html, /default-src 'none'/);
     assert.match(html, /script-src 'self'/);
-    assert.match(html, /frame-src 'self' https:\/\/kim-em\.github\.io/);
+    assert.match(html, /frame-src 'self' https:\/\/palomarregistry\.github\.io/);
     assert.match(html, /object-src 'none'/);
   }
 });
@@ -541,4 +541,46 @@ test("About states the repository licence boundary", async () => {
   assert.match(about, /reused formalizations, and\s+dependencies retain their own licences/);
   assert.match(about, /repository root is the default project directory/);
   assert.match(about, /licence file remains at repository root/);
+});
+
+// Palomar moved to the PalomarRegistry organisation on 2026-08-04. Records
+// published before the move are immutable and name the old repository, so both
+// are canonical, and a record must still be internally consistent about which.
+
+function withSubmissionRepository(repository) {
+  return entry({
+    submission: {
+      repository,
+      issue: 123,
+      url: `https://github.com/${repository}/issues/123`,
+      submitter: "example",
+    },
+    verification: {
+      ...entry().verification,
+      workflow_url: `https://github.com/${repository}/actions/runs/12345`,
+    },
+    review: {
+      ...entry().review,
+      report_url: `https://github.com/${repository}/issues/123#issuecomment-456`,
+    },
+  });
+}
+
+test("a record published before the organisation move still validates", () => {
+  const historical = withSubmissionRepository("kim-em/PalomarSubmission");
+  assert.equal(validateEntry(historical, summary()).id, "PALOMAR-2026-07-29-000123");
+});
+
+test("an unknown submission repository is refused", () => {
+  assert.throws(
+    () => validateEntry(withSubmissionRepository("attacker/PalomarSubmission"), summary()),
+    /submission evidence does not match/,
+  );
+});
+
+test("submission, run, and report links must name the same repository", () => {
+  const mixed = withSubmissionRepository("PalomarRegistry/PalomarSubmission");
+  mixed.review.report_url =
+    "https://github.com/kim-em/PalomarSubmission/issues/123#issuecomment-456";
+  assert.throws(() => validateEntry(mixed, summary()), /review.report_url is not a canonical/);
 });

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -168,7 +168,7 @@ test("an unversioned entry link resolves to the current immutable URL", async ({
   await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
     "href",
-    "https://kim-em.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000123&version=2",
+    "https://palomarregistry.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000123&version=2",
   );
 });
 
@@ -202,7 +202,7 @@ test("entry pages list immutable versions and flag superseded snapshots", async 
   );
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
     "href",
-    "https://kim-em.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000123&version=1",
+    "https://palomarregistry.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000123&version=1",
   );
 });
 


### PR DESCRIPTION
This PR repoints the site after the move to the PalomarRegistry organisation, and replaces the single hard-coded submission repository with a check that survives the move.

GitHub redirects repository, blob, tree and raw URLs after a transfer, but it does not redirect GitHub Pages URLs at all, so `DEFAULT_RENDER_BASE` was pointing at a dead host the moment the transfer completed. The database source, render base, feed base, canonical web base, RSS links and the CSP `frame-src` all move to `palomarregistry.github.io`.

The more interesting change is in `assets/security.mjs`. It previously derived the expected issue, Actions run and report-comment URLs from one `SUBMISSION_REPOSITORY` constant, so repointing that constant would have rejected all three published records, whose `submission.repository` is immutably `kim-em/PalomarSubmission`. Validation now takes the repository from the record's own `submission.repository`, requires it to be one of the known Palomar submission repositories, and derives every URL from that. A record that names one repository but links to another is still refused, which is what keeps this exactly as strong as the single-constant version rather than merely more permissive.

Three tests cover the new behaviour: a pre-move record still validates, an unknown submission repository is refused, and a record mixing the two repositories is refused. All 28 unit tests pass.

I could not run the Playwright suite locally: the downloaded Chromium cannot find `libglib-2.0.so.0` on this host and installing system dependencies needs sudo. CI runs it with `--with-deps`, so the browser tests are unverified by me and CI is the check here.

These hosts move once more when `palomar-registry.org` is in place. Splitting it in two keeps a migration failure distinguishable from a DNS failure.

🤖 Prepared with Claude Code