### PR TITLE
refactor: display the one schema the registry publishes

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -8,18 +8,15 @@ import {
   databaseBaseFor,
   RESULT_ORIGIN_LABELS,
   REPOSITORY_ROLE_LABELS,
-  UNSTATED_PROVENANCE,
   entryRecordUrl,
   isLoopbackHostname,
   pinnedSourceDirectoryUrl,
   pinnedSourceFileUrl,
-  reportIssueNumber,
   safeDataUrl,
   safeExternalUrl,
   safeInternalUrl,
   selectDatabaseUrl,
   selectRenderBase,
-  supportsProjectPaths,
   validateEntry,
   validateIndex,
   workflowRunId,
@@ -163,7 +160,7 @@ function entryCard(entry, versionCount) {
     authorNames(entry),
     theoremNames(entry),
     entry.source.repository,
-    supportsProjectPaths(entry) ? entry.source.project_path || "" : "",
+    entry.source.project_path || "",
     entry.id,
     ...categories.arxiv,
     ...categories.msc2020,
@@ -187,7 +184,7 @@ function entryCard(entry, versionCount) {
   const subjects = el("div", "card-subjects");
   subjects.append(el("small", "", "Subjects"), categoryTokens(entry));
   meta.append(authors, theorems, subjects);
-  if (supportsProjectPaths(entry) && entry.source.project_path) {
+  if (entry.source.project_path) {
     const project = el("div", "card-project");
     project.append(
       el("small", "", "Project directory"),
@@ -638,21 +635,17 @@ function acceptanceCallout(entry) {
   check.setAttribute("aria-hidden", "true");
   const copy = el("div");
   const evidenceLinks = el("p", "certificate-evidence-links");
-  if (entry.schema_version >= 5) {
-    evidenceLinks.append(
-      externalLink(
-        "Archived mechanical report",
-        `${DATABASE_SOURCE_BASE}${entry.verification.evidence_path}mechanical-report.json`,
-      ),
-      " · ",
-    );
-  } else {
-    evidenceLinks.append(
-      externalLink("Mechanical evidence", entry.verification.workflow_url),
-      " · ",
-    );
-  }
-  evidenceLinks.append(externalLink("Editorial evidence", entry.review.report_url));
+  evidenceLinks.append(
+    externalLink(
+      "Archived mechanical report",
+      `${DATABASE_SOURCE_BASE}${entry.verification.evidence_path}mechanical-report.json`,
+    ),
+    " · ",
+    externalLink(
+      "Archived editorial review",
+      `${DATABASE_SOURCE_BASE}${entry.verification.evidence_path}review.json`,
+    ),
+  );
   copy.append(
     el("strong", "", `Accepted on ${displayDate(acceptanceDate(entry))}`),
     el(
@@ -719,20 +712,17 @@ function provenanceSection(entry) {
 
   const details = el("dl", "details provenance-details");
   details.append(
-    detailRow("Result origin", RESULT_ORIGIN_LABELS[provenance.result_origin] ?? UNSTATED_PROVENANCE),
-    detailRow("Repository role", REPOSITORY_ROLE_LABELS[provenance.repository_role] ?? UNSTATED_PROVENANCE),
+    detailRow("Result origin", RESULT_ORIGIN_LABELS[provenance.result_origin]),
+    detailRow("Repository role", REPOSITORY_ROLE_LABELS[provenance.repository_role]),
     detailRow(
       "Responsible maintainers",
-      provenance.responsible_maintainers.length
-        ? provenance.responsible_maintainers.map((person) => person.name).join(", ")
-        : UNSTATED_PROVENANCE,
+      provenance.responsible_maintainers.map((person) => person.name).join(", "),
     ),
     detailRow(
       "Submission basis",
       {
         maintainer: "Submitted by a responsible author or maintainer",
         approved: "Submitted with approval from a responsible author or maintainer",
-        "legacy-unspecified": "Not recorded by the earlier submission form",
       }[entry.submission.authorization.relationship],
     ),
   );
@@ -840,7 +830,7 @@ function solutionMetadata(entry, renderMetadata) {
   const list = el("ul", "dependency-list");
   for (const dependency of dependencies) {
     const item = el("li");
-    if (supportsProjectPaths(entry) && dependency.path !== undefined) {
+    if (dependency.path !== undefined) {
       item.append(
         externalLink(
           dependency.name,
@@ -901,7 +891,7 @@ async function renderEntry(
     ),
     externalDetailRow(
       "Project directory",
-      supportsProjectPaths(entry) ? entry.source.project_path || "Repository root" : "Repository root",
+      entry.source.project_path || "Repository root",
       entry.source.tree_url,
     ),
     externalDetailRow(
@@ -932,7 +922,7 @@ async function renderEntry(
       entry.verification.workflow_url,
     ),
   );
-  if (supportsProjectPaths(entry)) {
+  {
     details.append(
       externalDetailRow(
         "Lakefile",
@@ -942,7 +932,7 @@ async function renderEntry(
     );
   }
   details.append(detailRow("NanoDa commit", entry.verification.nanoda_commit));
-  if (entry.schema_version >= 5) {
+  {
     details.append(
       externalDetailRow(
         "Durable verification report",
@@ -962,7 +952,7 @@ async function renderEntry(
     );
   }
   evidence.append(details);
-  if (entry.schema_version >= 5) {
+  {
     evidence.append(
       el(
         "p",
@@ -1029,8 +1019,8 @@ async function renderEntry(
   }
   editorial.append(
     externalLink(
-      `Read the review on submission #${reportIssueNumber(entry.review.report_url)}`,
-      entry.review.report_url,
+      "Read the archived review",
+      `${DATABASE_SOURCE_BASE}${entry.verification.evidence_path}review.json`,
     ),
   );
 
@@ -1051,7 +1041,7 @@ async function renderEntry(
     versionHistory(entry, versions, currentVersion),
     classificationSection(entry, currentVersion),
   );
-  if (entry.schema_version >= 4) content.append(provenanceSection(entry));
+  content.append(provenanceSection(entry));
   content.append(
     challenge.section,
     evidence,

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -1,5 +1,5 @@
 export const INDEX_SCHEMA_VERSION = 2;
-export const ENTRY_SCHEMA_VERSIONS = new Set([2, 3, 4, 5, 6]);
+export const ENTRY_SCHEMA_VERSION = 1;
 export const DEFAULT_DATABASE =
   "https://raw.githubusercontent.com/PalomarRegistry/PalomarDatabase/main/index.json";
 export const DEFAULT_RENDER_BASE = "https://data.palomar-registry.org/";
@@ -8,32 +8,21 @@ export const DEFAULT_RENDER_BASE = "https://data.palomar-registry.org/";
 // submitter never told us" into a positive claim about someone's work, which
 // is the one thing a registry must not do. These live here, beside the
 // validator that decides which values are legal, so the two cannot drift.
-export const UNSTATED_PROVENANCE = "Not stated by the submitter";
 export const RESULT_ORIGIN_LABELS = Object.freeze({
   original: "Original result first presented by this formalization",
   "source-based": "Formalization of or response to existing mathematical work",
-  unspecified: UNSTATED_PROVENANCE,
 });
 export const REPOSITORY_ROLE_LABELS = Object.freeze({
   "substantive-development": "Substantive formalization development",
   "thin-wrapper": "Thin Comparator wrapper around another formalization repository",
-  unspecified: UNSTATED_PROVENANCE,
 });
 
-export function supportsProjectPaths(entry) {
-  return entry?.schema_version === 6;
-}
-
-// Palomar moved from a personal account to the PalomarRegistry organisation on
-// 2026-08-04. Records published before the move name the old repository and are
-// immutable, so both are canonical forever. A record must still be internally
-// consistent: every derived URL below comes from the repository the record
-// itself names, and that repository must be one of these.
-const SUBMISSION_REPOSITORIES = new Set([
-  "kim-em/PalomarSubmission",
-  "PalomarRegistry/PalomarSubmission",
-]);
+// Verification runs in exactly one public workflow, and every run URL a record
+// carries is derived from the repository the record itself names, which must
+// be this one.
+const SUBMISSION_REPOSITORY = "PalomarRegistry/PalomarSubmission";
 const ID_RE = /^PALOMAR-([0-9]{4}-[0-9]{2}-[0-9]{2})-([0-9]{6})$/;
+const SUBMISSION_ID_RE = /^[0-9a-z]{12}$/;
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const COMMIT_RE = /^[0-9a-f]{40}$/;
 const SHA256_RE = /^[0-9a-f]{64}$/;
@@ -233,17 +222,11 @@ function safeDependencyPath(value, field) {
 function validateCanonicalRecordLinks(entry) {
   const identifier = ID_RE.exec(entry.id);
   if (identifier[1] !== entry.accepted_at) fail("entry ID date does not match accepted_at");
-  const issue = Number(identifier[2]);
+
   const submission = entry.submission;
-  const submissionRepository = submission.repository;
-  if (
-    !SUBMISSION_REPOSITORIES.has(submissionRepository) ||
-    submission.issue !== issue ||
-    submission.url !== `https://github.com/${submissionRepository}/issues/${issue}`
-  ) {
-    fail("submission evidence does not match the Palomar ID and canonical issue");
+  if (!SUBMISSION_ID_RE.test(submission.submission_id)) {
+    fail("entry.submission.submission_id is malformed");
   }
-  safeExternalUrl(submission.url);
 
   const source = entry.source;
   if (!REPOSITORY_RE.test(source.repository)) fail("source.repository is malformed");
@@ -251,10 +234,7 @@ function validateCanonicalRecordLinks(entry) {
   const repositoryUrl = `https://github.com/${source.repository}`;
   if (source.repository_url !== repositoryUrl) fail("source.repository_url is not canonical");
   let expectedTreeUrl = `${repositoryUrl}/tree/${source.commit}`;
-  if (!supportsProjectPaths(entry) && source.project_path !== undefined) {
-    fail("source.project_path is not supported by this entry schema");
-  }
-  if (supportsProjectPaths(entry) && source.project_path !== undefined) {
+  if (source.project_path !== undefined) {
     safeRepositoryPath(source.project_path, "entry.source.project_path");
     expectedTreeUrl += `/${encodedRepositoryPath(source.project_path)}`;
   }
@@ -263,29 +243,24 @@ function validateCanonicalRecordLinks(entry) {
   }
   safeExternalUrl(source.tree_url);
 
-  const runPrefix = `https://github.com/${submissionRepository}/actions/runs/`;
-  const runId = entry.verification.workflow_url.slice(runPrefix.length);
-  if (
-    !entry.verification.workflow_url.startsWith(runPrefix) ||
-    !POSITIVE_INTEGER_RE.test(runId)
-  ) {
-    fail("verification.workflow_url is not a canonical PalomarSubmission Actions run");
+  // The run URL is derived, never trusted: a record names the repository, the
+  // run id and the workflow, and the link follows from those.
+  const verification = entry.verification;
+  if (verification.repository !== SUBMISSION_REPOSITORY) {
+    fail("verification.repository is not the Palomar verification repository");
   }
-
-  const reportPrefix =
-    `https://github.com/${submissionRepository}/issues/${issue}#issuecomment-`;
-  const commentId = entry.review.report_url.slice(reportPrefix.length);
-  if (!entry.review.report_url.startsWith(reportPrefix) || !POSITIVE_INTEGER_RE.test(commentId)) {
-    fail("review.report_url is not a canonical report comment for this Palomar ID");
+  const expectedRunUrl =
+    `https://github.com/${verification.repository}/actions/runs/${verification.run_id}`;
+  if (verification.workflow_url !== expectedRunUrl) {
+    fail("verification.workflow_url is not derived from the recorded run");
   }
-  safeExternalUrl(entry.verification.workflow_url);
-  safeExternalUrl(entry.review.report_url);
+  safeExternalUrl(verification.workflow_url);
 }
 
 export function validateEntry(entry, summary) {
   object(entry, "entry");
   object(summary, "entry summary");
-  if (!ENTRY_SCHEMA_VERSIONS.has(entry.schema_version)) {
+  if (entry.schema_version !== ENTRY_SCHEMA_VERSION) {
     fail(`unsupported entry schema_version ${String(entry.schema_version)}`);
   }
   if (entry.status !== "accepted") fail("entry status is not accepted");
@@ -307,10 +282,7 @@ export function validateEntry(entry, summary) {
     string(object(value, `entry.authors[${position}]`).name, `entry.authors[${position}].name`);
   }
 
-  if (entry.schema_version === 2 && entry.classification !== undefined) {
-    fail("entry.classification is not valid in schema version 2");
-  }
-  if (entry.schema_version >= 3) {
+  {
     const classification = object(entry.classification, "entry.classification");
     const arxiv = stringArray(classification.arxiv, "entry.classification.arxiv");
     const msc2020 = stringArray(classification.msc2020, "entry.classification.msc2020");
@@ -328,15 +300,17 @@ export function validateEntry(entry, summary) {
     }
   }
 
+  // A published record names the submission, and nothing about the person who
+  // sent it. There is no submitter field to display, by construction.
   const submission = object(entry.submission, "entry.submission");
-  string(submission.repository, "entry.submission.repository");
-  integer(submission.issue, "entry.submission.issue");
-  string(submission.url, "entry.submission.url");
-  string(submission.submitter, "entry.submission.submitter");
+  string(submission.submission_id, "entry.submission.submission_id");
+  if (Object.hasOwn(submission, "submitter") || Object.hasOwn(submission, "issue")) {
+    fail("entry.submission carries a field this schema does not have");
+  }
 
-  if (entry.schema_version >= 4) {
+  {
     const authorization = object(submission.authorization, "entry.submission.authorization");
-    if (!["maintainer", "approved", "legacy-unspecified"].includes(authorization.relationship)) {
+    if (!["maintainer", "approved"].includes(authorization.relationship)) {
       fail("entry.submission.authorization.relationship is not recognized");
     }
     if (authorization.evidence !== undefined) {
@@ -344,43 +318,19 @@ export function validateEntry(entry, summary) {
     }
 
     const provenance = object(entry.provenance, "entry.provenance");
-    // Provenance intake did not exist when the first records were published,
-    // so schema v5 added "unspecified", a `declared` map recording which
-    // fields the submitter actually asserted, and dropped the requirement for
-    // at least one maintainer. Schema v4 has none of that and forbids
-    // `declared` outright, so the allowance is gated rather than global:
-    // matching the schema in both directions is the whole point, since being
-    // stricter takes the site down and being looser defeats this validator.
-    const undeclarable = entry.schema_version >= 5;
-    const origins = ["original", "source-based"];
-    const roles = ["substantive-development", "thin-wrapper"];
-    if (undeclarable) {
-      origins.push("unspecified");
-      roles.push("unspecified");
-    } else if (Object.hasOwn(provenance, "declared")) {
-      fail("entry.provenance.declared is not permitted by this entry schema");
-    }
-    if (!origins.includes(provenance.result_origin)) {
+    // Provenance is declared at intake, so every published record states it.
+    // The labels live beside this list so the two cannot drift.
+    if (!Object.hasOwn(RESULT_ORIGIN_LABELS, provenance.result_origin)) {
       fail("entry.provenance.result_origin is not recognized");
     }
-    if (!roles.includes(provenance.repository_role)) {
+    if (!Object.hasOwn(REPOSITORY_ROLE_LABELS, provenance.repository_role)) {
       fail("entry.provenance.repository_role is not recognized");
-    }
-    if (Object.hasOwn(provenance, "declared")) {
-      const declared = object(provenance.declared, "entry.provenance.declared");
-      for (const flag of ["result_origin", "repository_role", "responsible_maintainers"]) {
-        // Own properties only: a plain property read is satisfied by the
-        // prototype chain, which is validation that fails open.
-        if (!Object.hasOwn(declared, flag) || typeof declared[flag] !== "boolean") {
-          fail(`entry.provenance.declared.${flag} must be a boolean`);
-        }
-      }
     }
     const maintainers = array(
       provenance.responsible_maintainers,
       "entry.provenance.responsible_maintainers",
     );
-    if (!undeclarable && !maintainers.length) {
+    if (!maintainers.length) {
       fail("entry.provenance.responsible_maintainers must not be empty");
     }
     for (const [position, maintainer] of maintainers.entries()) {
@@ -430,7 +380,7 @@ export function validateEntry(entry, summary) {
   string(source.repository_url, "entry.source.repository_url");
   string(source.commit, "entry.source.commit");
   string(source.tree_url, "entry.source.tree_url");
-  if (entry.schema_version >= 5) {
+  {
     const license = object(source.license, "entry.source.license");
     const licensePath = string(license.path, "entry.source.license.path");
     if (!LICENSE_PATH_RE.test(licensePath)) {
@@ -461,10 +411,7 @@ export function validateEntry(entry, summary) {
     formalization.formalization_metadata_path,
     "entry.formalization.formalization_metadata_path",
   );
-  if (!supportsProjectPaths(entry) && formalization.lakefile_path !== undefined) {
-    fail("entry.formalization.lakefile_path is not supported by this entry schema");
-  }
-  if (supportsProjectPaths(entry)) {
+  {
     safeRepositoryPath(formalization.lakefile_path, "entry.formalization.lakefile_path");
     const prefix = source.project_path ? `${source.project_path}/` : "";
     for (const [field, value] of [
@@ -496,14 +443,11 @@ export function validateEntry(entry, summary) {
       dependency.name,
       `entry.formalization.project_dependencies[${position}].name`,
     );
-    if (supportsProjectPaths(entry) && dependencyNames.has(dependencyName)) {
+    if (dependencyNames.has(dependencyName)) {
       fail(`entry.formalization.project_dependencies[${position}].name is duplicated`);
     }
     dependencyNames.add(dependencyName);
-    if (!supportsProjectPaths(entry) && dependency.path !== undefined) {
-      fail(`entry.formalization.project_dependencies[${position}].path is not supported`);
-    }
-    if (supportsProjectPaths(entry) && dependency.path !== undefined) {
+    if (dependency.path !== undefined) {
       const path = safeDependencyPath(
         dependency.path,
         `entry.formalization.project_dependencies[${position}].path`,
@@ -532,18 +476,10 @@ export function validateEntry(entry, summary) {
   commit(verification.comparator_commit, "entry.verification.comparator_commit");
   commit(verification.lean4export_commit, "entry.verification.lean4export_commit");
   commit(verification.landrun_commit, "entry.verification.landrun_commit");
-  // NanoDa verification arrived in schema v4. Demanding the pin of the v2 and
-  // v3 records published before it made them undisplayable; accepting it on
-  // those records would be looser than their schemas, which set
-  // additionalProperties false.
-  if (entry.schema_version >= 4) {
-    commit(verification.nanoda_commit, "entry.verification.nanoda_commit");
-  } else if (Object.hasOwn(verification, "nanoda_commit")) {
-    fail("entry.verification.nanoda_commit is not permitted by this entry schema");
-  }
+  commit(verification.nanoda_commit, "entry.verification.nanoda_commit");
   digest(verification.challenge_sha256, "entry.verification.challenge_sha256");
   digest(verification.solution_sha256, "entry.verification.solution_sha256");
-  if (entry.schema_version >= 5) {
+  {
     commit(verification.workflow_commit, "entry.verification.workflow_commit");
     integer(verification.workflow_run_attempt, "entry.verification.workflow_run_attempt");
     digest(verification.evidence_tree_sha256, "entry.verification.evidence_tree_sha256");
@@ -594,7 +530,10 @@ export function validateEntry(entry, summary) {
   string(review.reviewed_at, "entry.review.reviewed_at");
   commit(review.policy_commit, "entry.review.policy_commit");
   if (review.verdict !== "accept") fail("entry.review.verdict is not accept");
-  string(review.report_url, "entry.review.report_url");
+  digest(object(review.report, "entry.review.report").sha256, "entry.review.report.sha256");
+  if (review.report.source_url !== undefined) {
+    safeExternalUrl(string(review.report.source_url, "entry.review.report.source_url"));
+  }
   stringArray(review.reviewer_models, "entry.review.reviewer_models");
   object(review.scores, "entry.review.scores");
   stringArray(review.warnings, "entry.review.warnings");
@@ -649,9 +588,4 @@ export function pinnedSourceDirectoryUrl(entry, path) {
 
 export function workflowRunId(workflowUrl) {
   return new URL(workflowUrl).pathname.split("/").at(-1);
-}
-
-export function reportIssueNumber(reportUrl) {
-  const match = new URL(reportUrl).pathname.match(/\/issues\/([1-9][0-9]*)$/);
-  return match ? match[1] : "?";
 }

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -15,14 +15,15 @@ HASH = "a" * 64
 
 
 def entry(identifier: str, lines: int, version: int = 1) -> dict:
-    issue = int(identifier.rsplit("-", 1)[-1])
+    serial = int(identifier.rsplit("-", 1)[-1])
+    submission_id = f"{serial:012x}".replace("x", "0")
     classification = (
         {"arxiv": ["math.CO", "cs.DM"], "msc2020": ["05C10"]}
         if identifier.endswith("000123")
         else {"arxiv": ["math.NT"], "msc2020": ["11N13"]}
     )
     record = {
-        "schema_version": 5,
+        "schema_version": 1,
         "id": identifier,
         "accepted_at": "2026-07-29",
         "version": version,
@@ -39,10 +40,7 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
             "related_formalizations": [],
         },
         "submission": {
-            "repository": "PalomarRegistry/PalomarSubmission",
-            "issue": issue,
-            "url": f"https://github.com/PalomarRegistry/PalomarSubmission/issues/{issue}",
-            "submitter": "example",
+            "submission_id": submission_id,
             "authorization": {"relationship": "maintainer"},
         },
         "source": {
@@ -62,6 +60,7 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
             "solution_path": "Solution.lean",
             "comparator_config_path": "comparator.json",
             "formalization_metadata_path": "formalization.yaml",
+            "lakefile_path": "lakefile.toml",
             "theorem_names": ["Example.theorem"],
             "definition_names": [],
             "lean_toolchain": "leanprover/lean4:v4.31.0-rc2",
@@ -75,6 +74,9 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
             ],
         },
         "verification": {
+            "repository": "PalomarRegistry/PalomarSubmission",
+            "run_id": 12345,
+            "workflow_path": ".github/workflows/submission.yml",
             "comparator_commit": "2" * 40,
             "lean4export_commit": "3" * 40,
             "landrun_commit": "4" * 40,
@@ -110,10 +112,7 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
                 "clarity": 5,
             },
             "warnings": [],
-            "report_url": (
-                "https://github.com/PalomarRegistry/PalomarSubmission/issues/"
-                f"{issue}#issuecomment-456"
-            ),
+            "report": {"sha256": "e" * 64},
         },
         "challenge_render": {
             "format": "verso-html",
@@ -128,7 +127,6 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
     }
     if identifier.endswith("000123"):
         project = "project"
-        record["schema_version"] = 6
         record["source"]["project_path"] = project
         record["source"]["tree_url"] += f"/{project}"
         record["formalization"].update(

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -6,11 +6,11 @@ import { htmlFiles } from "../scripts/build-site.mjs";
 
 import {
   DEFAULT_DATABASE,
+  ENTRY_SCHEMA_VERSION,
   DEFAULT_RENDER_BASE,
   databaseBaseFor,
   RESULT_ORIGIN_LABELS,
   REPOSITORY_ROLE_LABELS,
-  UNSTATED_PROVENANCE,
   entryRecordUrl,
   isLoopbackHostname,
   pinnedSourceDirectoryUrl,
@@ -46,8 +46,9 @@ function index(entries = [summary()], overrides = {}) {
 }
 
 function entry(overrides = {}) {
+  const evidenceTree = "c".repeat(64);
   const value = {
-    schema_version: 2,
+    schema_version: 1,
     id: "PALOMAR-2026-07-29-000123",
     accepted_at: "2026-07-29",
     version: 1,
@@ -55,23 +56,36 @@ function entry(overrides = {}) {
     title: "Fixture theorem",
     abstract: "A security fixture.",
     authors: [{ name: "Example" }],
+    classification: { arxiv: ["math.CO"], msc2020: ["05C10"] },
     submission: {
-      repository: "PalomarRegistry/PalomarSubmission",
-      issue: 123,
-      url: "https://github.com/PalomarRegistry/PalomarSubmission/issues/123",
-      submitter: "example",
+      submission_id: "a1b2c3d4e5f6",
+      authorization: { relationship: "maintainer" },
+    },
+    provenance: {
+      result_origin: "original",
+      repository_role: "substantive-development",
+      responsible_maintainers: [{ name: "Example" }],
+      mathematical_sources: [],
+      related_formalizations: [],
     },
     source: {
       repository: "example/challenge",
       repository_url: "https://github.com/example/challenge",
       commit: COMMIT,
       tree_url: `https://github.com/example/challenge/tree/${COMMIT}`,
+      license: {
+        path: "LICENSE",
+        sha256: DIGEST,
+        declared_identifier: "Apache-2.0",
+        detected_identifier: "Apache-2.0",
+      },
     },
     formalization: {
       challenge_path: "Challenge.lean",
       solution_path: "Solution.lean",
       comparator_config_path: "comparator.json",
       formalization_metadata_path: "formalization.yaml",
+      lakefile_path: "lakefile.toml",
       lean_toolchain: "leanprover/lean4:v4.31.0",
       theorem_names: ["Example.theorem"],
       definition_names: [],
@@ -81,13 +95,22 @@ function entry(overrides = {}) {
       ],
     },
     verification: {
+      repository: "PalomarRegistry/PalomarSubmission",
+      run_id: 12345,
+      workflow_path: ".github/workflows/submission.yml",
       comparator_commit: "2".repeat(40),
       lean4export_commit: "3".repeat(40),
       landrun_commit: "4".repeat(40),
+      nanoda_commit: "9".repeat(40),
       verified_at: "2026-07-29T08:46:32Z",
       workflow_url: "https://github.com/PalomarRegistry/PalomarSubmission/actions/runs/12345",
+      workflow_commit: "8".repeat(40),
+      workflow_run_attempt: 1,
       challenge_sha256: DIGEST,
       solution_sha256: "b".repeat(64),
+      evidence_tree_sha256: evidenceTree,
+      mechanical_report_sha256: "d".repeat(64),
+      evidence_path: `evidence/PALOMAR-2026-07-29-000123-v1/${evidenceTree}/`,
     },
     trust: {
       level: "high",
@@ -101,8 +124,7 @@ function entry(overrides = {}) {
       reviewed_at: "2026-07-29T08:53:02Z",
       policy_commit: "5".repeat(40),
       verdict: "accept",
-      report_url:
-        "https://github.com/PalomarRegistry/PalomarSubmission/issues/123#issuecomment-456",
+      report: { sha256: "e".repeat(64) },
       scores: { clarity: 5 },
       reviewer_models: ["fixture:model"],
       warnings: [],
@@ -258,7 +280,7 @@ test("withdrawn palomar-indexed provenance is rejected", () => {
 });
 
 test("entry schema, acceptance state, verdict, and selected identity fail closed", () => {
-  assert.throws(() => validateEntry(entry({ schema_version: 7 }), summary()), /unsupported entry/);
+  assert.throws(() => validateEntry(entry({ schema_version: 2 }), summary()), /unsupported entry/);
   assert.throws(() => validateEntry(entry({ status: "draft" }), summary()), /not accepted/);
   const rejected = entry();
   rejected.review.verdict = "reject";
@@ -273,239 +295,61 @@ test("entry schema, acceptance state, verdict, and selected identity fail closed
   );
 });
 
-test("schema v3 classification is required and strictly shaped", () => {
-  const valid = entry({
-    schema_version: 3,
-    classification: { arxiv: ["math.CO", "cs.DM"], msc2020: ["05C10"] },
-  });
-  assert.doesNotThrow(() => validateEntry(valid, summary()));
-
-  assert.throws(
-    () => validateEntry(entry({ schema_version: 3 }), summary()),
-    /classification must be an object/,
-  );
-  const malformed = entry({
-    schema_version: 3,
-    classification: { arxiv: ["math.NOT REAL"], msc2020: ["05C10"] },
-  });
-  assert.throws(() => validateEntry(malformed, summary()), /malformed code/);
-});
-
-test("schema v4 requires explicit provenance and submission authorization", () => {
-  const valid = entry({
-    schema_version: 4,
-    classification: { arxiv: ["math.CO"], msc2020: ["05C10"] },
-    provenance: {
-      result_origin: "original",
-      repository_role: "substantive-development",
-      responsible_maintainers: [{ name: "Example" }],
-      mathematical_sources: [],
-      related_formalizations: [],
-    },
-  });
-  valid.submission.authorization = { relationship: "maintainer" };
-  valid.verification.nanoda_commit = "9".repeat(40);
-  assert.doesNotThrow(() => validateEntry(valid, summary()));
-
-  const sourceBasedWithoutSource = structuredClone(valid);
-  sourceBasedWithoutSource.provenance.result_origin = "source-based";
-  assert.throws(
-    () => validateEntry(sourceBasedWithoutSource, summary()),
-    /lacks a substantive mathematical source/,
-  );
-
-  const wrapperWithoutTarget = structuredClone(valid);
-  wrapperWithoutTarget.provenance.repository_role = "thin-wrapper";
-  assert.throws(
-    () => validateEntry(wrapperWithoutTarget, summary()),
-    /substantive_formalization must be an object/,
-  );
-
-});
-
-test("schema v5 requires content-addressed durable verification evidence", () => {
-  const evidenceTree = "c".repeat(64);
-  const valid = entry({
-    schema_version: 5,
-    classification: { arxiv: ["math.CO"], msc2020: ["05C10"] },
-    provenance: {
-      result_origin: "original",
-      repository_role: "substantive-development",
-      responsible_maintainers: [{ name: "Example" }],
-      mathematical_sources: [],
-      related_formalizations: [],
-    },
-  });
-  valid.submission.authorization = { relationship: "maintainer" };
-  valid.verification.nanoda_commit = "9".repeat(40);
-  valid.source.license = {
-    path: "LICENSE",
-    sha256: DIGEST,
-    declared_identifier: "Apache-2.0",
-    detected_identifier: "Apache-2.0",
-  };
-  Object.assign(valid.verification, {
-    nanoda_commit: "9".repeat(40),
-    workflow_commit: "8".repeat(40),
-    workflow_run_attempt: 1,
-    evidence_tree_sha256: evidenceTree,
-    mechanical_report_sha256: "d".repeat(64),
-    evidence_path: `evidence/${valid.id}-v${valid.version}/${evidenceTree}/`,
-  });
-  assert.doesNotThrow(() => validateEntry(valid, summary()));
-
-  const disagreement = structuredClone(valid);
-  disagreement.source.license.detected_identifier = "MIT";
-  assert.throws(() => validateEntry(disagreement, summary()), /identifiers disagree/);
-
-  const nestedLicense = structuredClone(valid);
-  nestedLicense.source.license.path = "licenses/LICENSE";
-  assert.throws(() => validateEntry(nestedLicense, summary()), /conventional root/);
-
-  const badLicenseDigest = structuredClone(valid);
-  badLicenseDigest.source.license.sha256 = "not a digest";
-  assert.throws(() => validateEntry(badLicenseDigest, summary()), /not a SHA-256/);
-
-  const traversal = structuredClone(valid);
-  traversal.verification.evidence_path = "../mechanical-report.json/";
-  assert.throws(() => validateEntry(traversal, summary()), /not a safe relative path/);
-
-  const wrongAddress = structuredClone(valid);
-  wrongAddress.verification.evidence_path =
-    `evidence/${valid.id}-v${valid.version}/${"e".repeat(64)}/`;
-  assert.throws(() => validateEntry(wrongAddress, summary()), /evidence_path must be/);
-});
-
-test("schema v6 accepts and canonically links a nested project and path dependency", () => {
-  const evidenceTree = "c".repeat(64);
-  const projectPath = "examples/Sharp Smoothing";
-  const valid = entry({
-    schema_version: 6,
-    classification: { arxiv: ["math.CO"], msc2020: ["05C10"] },
-    provenance: {
-      result_origin: "original",
-      repository_role: "substantive-development",
-      responsible_maintainers: [{ name: "Example" }],
-      mathematical_sources: [],
-      related_formalizations: [],
-    },
-  });
-  valid.submission.authorization = { relationship: "maintainer" };
-  valid.source.project_path = projectPath;
-  valid.source.tree_url =
-    `https://github.com/example/challenge/tree/${COMMIT}/examples/Sharp%20Smoothing`;
-  valid.source.license = {
-    path: "LICENSE",
-    sha256: DIGEST,
-    declared_identifier: "Apache-2.0",
-    detected_identifier: "Apache-2.0",
-  };
-  Object.assign(valid.formalization, {
-    challenge_path: `${projectPath}/Comparator/Task.lean`,
-    solution_path: `${projectPath}/Comparator/Answer.lean`,
-    comparator_config_path: `${projectPath}/Comparator/settings.json`,
-    formalization_metadata_path: `${projectPath}/formalization.yaml`,
-    lakefile_path: `${projectPath}/lakefile.lean`,
-    project_dependencies: [
-      { name: "local", path: "." },
-      { name: "mathlib", repository: "leanprover-community/mathlib4", revision: COMMIT },
-    ],
-  });
-  Object.assign(valid.verification, {
-    nanoda_commit: "9".repeat(40),
-    workflow_commit: "8".repeat(40),
-    workflow_run_attempt: 1,
-    evidence_tree_sha256: evidenceTree,
-    mechanical_report_sha256: "d".repeat(64),
-    evidence_path: `evidence/${valid.id}-v${valid.version}/${evidenceTree}/`,
-  });
-  assert.doesNotThrow(() => validateEntry(valid, summary()));
-  assert.equal(
-    pinnedSourceFileUrl(valid, valid.formalization.challenge_path).href,
-    `https://github.com/example/challenge/blob/${COMMIT}/examples/Sharp%20Smoothing/Comparator/Task.lean`,
-  );
-  assert.equal(
-    pinnedSourceDirectoryUrl(valid, ".").href,
-    `https://github.com/example/challenge/tree/${COMMIT}`,
-  );
-
-  const wrongTree = structuredClone(valid);
-  wrongTree.source.tree_url = `https://github.com/example/challenge/tree/${COMMIT}`;
-  assert.throws(() => validateEntry(wrongTree, summary()), /tree_url is not derived/);
-
-  const escape = structuredClone(valid);
-  escape.formalization.project_dependencies[0].path = "../outside";
-  assert.throws(() => validateEntry(escape, summary()), /not a safe relative path/);
-
-  const misplacedLakefile = structuredClone(valid);
-  misplacedLakefile.formalization.lakefile_path = `${projectPath}/nested/lakefile.toml`;
-  assert.throws(() => validateEntry(misplacedLakefile, summary()), /selected project's Lakefile/);
-});
-
-test("schema v6 keeps the repository-root layout as the natural default", () => {
-  const evidenceTree = "c".repeat(64);
-  const valid = entry({
-    schema_version: 6,
-    classification: { arxiv: ["math.CO"], msc2020: ["05C10"] },
-    provenance: {
-      result_origin: "original",
-      repository_role: "substantive-development",
-      responsible_maintainers: [{ name: "Example" }],
-      mathematical_sources: [],
-      related_formalizations: [],
-    },
-  });
-  valid.submission.authorization = { relationship: "maintainer" };
-  valid.source.license = {
-    path: "LICENSE",
-    sha256: DIGEST,
-    declared_identifier: "Apache-2.0",
-    detected_identifier: "Apache-2.0",
-  };
-  valid.formalization.lakefile_path = "lakefile.toml";
-  Object.assign(valid.verification, {
-    nanoda_commit: "9".repeat(40),
-    workflow_commit: "8".repeat(40),
-    workflow_run_attempt: 1,
-    evidence_tree_sha256: evidenceTree,
-    mechanical_report_sha256: "d".repeat(64),
-    evidence_path: `evidence/${valid.id}-v${valid.version}/${evidenceTree}/`,
-  });
-  assert.doesNotThrow(() => validateEntry(valid, summary()));
-
-  const misplacedLakefile = structuredClone(valid);
-  misplacedLakefile.formalization.lakefile_path = "src/lakefile.toml";
-  assert.throws(() => validateEntry(misplacedLakefile, summary()), /selected project's Lakefile/);
-
-  const legacyWithProjectPath = entry();
-  legacyWithProjectPath.source.project_path = "project";
-  assert.throws(() => validateEntry(legacyWithProjectPath, summary()), /not supported/);
-});
-
 test("record evidence links must agree with their canonical values", () => {
   const wrongDate = entry({ accepted_at: "2026-07-30" });
   assert.throws(() => validateEntry(wrongDate, summary()), /ID date does not match/);
 
-  const wrongSubmission = entry();
-  wrongSubmission.submission.url =
-    "https://github.com/PalomarRegistry/PalomarSubmission/issues/999";
-  assert.throws(
-    () => validateEntry(wrongSubmission, summary()),
-    /submission evidence does not match/,
-  );
+  const wrongSubmissionId = entry();
+  wrongSubmissionId.submission.submission_id = "not-an-id";
+  assert.throws(() => validateEntry(wrongSubmissionId, summary()), /submission_id is malformed/);
 
   const wrongTree = entry();
   wrongTree.source.tree_url = `https://github.com/attacker/wrong/tree/${COMMIT}`;
   assert.throws(() => validateEntry(wrongTree, summary()), /tree_url is not derived/);
 
+  // The run URL is derived from the recorded repository and run id, so a link
+  // pointing anywhere else is a disagreement inside the record itself.
   const activeWorkflow = entry();
   activeWorkflow.verification.workflow_url = "javascript:alert(1)";
-  assert.throws(() => validateEntry(activeWorkflow, summary()), /workflow_url is not a canonical/);
+  assert.throws(() => validateEntry(activeWorkflow, summary()), /not derived from the recorded run/);
 
-  const wrongReview = entry();
-  wrongReview.review.report_url =
-    "https://github.com/PalomarRegistry/PalomarSubmission/issues/999#issuecomment-456";
-  assert.throws(() => validateEntry(wrongReview, summary()), /report_url is not a canonical/);
+  const foreignRun = entry();
+  foreignRun.verification.workflow_url =
+    "https://github.com/attacker/PalomarSubmission/actions/runs/12345";
+  assert.throws(() => validateEntry(foreignRun, summary()), /not derived from the recorded run/);
+
+  const foreignRepository = entry();
+  foreignRepository.verification.repository = "attacker/PalomarSubmission";
+  foreignRepository.verification.workflow_url =
+    "https://github.com/attacker/PalomarSubmission/actions/runs/12345";
+  assert.throws(
+    () => validateEntry(foreignRepository, summary()),
+    /not the Palomar verification repository/,
+  );
+
+  const relabelledRun = entry();
+  relabelledRun.verification.run_id = 99999;
+  assert.throws(() => validateEntry(relabelledRun, summary()), /not derived from the recorded run/);
+});
+
+test("a published record never carries the submitter", () => {
+  // Keeping the submitter private is the whole point of a private intake, and
+  // the schema has no field for one. A record that grew one is not displayed.
+  for (const field of ["submitter", "issue"]) {
+    const leaky = entry();
+    leaky.submission[field] = "example";
+    assert.throws(() => validateEntry(leaky, summary()), /a field this schema does not have/);
+  }
+});
+
+test("the archived review is cited by digest, not by a public link", () => {
+  const badDigest = entry();
+  badDigest.review.report = { sha256: "not a digest" };
+  assert.throws(() => validateEntry(badDigest, summary()), /report.sha256 is not a SHA-256/);
+
+  const activeSource = entry();
+  activeSource.review.report = { sha256: "e".repeat(64), source_url: "javascript:alert(1)" };
+  assert.throws(() => validateEntry(activeSource, summary()));
 });
 
 test("unsafe source paths and malformed displayed digests fail closed", () => {
@@ -517,158 +361,21 @@ test("unsafe source paths and malformed displayed digests fail closed", () => {
   badDigest.verification.challenge_sha256 = "not a digest";
   assert.throws(() => validateEntry(badDigest, summary()), /challenge_sha256 is not a SHA-256/);
 
-  // NanoDa verification arrived in schema v4, so the pin is demanded from v4
-  // onwards and must not be demanded of the records published before it.
-  const modern = () => {
-    const value = entry({
-      schema_version: 4,
-      classification: { arxiv: ["math.CO"], msc2020: ["05C10"] },
-      provenance: {
-        result_origin: "original",
-        repository_role: "substantive-development",
-        responsible_maintainers: [{ name: "Example" }],
-        mathematical_sources: [],
-        related_formalizations: [],
-      },
-    });
-    value.submission.authorization = { relationship: "maintainer" };
-    value.verification.nanoda_commit = "9".repeat(40);
-    return value;
-  };
-
-  const badNanodaPin = modern();
+  const badNanodaPin = entry();
   badNanodaPin.verification.nanoda_commit = "not a commit";
   assert.throws(
     () => validateEntry(badNanodaPin, summary()),
     /nanoda_commit is not a full lowercase commit/,
   );
 
-  const missingNanodaPin = modern();
+  const missingNanodaPin = entry();
   delete missingNanodaPin.verification.nanoda_commit;
   assert.throws(
     () => validateEntry(missingNanodaPin, summary()),
     /nanoda_commit is not a full lowercase commit/,
   );
-
-  const preNanoda = entry();
-  delete preNanoda.verification.nanoda_commit;
-  assert.doesNotThrow(() => validateEntry(preNanoda, summary()));
 });
 
-test("provenance the submitter never declared is displayable", () => {
-  // Schemas v5 and v6 allow "unspecified", a `declared` map, and an empty
-  // maintainer list, for records published before provenance intake existed.
-  // This validator did not, which left the only published entry, and
-  // therefore the whole registry listing, unloadable.
-  const legacy = (schema_version) => {
-    const value = entry({
-      schema_version,
-      classification: { arxiv: ["math.CO"], msc2020: ["05C10"] },
-      provenance: {
-        declared: {
-          result_origin: false,
-          repository_role: false,
-          responsible_maintainers: false,
-        },
-        result_origin: "unspecified",
-        repository_role: "unspecified",
-        responsible_maintainers: [],
-        mathematical_sources: [],
-        related_formalizations: [],
-      },
-    });
-    value.submission.authorization = { relationship: "legacy-unspecified" };
-    value.source.license = {
-      path: "LICENSE", sha256: DIGEST,
-      declared_identifier: "Apache-2.0", detected_identifier: "Apache-2.0",
-    };
-    const evidenceTree = "c".repeat(64);
-    Object.assign(value.verification, {
-      nanoda_commit: "9".repeat(40),
-      workflow_commit: "8".repeat(40),
-      workflow_run_attempt: 1,
-      evidence_tree_sha256: evidenceTree,
-      mechanical_report_sha256: "d".repeat(64),
-      evidence_path: `evidence/${value.id}-v${value.version}/${evidenceTree}/`,
-    });
-    if (schema_version === 6) value.formalization.lakefile_path = "lakefile.toml";
-    return value;
-  };
-
-  for (const version of [5, 6]) {
-    assert.doesNotThrow(() => validateEntry(legacy(version), summary()));
-  }
-
-  // The schemas place no minimum on maintainers for v5 and v6, so neither may
-  // this. Inventing a stricter rule here is how the outage happened.
-  const undeclaredFlagButEmpty = legacy(5);
-  undeclaredFlagButEmpty.provenance.declared.responsible_maintainers = true;
-  assert.doesNotThrow(() => validateEntry(undeclaredFlagButEmpty, summary()));
-
-  // An unrecognised value is still unrecognised.
-  const nonsense = legacy(5);
-  nonsense.provenance.result_origin = "invented";
-  assert.throws(() => validateEntry(nonsense, summary()), /result_origin is not recognized/);
-
-  // `declared` must be a well-formed object of booleans, and must not be
-  // satisfiable through the prototype chain.
-  for (const bad of [null, "yes", 42, [], { result_origin: false }]) {
-    const malformed = legacy(5);
-    malformed.provenance.declared = bad;
-    assert.throws(() => validateEntry(malformed, summary()));
-  }
-  const inherited = legacy(5);
-  inherited.provenance.declared = Object.create({
-    result_origin: false, repository_role: false, responsible_maintainers: false,
-  });
-  assert.throws(() => validateEntry(inherited, summary()), /must be a boolean/);
-});
-
-test("schema v4 gets none of the undeclared-provenance allowances", () => {
-  // Schema v4 permits neither "unspecified" nor `declared`, and requires a
-  // maintainer. Relaxing the client for v5 must not quietly relax v4 too.
-  const v4 = () => {
-    const value = entry({
-      schema_version: 4,
-      classification: { arxiv: ["math.CO"], msc2020: ["05C10"] },
-      provenance: {
-        result_origin: "original",
-        repository_role: "substantive-development",
-        responsible_maintainers: [{ name: "Example" }],
-        mathematical_sources: [],
-        related_formalizations: [],
-      },
-    });
-    value.submission.authorization = { relationship: "maintainer" };
-    value.verification.nanoda_commit = "9".repeat(40);
-    return value;
-  };
-  assert.doesNotThrow(() => validateEntry(v4(), summary()));
-
-  const unspecifiedOrigin = v4();
-  unspecifiedOrigin.provenance.result_origin = "unspecified";
-  assert.throws(() => validateEntry(unspecifiedOrigin, summary()), /result_origin is not recognized/);
-
-  const unspecifiedRole = v4();
-  unspecifiedRole.provenance.repository_role = "unspecified";
-  assert.throws(() => validateEntry(unspecifiedRole, summary()), /repository_role is not recognized/);
-
-  const declaredMap = v4();
-  declaredMap.provenance.declared = { responsible_maintainers: false };
-  assert.throws(() => validateEntry(declaredMap, summary()), /declared is not permitted/);
-
-  const noMaintainers = v4();
-  noMaintainers.provenance.responsible_maintainers = [];
-  assert.throws(() => validateEntry(noMaintainers, summary()), /must not be empty/);
-});
-
-test("a pre-v4 record may not carry a NanoDa pin", () => {
-  // Schemas v2 and v3 set additionalProperties false and define no such field,
-  // so accepting one would be looser than the schema rather than stricter.
-  const stray = entry();
-  stray.verification.nanoda_commit = "9".repeat(40);
-  assert.throws(() => validateEntry(stray, summary()), /not permitted by this entry schema/);
-});
 test("every HTML entry point carries the restrictive CSP", async () => {
   for (const name of htmlFiles) {
     const html = await readFile(new URL(`../${name}`, import.meta.url), "utf8");
@@ -705,81 +412,37 @@ test("About states the repository licence boundary", async () => {
   assert.match(about, /licence file remains at repository root/);
 });
 
-// Palomar moved to the PalomarRegistry organisation on 2026-08-04. Records
-// published before the move are immutable and name the old repository, so both
-// are canonical, and a record must still be internally consistent about which.
-
-function withSubmissionRepository(repository) {
-  return entry({
-    submission: {
-      repository,
-      issue: 123,
-      url: `https://github.com/${repository}/issues/123`,
-      submitter: "example",
-    },
-    verification: {
-      ...entry().verification,
-      workflow_url: `https://github.com/${repository}/actions/runs/12345`,
-    },
-    review: {
-      ...entry().review,
-      report_url: `https://github.com/${repository}/issues/123#issuecomment-456`,
-    },
-  });
-}
-
-test("a record published before the organisation move still validates", () => {
-  const historical = withSubmissionRepository("kim-em/PalomarSubmission");
-  assert.equal(validateEntry(historical, summary()).id, "PALOMAR-2026-07-29-000123");
-});
-
-test("an unknown submission repository is refused", () => {
-  assert.throws(
-    () => validateEntry(withSubmissionRepository("attacker/PalomarSubmission"), summary()),
-    /submission evidence does not match/,
-  );
-});
-
-test("submission, run, and report links must name the same repository", () => {
-  const mixed = withSubmissionRepository("PalomarRegistry/PalomarSubmission");
-  mixed.review.report_url =
-    "https://github.com/kim-em/PalomarSubmission/issues/123#issuecomment-456";
-  assert.throws(() => validateEntry(mixed, summary()), /review.report_url is not a canonical/);
-});
-
-
-test("every provenance value the schemas allow has an explicit label", async () => {
-  // The renderer used a binary fallback, so "unspecified" was displayed as
-  // "Substantive formalization development": a positive claim nobody made.
-  // Anything the validator accepts must have a label of its own, and only
-  // "unspecified" may read as unstated.
-  // The authoritative schemas live in PalomarDatabase. CI checks it out and
+test("every provenance value the schema allows has an explicit label", async () => {
+  // The renderer once used a binary fallback, so a value nobody stated was
+  // displayed as a positive claim about someone's work. Anything the
+  // validator accepts must have a label of its own.
+  // The authoritative schema lives in PalomarDatabase. CI checks it out and
   // sets PALOMAR_DATABASE_CHECKOUT; locally a sibling clone is assumed. This
   // test exists because the site drifting from the schema is what took the
   // registry down, so an unavailable schema is a failure, not a skip.
   const checkout = process.env.PALOMAR_DATABASE_CHECKOUT
     ?? new URL("../../PalomarDatabase/", import.meta.url).pathname;
   const schema = JSON.parse(
-    await readFile(new URL("schema-v6.json", `file://${checkout}/`), "utf8"),
+    await readFile(new URL("schema-v1.json", `file://${checkout}/`), "utf8"),
   );
   const provenance = schema.properties.provenance.properties;
-  const cases = [
+  for (const [field, labels] of [
     ["result_origin", RESULT_ORIGIN_LABELS],
     ["repository_role", REPOSITORY_ROLE_LABELS],
-  ];
-  for (const [field, labels] of cases) {
-    const allowed = provenance[field].enum;
+  ]) {
     assert.deepStrictEqual(
       Object.keys(labels).sort(),
-      [...allowed].sort(),
+      [...provenance[field].enum].sort(),
       `${field} labels must cover exactly the schema's values`,
     );
-    for (const value of allowed) {
-      assert.strictEqual(
-        labels[value] === UNSTATED_PROVENANCE,
-        value === "unspecified",
-        `${field} "${value}" is labelled as the wrong kind of claim`,
-      );
-    }
   }
+});
+
+test("the site validates exactly the schema version the database publishes", async () => {
+  const checkout = process.env.PALOMAR_DATABASE_CHECKOUT
+    ?? new URL("../../PalomarDatabase/", import.meta.url).pathname;
+  const schema = JSON.parse(
+    await readFile(new URL("schema-v1.json", `file://${checkout}/`), "utf8"),
+  );
+  assert.strictEqual(schema.properties.schema_version.const, ENTRY_SCHEMA_VERSION);
 });

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -11,6 +11,27 @@ function fileAtPreviousDeployment(path) {
   return execFileSync("git", ["show", `${previousRef}:${path}`], { encoding: "utf8" });
 }
 
+/**
+ * Which entry schemas the previous deployment's validator would accept.
+ *
+ * Cached JavaScript can only be compatible with records it can read. When the
+ * published schema changes, cached JavaScript is deliberately incompatible,
+ * and asserting otherwise would only be satisfiable by never changing it.
+ */
+function entrySchemasAtPreviousDeployment() {
+  const source = fileAtPreviousDeployment("assets/security.mjs");
+  const set = /ENTRY_SCHEMA_VERSIONS = new Set\(\[([0-9,\s]*)\]\)/.exec(source);
+  if (set) return new Set(set[1].split(",").map((n) => Number(n.trim())));
+  const single = /ENTRY_SCHEMA_VERSION = ([0-9]+)/.exec(source);
+  return single ? new Set([Number(single[1])]) : new Set();
+}
+
+const currentEntrySchema = Number(
+  /ENTRY_SCHEMA_VERSION = ([0-9]+)/.exec(
+    readFileSync(fileURLToPath(new URL("../assets/security.mjs", import.meta.url)), "utf8"),
+  )[1],
+);
+
 test("about headings expose hoverable links that copy their section URL", async ({ context, page }) => {
   await context.grantPermissions(["clipboard-read", "clipboard-write"]);
   await page.goto("/about.html");
@@ -393,6 +414,10 @@ test("larger Challenge falls back to the dedicated wrapper", async ({ page }) =>
 
 test("current HTML remains compatible with cached JavaScript from the previous deployment", async ({ page }) => {
   test.skip(!previousRef, "PALOMAR_PREVIOUS_REF is only set in deployment and pull-request CI");
+  test.skip(
+    !entrySchemasAtPreviousDeployment().has(currentEntrySchema),
+    "the published entry schema changed, so cached JavaScript cannot read current records",
+  );
   await page.route("**/assets/app.js", (route) => route.fulfill({
     body: fileAtPreviousDeployment("assets/app.js"),
     contentType: "text/javascript; charset=utf-8",

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -218,7 +218,7 @@ test("a single current version has no supersession treatment", async ({ page }) 
   await expect(page.locator("#version-history li")).toHaveCount(1);
 });
 
-test("schema v5 entries display repository licence evidence and its boundary", async ({ page }) => {
+test("entries display repository licence evidence and its boundary", async ({ page }) => {
   await page.goto(
     `/entry.html?id=PALOMAR-2026-07-29-000124&version=1&database=${database}`,
   );
@@ -332,7 +332,7 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   await expect(page.locator(".acceptance-callout")).toContainText("AI-mediated review");
   await expect(page.getByRole("link", { name: "Archived mechanical report" })).toBeVisible();
   await expect(page.getByText("Verification workflow commit")).toBeVisible();
-  await expect(page.getByRole("link", { name: "Editorial evidence" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Archived editorial review" })).toBeVisible();
   await expect(page.getByRole("link", { name: "project/Comparator/Answer.lean" }).first()).toHaveAttribute(
     "href",
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/project/Comparator/Answer.lean`,


### PR DESCRIPTION
This PR takes the website down to a single entry schema. The validator accepted five versions, required a submission issue, a submitter and a report comment URL, and gated a dozen rules on version comparisons; all of that described records that no longer exist and could no longer be produced.

The site now derives the verification run link from the repository and run id a record names rather than trusting the URL it carries, refuses a record carrying a submitter or an issue number at all, and links the archived review beside the archived mechanical report instead of a public comment that is no longer written. A parity test asserts the site validates exactly the schema version PalomarDatabase publishes, since the site drifting from the schema is what took the registry down before.

Checked in a browser as well as in unit tests: the Playwright suite passes against the rewritten fixtures, which is what caught a stale import that left the landing page blank while every asset-level check passed.

🤖 Prepared with Claude Code