### PR TITLE
feat: serve renders from their own origin

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#ffffff">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; frame-src 'self' https://palomarregistry.github.io; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Not found — Palomar</title>
     <link rel="stylesheet" href="assets/style.css">
   </head>

--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="About Palomar and submitting machine-checked formal mathematics.">
     <meta name="theme-color" content="#ffffff">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; frame-src 'self' https://palomarregistry.github.io; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>About — Palomar</title>
     <link rel="stylesheet" href="assets/style.css">
   </head>

--- a/assets/app.js
+++ b/assets/app.js
@@ -23,7 +23,7 @@ import {
 } from "./security.mjs";
 
 const CANONICAL_WEB_BASE = "https://palomarregistry.github.io/PalomarWeb/";
-const FEED_BASE = "https://palomarregistry.github.io/PalomarDatabase/feeds/";
+const FEED_BASE = "https://data.palomar-registry.org/feeds/";
 const DATABASE_SOURCE_BASE = "https://github.com/PalomarRegistry/PalomarDatabase/blob/main/";
 
 const params = new URLSearchParams(window.location.search);

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -2,7 +2,7 @@ export const INDEX_SCHEMA_VERSION = 2;
 export const ENTRY_SCHEMA_VERSIONS = new Set([2, 3, 4, 5, 6]);
 export const DEFAULT_DATABASE =
   "https://raw.githubusercontent.com/PalomarRegistry/PalomarDatabase/main/index.json";
-export const DEFAULT_RENDER_BASE = "https://palomarregistry.github.io/PalomarDatabase/";
+export const DEFAULT_RENDER_BASE = "https://data.palomar-registry.org/";
 
 export function supportsProjectPaths(entry) {
   return entry?.schema_version === 6;

--- a/entry.html
+++ b/entry.html
@@ -4,10 +4,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#ffffff">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; frame-src 'self' https://palomarregistry.github.io; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Registry entry — Palomar</title>
     <link rel="stylesheet" href="assets/style.css">
-    <link rel="alternate" type="application/rss+xml" title="Palomar accepted results" href="https://palomarregistry.github.io/PalomarDatabase/feed.xml">
+    <link rel="alternate" type="application/rss+xml" title="Palomar accepted results" href="https://data.palomar-registry.org/feed.xml">
   </head>
   <body data-page="entry">
     <a class="skip-link" href="#entry">Skip to entry</a>

--- a/index.html
+++ b/index.html
@@ -5,11 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="A public registry of Lean-verified mathematical results.">
     <meta name="theme-color" content="#ffffff">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; frame-src 'self' https://palomarregistry.github.io; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Palomar — Lean-verified mathematics</title>
     <link rel="stylesheet" href="assets/style.css">
     <link rel="manifest" href="site.webmanifest">
-    <link rel="alternate" type="application/rss+xml" title="Palomar accepted results" href="https://palomarregistry.github.io/PalomarDatabase/feed.xml">
+    <link rel="alternate" type="application/rss+xml" title="Palomar accepted results" href="https://data.palomar-registry.org/feed.xml">
   </head>
   <body data-page="index">
     <a class="skip-link" href="#registry">Skip to registry</a>
@@ -86,7 +86,7 @@
         <span> — a registry of Lean-verified results</span>
       </div>
       <div class="footer-links">
-        <a href="https://palomarregistry.github.io/PalomarDatabase/feed.xml">RSS</a>
+        <a href="https://data.palomar-registry.org/feed.xml">RSS</a>
         <a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a>
         <a href="https://github.com/PalomarRegistry/PalomarDatabase">Data</a>
         <a href="https://github.com/leanprover/comparator">Comparator</a>

--- a/render.html
+++ b/render.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#ffffff">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; frame-src 'self' https://palomarregistry.github.io; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Named compared declarations — Palomar</title>
     <link rel="stylesheet" href="assets/style.css">
   </head>

--- a/tests/rendering.test.js
+++ b/tests/rendering.test.js
@@ -48,8 +48,8 @@ test("inline policy includes both size limits and exactly one declaration", () =
 
 test("artifact URL is derived only from the content-addressed registry fields", () => {
   assert.equal(
-    challengeArtifactUrl(entry(), "https://palomarregistry.github.io/PalomarDatabase/").href,
-    `https://palomarregistry.github.io/PalomarDatabase/renders/PALOMAR-2026-07-29-000123-v1/${"a".repeat(64)}/Challenge/index.html`,
+    challengeArtifactUrl(entry(), "https://data.palomar-registry.org/").href,
+    `https://data.palomar-registry.org/renders/PALOMAR-2026-07-29-000123-v1/${"a".repeat(64)}/Challenge/index.html`,
   );
   const traversal = entry();
   traversal.challenge_render.artifact_path = "renders/../../attacker/";
@@ -58,8 +58,8 @@ test("artifact URL is derived only from the content-addressed registry fields", 
 
 test("artifact metadata URL stays inside the content-addressed bundle", () => {
   assert.equal(
-    challengeMetadataUrl(entry(), "https://palomarregistry.github.io/PalomarDatabase/").href,
-    `https://palomarregistry.github.io/PalomarDatabase/renders/PALOMAR-2026-07-29-000123-v1/${"a".repeat(64)}/challenge-metadata.json`,
+    challengeMetadataUrl(entry(), "https://data.palomar-registry.org/").href,
+    `https://data.palomar-registry.org/renders/PALOMAR-2026-07-29-000123-v1/${"a".repeat(64)}/challenge-metadata.json`,
   );
 });
 

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -21,6 +21,9 @@ import {
   validateIndex,
 } from "../assets/security.mjs";
 
+// The website's own origin, for the cross-origin assertion below.
+const CANONICAL_WEB_BASE_FOR_TEST = "https://palomarregistry.github.io/PalomarWeb/";
+
 const COMMIT = "1".repeat(40);
 const DIGEST = "a".repeat(64);
 
@@ -124,7 +127,7 @@ test("production ignores every database query override", () => {
   ]) {
     assert.equal(
       selectDatabaseUrl(
-        "https://palomarregistry.github.io/PalomarWeb/",
+        "https://data.palomar-registry.org/PalomarWeb/",
         `?database=${encodeURIComponent(override)}`,
       ).href,
       DEFAULT_DATABASE,
@@ -135,7 +138,7 @@ test("production ignores every database query override", () => {
 test("production also pins the rendered-Challenge origin", () => {
   assert.equal(
     selectRenderBase(
-      "https://palomarregistry.github.io/PalomarWeb/",
+      "https://data.palomar-registry.org/PalomarWeb/",
       "?render-base=https://attacker.invalid/",
       "https://attacker.invalid/database/",
     ).href,
@@ -530,9 +533,26 @@ test("every HTML entry point carries the restrictive CSP", async () => {
     assert.match(html, /Content-Security-Policy/);
     assert.match(html, /default-src 'none'/);
     assert.match(html, /script-src 'self'/);
-    assert.match(html, /frame-src 'self' https:\/\/palomarregistry\.github\.io/);
+    assert.match(html, /frame-src 'self' https:\/\/data\.palomar-registry\.org/);
+    // The render origin is fetched as well as framed: app.js reads
+    // challenge-metadata.json from it. While the site and the renders shared
+    // an origin, connect-src 'self' covered that silently. It does not now,
+    // and omitting it fails only in the browser console.
+    assert.match(
+      html,
+      /connect-src 'self' https:\/\/raw\.githubusercontent\.com https:\/\/data\.palomar-registry\.org/,
+    );
     assert.match(html, /object-src 'none'/);
   }
+});
+
+test("the render origin is a different origin from the site", () => {
+  // The iframe sandbox omits allow-same-origin, but that should not be the
+  // only thing separating a submitter's rendered output from the registry.
+  const site = new URL(CANONICAL_WEB_BASE_FOR_TEST);
+  const renders = new URL(DEFAULT_RENDER_BASE);
+  assert.notStrictEqual(renders.origin, site.origin);
+  assert.strictEqual(renders.protocol, "https:");
 });
 
 test("About states the repository licence boundary", async () => {


### PR DESCRIPTION
This PR gives Challenge renders their own web origin, closing the follow-up recorded in `PalomarDatabase/docs/render-origin.md`.

A render bundle is untrusted output derived from a submitter's Lean source. It is framed with `sandbox="allow-scripts"` and deliberately without `allow-same-origin`, so the framed document receives an opaque origin. Until now the website and the bundles both lived on `palomarregistry.github.io`, which meant that one sandbox attribute was the *only* thing separating them. That note called a separately governed origin the intended design and said it was blocked purely on not controlling DNS.

Renders and feeds now come from `data.palomar-registry.org`, a GitHub Pages custom domain on `PalomarDatabase`. The hostname is deliberately not `renders`: a Pages custom domain moves the entire site, so the RSS feeds move with it, and naming the host after only one of the two things it serves would have been a small permanent lie in URLs that are meant to be subscribed to.

**The part worth reviewing is `connect-src`.** `app.js` fetches `challenge-metadata.json` from the render base. While the site and the renders shared an origin, `connect-src 'self'` covered that silently. It does not once they differ, and a blocked fetch shows up only in the browser console, so it is exactly the kind of thing that ships broken. Both `connect-src` and `frame-src` now name the new origin, the CSP test asserts both, and a further test asserts the render origin and the site origin genuinely differ rather than trusting the strings to stay in step.

Verified against the live origin before merging: renders, `challenge-metadata.json`, `feed.xml` and the per-subject feeds all serve over HTTPS, `access-control-allow-origin: *` is present, and the old `palomarregistry.github.io/PalomarDatabase/` paths 301 across.

29 unit tests and 16 browser tests pass, the latter run locally against a Nix-provided Chromium. I checked the `connect-src` assertion is not vacuous by removing the directive from one file and confirming the suite fails.

🤖 Prepared with Claude Code