### PR TITLE
feat: give Palomar a telescope

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,19 +19,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
       # The site re-validates every record client-side. Drifting from the
       # authoritative schemas is what made the whole registry unloadable, so
       # the schemas are checked out and the tests compare against them.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: PalomarRegistry/PalomarDatabase
           persist-credentials: false
           path: palomar-database
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.4.1"
           cache: npm
@@ -51,8 +51,8 @@ jobs:
         env:
           PALOMAR_PREVIOUS_REF: ${{ env.PALOMAR_PREVIOUS_REF }}
       - run: npm run build -- --version "${GITHUB_SHA}" --output .site
-      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
-      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: .site
 
@@ -65,4 +65,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,19 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
       # The site re-validates every record client-side. Drifting from the
       # authoritative schemas is what made the whole registry unloadable, so
       # the schemas are checked out and the tests compare against them.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: PalomarRegistry/PalomarDatabase
           persist-credentials: false
           path: palomar-database
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.4.1"
           cache: npm

--- a/404.html
+++ b/404.html
@@ -6,6 +6,7 @@
     <meta name="theme-color" content="#ffffff">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Not found — Palomar</title>
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="assets/style.css">
   </head>
   <body>

--- a/about.html
+++ b/about.html
@@ -7,6 +7,7 @@
     <meta name="theme-color" content="#ffffff">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>About — Palomar</title>
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="assets/style.css">
   </head>
   <body data-page="about">

--- a/entry.html
+++ b/entry.html
@@ -6,6 +6,7 @@
     <meta name="theme-color" content="#ffffff">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Registry entry — Palomar</title>
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="assets/style.css">
     <link rel="alternate" type="application/rss+xml" title="Palomar accepted results" href="https://data.palomar-registry.org/feed.xml">
   </head>

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Palomar">
+  <title>Palomar</title>
+  <style>
+    /* Dark blue vanishes against a dark tab strip, so the mark follows the
+       same pairing as the rest of the site. */
+    path, circle { fill: #123a6b; }
+    @media (prefers-color-scheme: dark) {
+      path, circle { fill: #7fb2f0; }
+    }
+  </style>
+  <!-- One continuous taper, rather than a tube and a separate objective,
+       because at sixteen pixels a flared head reads as a mallet. -->
+  <path d="M4.8 13.8 24.7 4.6 27 9.6 6 16.7Z"/>
+  <!-- Star diagonal and eyepiece at the narrow end. -->
+  <path d="m5 15 2.6.5-1.4 4.2-2.7-.6Z"/>
+  <path d="m2.8 18.2 4.1 1.3-.8 2.5L2 20.7Z"/>
+  <!-- Mount hub and splayed tripod, which is what says telescope. -->
+  <circle cx="14.8" cy="17.1" r="2.7"/>
+  <path d="M13.1 18.5h3.4L10.2 29H6.5Zm2.4.3h3.2L25 29h-3.7Z"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <meta name="theme-color" content="#ffffff">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Palomar — Lean-verified mathematics</title>
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="assets/style.css">
     <link rel="manifest" href="site.webmanifest">
     <link rel="alternate" type="application/rss+xml" title="Palomar accepted results" href="https://data.palomar-registry.org/feed.xml">

--- a/render.html
+++ b/render.html
@@ -6,6 +6,7 @@
     <meta name="theme-color" content="#ffffff">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Named compared declarations — Palomar</title>
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="assets/style.css">
   </head>
   <body data-page="render">

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 
 const root = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 export const htmlFiles = ["404.html", "about.html", "entry.html", "index.html", "render.html"];
-const publicFiles = [...htmlFiles, "site.webmanifest"];
+const publicFiles = [...htmlFiles, "site.webmanifest", "favicon.svg"];
 const assetFiles = ["about.js", "app.js", "rendering.js", "security.mjs", "style.css"];
 
 function options(args) {

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -4,5 +4,12 @@
   "start_url": "./",
   "display": "standalone",
   "background_color": "#ffffff",
-  "theme_color": "#ffffff"
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
 }

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -459,3 +459,18 @@ test("the site validates exactly the schema version the database publishes", asy
   );
   assert.strictEqual(schema.properties.schema_version.const, ENTRY_SCHEMA_VERSION);
 });
+
+test("the favicon ships with the site and every page asks for it", async () => {
+  // The build copies a fixed list, so an asset that is not on it is simply
+  // absent from the deployment however correct the markup is.
+  const build = await readFile(new URL("../scripts/build-site.mjs", import.meta.url), "utf8");
+  assert.match(build, /"favicon\.svg"/);
+  for (const name of htmlFiles) {
+    const html = await readFile(new URL(`../${name}`, import.meta.url), "utf8");
+    assert.match(html, /rel="icon" href="favicon\.svg"/, `${name} does not ask for the favicon`);
+  }
+  const icon = await readFile(new URL("../favicon.svg", import.meta.url), "utf8");
+  // One flat colour per scheme, and nothing that a strict policy would refuse.
+  assert.match(icon, /prefers-color-scheme: dark/);
+  assert.doesNotMatch(icon, /<script|xlink:href|href="http/);
+});


### PR DESCRIPTION
The same mark as the submission server, so the identity does not change halfway through submitting.

The build copies a fixed list of files, so the favicon is added to it: markup asking for an asset the build never ships is markup asking for a 404. A test checks both the list and the markup, and that the icon carries nothing a strict policy would refuse.

🤖 Prepared with Claude Code