### PR TITLE
feat: serve the website from palomar-registry.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ history when older snapshots exist.
 An entry URL with both `id` and `version` identifies one immutable snapshot:
 
 ```text
-https://palomarregistry.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000001&version=1
+https://palomar-registry.org/entry.html?id=PALOMAR-2026-07-29-000001&version=1
 ```
 
 Its HTML canonical link points to that same official, explicit version,

--- a/about.html
+++ b/about.html
@@ -326,7 +326,7 @@
           For a complete public example, see the
           <a href="https://github.com/kim-em/erdos-unit-distance-comparator">source repository</a>
           for Palomar’s
-          <a href="https://palomarregistry.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000001&amp;version=2">first registered result</a>.
+          <a href="https://palomar-registry.org/entry.html?id=PALOMAR-2026-07-29-000001&amp;version=2">first registered result</a>.
         </p>
         <p>
           The repository root is the default project directory, so the usual

--- a/assets/app.js
+++ b/assets/app.js
@@ -25,7 +25,7 @@ import {
   workflowRunId,
 } from "./security.mjs";
 
-const CANONICAL_WEB_BASE = "https://palomarregistry.github.io/PalomarWeb/";
+const CANONICAL_WEB_BASE = "https://palomar-registry.org/";
 const FEED_BASE = "https://data.palomar-registry.org/feeds/";
 const DATABASE_SOURCE_BASE = "https://github.com/PalomarRegistry/PalomarDatabase/blob/main/";
 

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -25,7 +25,7 @@ import {
 } from "../assets/security.mjs";
 
 // The website's own origin, for the cross-origin assertion below.
-const CANONICAL_WEB_BASE_FOR_TEST = "https://palomarregistry.github.io/PalomarWeb/";
+const CANONICAL_WEB_BASE_FOR_TEST = "https://palomar-registry.org/";
 
 const COMMIT = "1".repeat(40);
 const DIGEST = "a".repeat(64);

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -168,7 +168,7 @@ test("an unversioned entry link resolves to the current immutable URL", async ({
   await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
     "href",
-    "https://palomarregistry.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000123&version=2",
+    "https://palomar-registry.org/entry.html?id=PALOMAR-2026-07-29-000123&version=2",
   );
 });
 
@@ -202,7 +202,7 @@ test("entry pages list immutable versions and flag superseded snapshots", async 
   );
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
     "href",
-    "https://palomarregistry.github.io/PalomarWeb/entry.html?id=PALOMAR-2026-07-29-000123&version=1",
+    "https://palomar-registry.org/entry.html?id=PALOMAR-2026-07-29-000123&version=1",
   );
 });
 


### PR DESCRIPTION
Puts the site on the domain. It previously carried only the render origin, so `palomar-registry.org` resolved to nothing.

Apex A/AAAA records point at GitHub Pages, `www` is a CNAME, both DNS-only so GitHub can issue the certificate. `CANONICAL_WEB_BASE` and the test expectations follow.

🤖 Prepared with Claude Code