### PR TITLE
Read registry data from filtered public origin

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,14 +23,20 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      # The site re-validates every record client-side. Drifting from the
-      # authoritative schemas is what made the whole registry unloadable, so
-      # the schemas are checked out and the tests compare against them.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: PalomarRegistry/PalomarDatabase
-          persist-credentials: false
-          path: palomar-database
+      # The canonical database is private. The site re-validates every public
+      # record client-side, so compare against the schemas from the filtered
+      # public snapshot rather than cloning the canonical repository.
+      - name: Download the published schemas
+        env:
+          PUBLIC_DATA_ORIGIN: https://palomar-data.palomar-server.workers.dev
+        run: |
+          mkdir palomar-database
+          curl --fail --silent --show-error --retry 3 \
+            "$PUBLIC_DATA_ORIGIN/schema-v1.json" \
+            --output palomar-database/schema-v1.json
+          curl --fail --silent --show-error --retry 3 \
+            "$PUBLIC_DATA_ORIGIN/schema-v2.json" \
+            --output palomar-database/schema-v2.json
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.4.1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,20 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      # The site re-validates every record client-side. Drifting from the
-      # authoritative schemas is what made the whole registry unloadable, so
-      # the schemas are checked out and the tests compare against them.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: PalomarRegistry/PalomarDatabase
-          persist-credentials: false
-          path: palomar-database
+      # The canonical database is private. The site re-validates every public
+      # record client-side, so compare against the schemas from the filtered
+      # public snapshot rather than cloning the canonical repository.
+      - name: Download the published schemas
+        env:
+          PUBLIC_DATA_ORIGIN: https://palomar-data.palomar-server.workers.dev
+        run: |
+          mkdir palomar-database
+          curl --fail --silent --show-error --retry 3 \
+            "$PUBLIC_DATA_ORIGIN/schema-v1.json" \
+            --output palomar-database/schema-v1.json
+          curl --fail --silent --show-error --retry 3 \
+            "$PUBLIC_DATA_ORIGIN/schema-v2.json" \
+            --output palomar-database/schema-v2.json
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.4.1"

--- a/404.html
+++ b/404.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#ffffff">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Not found — Palomar</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="assets/style.css">

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # Palomar Web
 
-The read-only human view of
-[`PalomarRegistry/PalomarDatabase`](https://github.com/PalomarRegistry/PalomarDatabase).
+The read-only human view of Palomar's machine-readable public registry.
 
-The site is static and deployed with GitHub Pages. It fetches `index.json` and
-entry records directly from the database repository at runtime, so publishing a
-database PR does not require a coordinated website deployment or a server.
+The site is static and deployed with GitHub Pages. It fetches the filtered
+`index.json` and entry records from <https://data.palomar-registry.org/> at
+runtime, so publishing a database change does not require a coordinated website
+deployment.
+Each render also loads the current source-availability manifest. When an
+original pinned commit has been confirmed missing and the recorded archive is
+available, source links automatically switch to the `PalomarArchive` copy while
+still displaying the original location. Missing archives are shown as degraded,
+and a stale or unavailable manifest never makes an unverified claim that a
+source is missing.
 Registry cards display arXiv and MSC2020 classifications, and the toolbar can
 filter the current records by either taxonomy. The classification fields suggest
 codes represented by current entries but also accept any exact code, so a deep
@@ -23,6 +29,8 @@ served from that development origin with `?database=/fixtures/index.json`. The
 matching render tree is resolved beside the fixture by default; use
 `&render-base=/fixtures/render-root/` to override it. These overrides are
 honored only when the site itself runs on localhost or another loopback address.
+Use `&availability=/fixtures/source-availability.json` to supply a local health
+manifest.
 The deployed site always reads the canonical database and render origins.
 
 Entry pages embed a rendered Challenge when the comparator names exactly one
@@ -32,15 +40,15 @@ always present. Rendered HTML is loaded in a fixed-height iframe with
 `sandbox="allow-scripts"` (deliberately without `allow-same-origin`) and no
 referrer.
 
-The website is a presentation layer only. Permanent data and schemas live in
-PalomarDatabase; consumers should use that repository directly. A versioned ID
+The website is a presentation layer only. Public data and schemas live at the
+machine-readable data origin. A versioned ID
 such as `PALOMAR-2026-07-29-000001-v1` names one immutable record. An ID without
 a version means the latest record; later versions may change its theorem,
 source, authors, or subject, so stable citations must include the version.
 
 ## RSS
 
-The static database deployment generates a main RSS feed and separate feeds for
+The filtered public-data deployment generates a main RSS feed and separate feeds for
 every arXiv and MSC2020 classification represented by a current entry. The web
 site advertises the main feed with RSS autodiscovery and links the relevant
 category feeds from each entry page. Static hosting is sufficient because feed
@@ -48,9 +56,9 @@ XML is regenerated whenever the append-only database changes.
 
 ## Version presentation
 
-Palomar uses integer versions and treats the greatest registered version of a
+Palomar uses integer versions and treats the greatest active version of a
 permanent ID as current. Registry cards show only that version and link to its
-history when older snapshots exist.
+active history when older snapshots exist.
 
 An entry URL with both `id` and `version` identifies one immutable snapshot:
 
@@ -64,12 +72,12 @@ local fixture. An `id`-only entry URL is a floating convenience link: the site
 resolves it to the current version and replaces the browser URL with the
 explicit snapshot URL.
 
-Entry pages list all registered versions. Older pages display a prominent link
+Entry pages list all active versions. Older pages display a prominent link
 to the current version. Each page renders the selected version's own authorship,
 statement, proof, trust information, review, and warnings; information is never
 borrowed from a newer record. The site provides links, not computed diffs.
-PalomarDatabase does not yet define change summaries, withdrawal states, or
-major/minor versions, so the website does not infer them. If a richer version
+The registry does not define change summaries or major/minor versions, so the
+website does not infer them. If a richer version
 scheme is adopted later, it will require a new URL contract; existing integer
 snapshot URLs remain permanent.
 

--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="About Palomar and submitting machine-checked formal mathematics.">
     <meta name="theme-color" content="#ffffff">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>About — Palomar</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="assets/style.css">
@@ -570,7 +570,7 @@
 
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="https://github.com/PalomarRegistry/PalomarDatabase">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="https://data.palomar-registry.org/index.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/about.js"></script>
   </body>

--- a/assets/app.js
+++ b/assets/app.js
@@ -6,25 +6,29 @@ import {
 } from "./rendering.js";
 import {
   databaseBaseFor,
+  availabilityRecord,
   RESULT_ORIGIN_LABELS,
   REPOSITORY_ROLE_LABELS,
   entryRecordUrl,
   isLoopbackHostname,
-  pinnedSourceDirectoryUrl,
-  pinnedSourceFileUrl,
+  pinnedRepositoryDirectoryUrl,
+  pinnedRepositoryFileUrl,
   safeDataUrl,
   safeExternalUrl,
   safeInternalUrl,
   selectDatabaseUrl,
+  selectAvailabilityUrl,
   selectRenderBase,
+  tombstoneUrl,
   validateEntry,
+  validateAvailability,
   validateIndex,
+  validateTombstone,
   workflowRunId,
 } from "./security.mjs";
 
 const CANONICAL_WEB_BASE = "https://palomar-registry.org/";
 const FEED_BASE = "https://data.palomar-registry.org/feeds/";
-const DATABASE_SOURCE_BASE = "https://github.com/PalomarRegistry/PalomarDatabase/blob/main/";
 
 const params = new URLSearchParams(window.location.search);
 const PALOMAR_ID = /^PALOMAR-\d{4}-\d{2}-\d{2}-\d{6}$/;
@@ -37,7 +41,12 @@ function dataSource() {
   const databaseUrl = selectDatabaseUrl(window.location.href, window.location.search);
   const databaseBase = databaseBaseFor(databaseUrl);
   const renderBase = selectRenderBase(window.location.href, window.location.search, databaseBase);
-  return { databaseUrl, databaseBase, renderBase };
+  const availabilityUrl = selectAvailabilityUrl(
+    window.location.href,
+    window.location.search,
+    databaseBase,
+  );
+  return { databaseUrl, databaseBase, renderBase, availabilityUrl };
 }
 
 function categoryFeedBase() {
@@ -83,6 +92,67 @@ async function fetchJson(url) {
     throw error;
   }
   return response.json();
+}
+
+async function loadAvailability(url) {
+  try {
+    return validateAvailability(await fetchJson(url));
+  } catch (error) {
+    console.warn(`Source availability is unavailable: ${error.message}`);
+    return null;
+  }
+}
+
+function sourceLocation(entry, availability, repository, commit) {
+  if (!entry.preservation) {
+    return {
+      repository,
+      originalRepository: repository,
+      archiveRepository: null,
+      commit,
+      originalStatus: "unknown",
+      archiveStatus: "unknown",
+      checkedAt: null,
+      useArchive: false,
+    };
+  }
+  const mapping = entry.preservation.repositories.find(
+    (row) => row.source_repository.toLowerCase() === repository.toLowerCase() &&
+      row.commit === commit,
+  );
+  if (!mapping) throw new Error(`entry has no preserved copy of ${repository}@${commit}`);
+  const observed = availabilityRecord(availability, repository, commit);
+  const status = observed &&
+      observed.fork_repository.toLowerCase() === mapping.fork_repository.toLowerCase()
+    ? observed
+    : null;
+  const originalStatus = status?.original.status || "unknown";
+  const archiveStatus = status?.archive.status || "unknown";
+  const useArchive = originalStatus === "missing" && archiveStatus !== "missing";
+  return {
+    repository: useArchive ? mapping.fork_repository : repository,
+    originalRepository: repository,
+    archiveRepository: mapping.fork_repository,
+    commit,
+    originalStatus,
+    archiveStatus,
+    checkedAt: status?.original.checked_at || null,
+    useArchive,
+  };
+}
+
+function topSourceLocation(entry, availability) {
+  return sourceLocation(entry, availability, entry.source.repository, entry.source.commit);
+}
+
+function sourceFileUrl(entry, path, availability) {
+  const location = topSourceLocation(entry, availability);
+  return pinnedRepositoryFileUrl(location.repository, entry.source.commit, path);
+}
+
+function sourceDirectoryUrl(entry, path, availability) {
+  const location = topSourceLocation(entry, availability);
+  return pinnedRepositoryDirectoryUrl(location.repository, entry.source.commit, path);
 }
 
 function authorNames(entry) {
@@ -148,7 +218,7 @@ function trustBadge(entry) {
   return badge;
 }
 
-function entryCard(entry, versionCount) {
+function entryCard(entry, versionCount, availability) {
   const categories = classification(entry);
   const card = el("article", "entry-card");
   card.dataset.trust = entry.trust.level;
@@ -193,16 +263,28 @@ function entryCard(entry, versionCount) {
     meta.append(project);
   }
   const footer = el("div", "card-footer");
+  const location = topSourceLocation(entry, availability);
   const historyUrl = new URL(localPageUrl("entry.html", entry));
   historyUrl.hash = "version-history";
   footer.append(
     externalLink(
-      entry.source.repository,
-      `${entry.source.repository_url}/tree/${entry.source.commit}`,
+      location.useArchive ? "Palomar preserved copy" : entry.source.repository,
+      pinnedRepositoryDirectoryUrl(location.repository, entry.source.commit),
       "repo-link",
     ),
     internalLink("View record", localPageUrl("entry.html", entry)),
   );
+  if (!location.useArchive && location.archiveRepository) {
+    footer.append(
+      externalLink(
+        "Palomar preserved copy",
+        pinnedRepositoryDirectoryUrl(location.archiveRepository, entry.source.commit),
+        "archive-link",
+      ),
+    );
+  } else {
+    footer.append(el("span", "source-status missing", "Original unavailable"));
+  }
   if (versionCount > 1) {
     const historyLink = internalLink(
       `${versionCount} versions`,
@@ -229,7 +311,8 @@ async function renderIndex() {
   const status = document.querySelector("#status");
   const grid = document.querySelector("#entry-grid");
   try {
-    const { databaseUrl, databaseBase } = dataSource();
+    const { databaseUrl, databaseBase, availabilityUrl } = dataSource();
+    const availabilityPromise = loadAvailability(availabilityUrl);
     const index = validateIndex(await fetchJson(databaseUrl));
     const versionCounts = new Map();
     for (const summary of index.entries) {
@@ -237,6 +320,7 @@ async function renderIndex() {
     }
     const currentIndex = { entries: latestVersions(index.entries) };
     const entries = await loadEntries(currentIndex, databaseBase);
+    const availability = await availabilityPromise;
     // GitHub Pages may briefly pair HTML and JavaScript from adjacent deployments.
     // Metrics are presentation-only, so a removed metric must not abort the registry.
     setOptionalText("#metric-results", String(entries.length));
@@ -252,7 +336,7 @@ async function renderIndex() {
     }
     status.hidden = true;
     for (const entry of entries.sort((a, b) => a.id.localeCompare(b.id))) {
-      grid.append(entryCard(entry, versionCounts.get(entry.id)));
+      grid.append(entryCard(entry, versionCounts.get(entry.id), availability));
     }
     let trust = "all";
     const search = document.querySelector("#search");
@@ -368,6 +452,19 @@ function externalDetailRow(labelText, text, href) {
   value.append(externalLink(text, href));
   row.append(value);
   return row;
+}
+
+function dataDetailRow(labelText, text, href) {
+  const row = el("div", "detail-row");
+  row.append(el("dt", "", labelText));
+  const value = el("dd");
+  value.append(dataLink(text, href));
+  row.append(value);
+  return row;
+}
+
+function evidenceDataUrl(entry, databaseBase, filename) {
+  return new URL(`${entry.verification.evidence_path}${filename}`, databaseBase);
 }
 
 function localPageUrl(page, entry) {
@@ -548,7 +645,7 @@ function challengeMetadata(metadata) {
 async function challengePresentation(
   entry,
   renderBase,
-  { forceFrame = false, dependenciesOnThisPage = false } = {},
+  { forceFrame = false, dependenciesOnThisPage = false, availability = null } = {},
 ) {
   const section = el("section", "challenge-presentation");
   const heading = el("div", "section-heading");
@@ -571,10 +668,11 @@ async function challengePresentation(
   const comparatorPath = entry.formalization.comparator_config_path;
   const challengePath = entry.formalization.challenge_path;
   const challengeFilename = pathBasename(challengePath);
+  const location = topSourceLocation(entry, availability);
   links.append(
     externalLink(
       `View full pinned statement file (${challengeFilename})`,
-      challengeSourceUrl(entry),
+      challengeSourceUrl(entry, location.repository),
       "challenge-source",
     ),
     " · ",
@@ -585,7 +683,7 @@ async function challengePresentation(
     " · ",
     externalLink(
       `View comparator configuration (${pathBasename(comparatorPath)})`,
-      pinnedSourceFileUrl(entry, comparatorPath),
+      sourceFileUrl(entry, comparatorPath, availability),
       "comparator-source",
     ),
   );
@@ -638,23 +736,32 @@ async function challengePresentation(
   return {section, metadata};
 }
 
-function acceptanceCallout(entry) {
+function acceptanceCallout(entry, databaseBase) {
   const callout = el("div", "acceptance-callout");
   const check = el("span", "acceptance-check", "✓");
   check.setAttribute("aria-hidden", "true");
   const copy = el("div");
   const evidenceLinks = el("p", "certificate-evidence-links");
   evidenceLinks.append(
-    externalLink(
+    dataLink(
       "Archived mechanical report",
-      `${DATABASE_SOURCE_BASE}${entry.verification.evidence_path}mechanical-report.json`,
+      evidenceDataUrl(entry, databaseBase, "mechanical-report.json"),
     ),
     " · ",
-    externalLink(
+    dataLink(
       "Archived editorial review",
-      `${DATABASE_SOURCE_BASE}${entry.verification.evidence_path}review.json`,
+      evidenceDataUrl(entry, databaseBase, "review.json"),
     ),
   );
+  if (entry.preservation) {
+    evidenceLinks.append(
+      " · ",
+      dataLink(
+        "Source preservation receipt",
+        evidenceDataUrl(entry, databaseBase, "source-archive.json"),
+      ),
+    );
+  }
   copy.append(
     el("strong", "", `Accepted on ${displayDate(acceptanceDate(entry))}`),
     el(
@@ -699,6 +806,67 @@ function classificationSearchUrl(scheme, code) {
   const url = new URL("index.html", document.baseURI);
   url.searchParams.set(scheme, code);
   return url;
+}
+
+function sourceAvailabilityNotice(entry, availability) {
+  const location = topSourceLocation(entry, availability);
+  const notice = el("section", "source-availability");
+  const original = pinnedRepositoryDirectoryUrl(
+    location.originalRepository,
+    location.commit,
+    entry.source.project_path || ".",
+  );
+  if (!location.archiveRepository) {
+    notice.classList.add("legacy");
+    notice.append(
+      el("strong", "", "Source recorded before automatic preservation"),
+      el("p", "", "This legacy entry links to its original pinned commit."),
+      externalLink("Recorded original location", original),
+    );
+    return notice;
+  }
+  const archived = pinnedRepositoryDirectoryUrl(
+    location.archiveRepository,
+    location.commit,
+    entry.source.project_path || ".",
+  );
+  if (location.originalStatus === "missing" && location.archiveStatus === "missing") {
+    notice.classList.add("unrecoverable");
+    notice.append(
+      el("strong", "", "No working preserved source location"),
+      el("p", "", "Both the recorded original and Palomar's preserved copy are currently unavailable."),
+      externalLink("Recorded original location", original),
+      " · ",
+      externalLink("Recorded Palomar copy", archived),
+    );
+  } else if (location.originalStatus === "missing") {
+    notice.classList.add("original-missing");
+    const checked = location.checkedAt ? ` (checked ${location.checkedAt})` : "";
+    notice.append(
+      el("strong", "", "Original source unavailable"),
+      el("p", "", `Source links on this page now use Palomar's preserved copy${checked}.`),
+      externalLink("Palomar preserved copy", archived),
+      " · ",
+      externalLink("Recorded original location", original),
+    );
+  } else if (location.archiveStatus === "missing") {
+    notice.classList.add("archive-missing");
+    notice.append(
+      el("strong", "", "Source preservation degraded"),
+      el("p", "", "The original source still works, but Palomar's preserved copy is unavailable."),
+      externalLink("Original source", original),
+      " · ",
+      externalLink("Recorded Palomar copy", archived),
+    );
+  } else {
+    notice.classList.add("preserved");
+    notice.append(
+      el("strong", "", "Source preserved by Palomar"),
+      " ",
+      externalLink("Palomar preserved copy", archived),
+    );
+  }
+  return notice;
 }
 
 function classificationSection(entry) {
@@ -751,7 +919,7 @@ function classificationSection(entry) {
   return section;
 }
 
-function provenanceSection(entry) {
+function provenanceSection(entry, availability) {
   const provenance = entry.provenance;
   const section = el("section", "entry-provenance");
   const heading = el("div", "section-heading");
@@ -766,11 +934,17 @@ function provenanceSection(entry) {
   // below the repository role that exists to announce it.
   if (provenance.repository_role === "thin-wrapper") {
     const substantive = provenance.substantive_formalization;
+    const location = sourceLocation(
+      entry,
+      availability,
+      substantive.repository,
+      substantive.commit,
+    );
     details.append(
       externalDetailRow(
         "Substantive formalization",
         `${substantive.repository}@${substantive.commit.slice(0, 12)}`,
-        substantive.tree_url,
+        pinnedRepositoryDirectoryUrl(location.repository, substantive.commit),
       ),
     );
   }
@@ -837,7 +1011,7 @@ function provenanceSection(entry) {
   return section;
 }
 
-function solutionMetadata(entry, renderMetadata) {
+function solutionMetadata(entry, renderMetadata, availability) {
   const section = el("section", "entry-solution");
   const heading = el("div", "section-heading");
   const title = el("div");
@@ -857,7 +1031,7 @@ function solutionMetadata(entry, renderMetadata) {
     externalDetailRow(
       "Proof file",
       entry.formalization.solution_path,
-      pinnedSourceFileUrl(entry, entry.formalization.solution_path),
+      sourceFileUrl(entry, entry.formalization.solution_path, availability),
     ),
     detailRow("Proof file checksum (SHA-256)", entry.verification.solution_sha256),
   );
@@ -887,18 +1061,33 @@ function solutionMetadata(entry, renderMetadata) {
       item.append(
         externalLink(
           dependency.name,
-          pinnedSourceDirectoryUrl(entry, dependency.path),
+          sourceDirectoryUrl(entry, dependency.path, availability),
         ),
         el("code", "", dependency.path),
       );
     } else {
+      const location = sourceLocation(
+        entry,
+        availability,
+        dependency.repository,
+        dependency.revision,
+      );
       item.append(
         externalLink(
-          dependency.repository,
-          `https://github.com/${dependency.repository}/tree/${dependency.revision}`,
+          location.useArchive ? `${dependency.repository} (Palomar copy)` : dependency.repository,
+          pinnedRepositoryDirectoryUrl(location.repository, dependency.revision),
         ),
         el("code", "", dependency.revision.slice(0, 12)),
       );
+      if (!location.useArchive && location.archiveRepository) {
+        item.append(
+          " · ",
+          externalLink(
+            "Palomar preserved copy",
+            pinnedRepositoryDirectoryUrl(location.archiveRepository, dependency.revision),
+          ),
+        );
+      }
     }
     list.append(item);
   }
@@ -914,6 +1103,8 @@ async function renderEntry(
   renderBase,
   versions,
   currentVersion,
+  availability,
+  databaseBase,
 ) {
   document.title = `${entry.title} — Palomar`;
   setCanonicalEntryPage(entry);
@@ -929,8 +1120,9 @@ async function renderEntry(
   const titleBlock = el("div");
   titleBlock.append(el("div", "eyebrow", "Verification"), el("h2", "", "What was checked"));
   evidenceTitle.append(titleBlock);
-  evidence.append(evidenceTitle, acceptanceCallout(entry));
+  evidence.append(evidenceTitle, acceptanceCallout(entry, databaseBase));
   const details = el("dl", "details");
+  const location = topSourceLocation(entry, availability);
   details.append(
     detailRow("Acceptance date", displayDate(acceptanceDate(entry))),
     detailRow(
@@ -940,27 +1132,31 @@ async function renderEntry(
     externalDetailRow(
       "Fixed source version",
       `${entry.source.repository}@${entry.source.commit.slice(0, 12)}`,
-      `${entry.source.repository_url}/tree/${entry.source.commit}`,
+      pinnedRepositoryDirectoryUrl(location.repository, entry.source.commit),
     ),
     externalDetailRow(
       "Project directory",
       entry.source.project_path || "Repository root",
-      entry.source.tree_url,
+      pinnedRepositoryDirectoryUrl(
+        location.repository,
+        entry.source.commit,
+        entry.source.project_path || ".",
+      ),
     ),
     externalDetailRow(
       "Statement file",
       entry.formalization.challenge_path,
-      pinnedSourceFileUrl(entry, entry.formalization.challenge_path),
+      sourceFileUrl(entry, entry.formalization.challenge_path, availability),
     ),
     externalDetailRow(
       "Proof file",
       entry.formalization.solution_path,
-      pinnedSourceFileUrl(entry, entry.formalization.solution_path),
+      sourceFileUrl(entry, entry.formalization.solution_path, availability),
     ),
     externalDetailRow(
       "Formalization metadata",
       entry.formalization.formalization_metadata_path,
-      pinnedSourceFileUrl(entry, entry.formalization.formalization_metadata_path),
+      sourceFileUrl(entry, entry.formalization.formalization_metadata_path, availability),
     ),
     detailRow("Challenge SHA-256", entry.verification.challenge_sha256),
     detailRow("Solution SHA-256", entry.verification.solution_sha256),
@@ -980,24 +1176,24 @@ async function renderEntry(
       externalDetailRow(
         "Lakefile",
         entry.formalization.lakefile_path,
-        pinnedSourceFileUrl(entry, entry.formalization.lakefile_path),
+        sourceFileUrl(entry, entry.formalization.lakefile_path, availability),
       ),
     );
   }
   details.append(detailRow("NanoDa commit", entry.verification.nanoda_commit));
   {
     details.append(
-      externalDetailRow(
+      dataDetailRow(
         "Durable verification report",
         entry.verification.mechanical_report_sha256,
-        `${DATABASE_SOURCE_BASE}${entry.verification.evidence_path}mechanical-report.json`,
+        evidenceDataUrl(entry, databaseBase, "mechanical-report.json"),
       ),
       detailRow("Verification workflow commit", entry.verification.workflow_commit),
       detailRow("Workflow run attempt", String(entry.verification.workflow_run_attempt)),
       externalDetailRow(
         "Repository licence file",
         entry.source.license.path,
-        pinnedSourceFileUrl(entry, entry.source.license.path),
+        sourceFileUrl(entry, entry.source.license.path, availability),
       ),
       detailRow("Declared repository licence", entry.source.license.declared_identifier),
       detailRow("Detected SPDX licence", entry.source.license.detected_identifier),
@@ -1071,9 +1267,9 @@ async function renderEntry(
     editorial.append(el("p", "no-warnings", "No permanent editorial warnings were recorded."));
   }
   editorial.append(
-    externalLink(
+    dataLink(
       "Read the archived review",
-      `${DATABASE_SOURCE_BASE}${entry.verification.evidence_path}review.json`,
+      evidenceDataUrl(entry, databaseBase, "review.json"),
     ),
   );
 
@@ -1088,8 +1284,9 @@ async function renderEntry(
 
   const challenge = await challengePresentation(entry, renderBase, {
     dependenciesOnThisPage: true,
+    availability,
   });
-  content.append(heading);
+  content.append(heading, sourceAvailabilityNotice(entry, availability));
   const notice = versionNotice(entry, currentVersion);
   if (notice) content.append(notice);
   // What was checked, then the statement it was checked about, then what that
@@ -1100,8 +1297,8 @@ async function renderEntry(
     evidence,
     challenge.section,
     trust,
-    solutionMetadata(entry, challenge.metadata),
-    provenanceSection(entry),
+    solutionMetadata(entry, challenge.metadata, availability),
+    provenanceSection(entry, availability),
     classificationSection(entry),
     editorial,
     versionHistory(entry, versions, currentVersion),
@@ -1110,25 +1307,59 @@ async function renderEntry(
 }
 
 async function loadEntry(id, requestedVersion) {
-  const { databaseUrl, databaseBase, renderBase } = dataSource();
+  const { databaseUrl, databaseBase, renderBase, availabilityUrl } = dataSource();
+  const availabilityPromise = loadAvailability(availabilityUrl);
   const index = validateIndex(await fetchJson(databaseUrl));
   const versions = index.entries
     .filter((item) => item.id === id)
     .sort((left, right) => left.version - right.version);
-  if (!versions.length) throw new Error("entry not found");
-  const currentVersion = versions.at(-1).version;
+  const currentVersion = versions.length ? versions.at(-1).version : null;
   const version = requestedVersion ?? currentVersion;
+  if (version === null) throw new Error("entry not found");
   const summary = index.entries.find((item) => item.id === id && item.version === version);
-  if (!summary) throw new Error("entry not found");
+  if (!summary) {
+    if (requestedVersion === null || requestedVersion === undefined) {
+      throw new Error("entry not found");
+    }
+    try {
+      const tombstone = validateTombstone(
+        await fetchJson(tombstoneUrl(id, requestedVersion, databaseBase)),
+        id,
+        requestedVersion,
+      );
+      return { tombstone };
+    } catch (error) {
+      if (error.status === 404) throw new Error("entry not found");
+      throw error;
+    }
+  }
   const canonicalUrl = entryRecordUrl(summary, databaseBase);
   const entry = validateEntry(await fetchJson(canonicalUrl), summary);
+  const availability = await availabilityPromise;
   return {
     entry,
     canonicalUrl,
     renderBase,
     versions,
     currentVersion,
+    availability,
+    databaseBase,
   };
+}
+
+function renderExactTombstone(tombstone, content) {
+  document.title = `${tombstone.id} v${tombstone.version} — Palomar`;
+  document.body.classList.add("exact-tombstone");
+  for (const node of document.querySelectorAll("body > .site-header, body > footer, body > .skip-link")) {
+    node.hidden = true;
+  }
+  const record = el("section", "tombstone-record");
+  record.append(
+    el("h1", "", `${tombstone.id} v${tombstone.version}`),
+    el("p", "", displayDate(tombstone.taken_down_on)),
+  );
+  content.replaceChildren(record);
+  content.hidden = false;
 }
 
 async function renderEntryPage() {
@@ -1150,13 +1381,21 @@ async function renderEntryPage() {
   }
   try {
     const requestedHash = window.location.hash;
+    const loaded = await loadEntry(id, version);
+    if (loaded.tombstone) {
+      status.hidden = true;
+      renderExactTombstone(loaded.tombstone, content);
+      return;
+    }
     const {
       entry,
       canonicalUrl,
       renderBase,
       versions,
       currentVersion,
-    } = await loadEntry(id, version);
+      availability,
+      databaseBase,
+    } = loaded;
     if (version === null) {
       const resolvedUrl = localPageUrl("entry.html", entry);
       resolvedUrl.hash = requestedHash;
@@ -1171,6 +1410,8 @@ async function renderEntryPage() {
       renderBase,
       versions,
       currentVersion,
+      availability,
+      databaseBase,
     );
     const anchorTarget = requestedHash.startsWith("#")
       ? document.getElementById(decodeURIComponent(requestedHash.slice(1)))
@@ -1198,14 +1439,24 @@ async function renderChallengePage() {
     return;
   }
   try {
-    const { entry, renderBase } = await loadEntry(id, version);
+    const loaded = await loadEntry(id, version);
+    if (loaded.tombstone) {
+      status.hidden = true;
+      renderExactTombstone(loaded.tombstone, content);
+      return;
+    }
+    const { entry, renderBase, availability } = loaded;
     document.title = `Named compared declarations — ${entry.title} — Palomar`;
     const heading = el("header", "entry-heading");
     heading.append(
       el("div", "entry-id", `${entry.id} v${entry.version}`),
       el("h1", "", entry.title),
     );
-    const challenge = await challengePresentation(entry, renderBase, { forceFrame: true });
+    const challenge = await challengePresentation(
+      entry,
+      renderBase,
+      { forceFrame: true, availability },
+    );
     content.append(heading, challenge.section);
     status.hidden = true;
     content.hidden = false;

--- a/assets/rendering.js
+++ b/assets/rendering.js
@@ -23,15 +23,13 @@ export function isInlineChallenge(entry) {
   );
 }
 
-export function challengeSourceUrl(entry) {
+export function challengeSourceUrl(entry, repositoryOverride = null) {
   const repository = entry?.source?.repository;
   const repositoryUrl = entry?.source?.repository_url?.replace(/\/+$/, "");
   const commit = entry?.source?.commit;
   const challengePath = entry?.formalization?.challenge_path;
-  let encodedPath;
   try {
     safeRepositoryPath(challengePath, "Challenge source path");
-    encodedPath = encodedRepositoryPath(challengePath);
   } catch {
     throw new Error("entry has invalid canonical Challenge source metadata");
   }
@@ -40,7 +38,15 @@ export function challengeSourceUrl(entry) {
       !SHA.test(commit || "")) {
     throw new Error("entry has invalid canonical Challenge source metadata");
   }
-  return `${repositoryUrl}/blob/${commit}/${encodedPath}`;
+  const selectedRepository = repositoryOverride || repository;
+  const isPreserved = entry?.preservation?.repositories?.some(
+    (row) => row.source_repository.toLowerCase() === repository.toLowerCase() &&
+      row.commit === commit && row.fork_repository === selectedRepository,
+  );
+  if (selectedRepository !== repository && !isPreserved) {
+    throw new Error("entry has invalid preserved Challenge source metadata");
+  }
+  return pinnedRepositoryFileUrl(selectedRepository, commit, challengePath).href;
 }
 
 export function challengeArtifactUrl(entry, renderBase) {
@@ -78,4 +84,4 @@ export function entryRecordPath(id, version, path) {
   }
   return expected;
 }
-import { encodedRepositoryPath, safeRepositoryPath } from "./security.mjs";
+import { pinnedRepositoryFileUrl, safeRepositoryPath } from "./security.mjs";

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -1,7 +1,10 @@
-export const INDEX_SCHEMA_VERSION = 2;
-export const ENTRY_SCHEMA_VERSION = 1;
+export const INDEX_SCHEMA_VERSION = 3;
+export const ENTRY_SCHEMA_VERSION = 2;
+export const ENTRY_SCHEMA_VERSIONS = new Set([1, 2]);
 export const DEFAULT_DATABASE =
-  "https://raw.githubusercontent.com/PalomarRegistry/PalomarDatabase/main/index.json";
+  "https://data.palomar-registry.org/index.json";
+export const DEFAULT_AVAILABILITY =
+  "https://data.palomar-registry.org/source-availability.json";
 export const DEFAULT_RENDER_BASE = "https://data.palomar-registry.org/";
 
 // Provenance is three-valued. Rendering it with a binary fallback turns "the
@@ -31,6 +34,8 @@ const DATE_RE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
 const ARXIV_RE = /^[a-z]+(?:-[a-z]+)*(?:\.[A-Za-z-]+)?$/;
 const MSC2020_RE = /^[0-9]{2}(?:[A-Z][0-9]{2}|-[0-9]{2})$/;
 const LICENSE_PATH_RE = /^(?:licen[cs]e|copying|unlicense|ofl)(?:\.(?:md|markdown|txt))?$/i;
+const TIMESTAMP_RE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/;
+const AVAILABILITY_MAX_AGE_MS = 18 * 60 * 60 * 1000;
 
 function fail(message) {
   throw new Error(`invalid registry data: ${message}`);
@@ -114,6 +119,19 @@ export function selectRenderBase(locationHref, search, databaseBase) {
   return candidate;
 }
 
+export function selectAvailabilityUrl(locationHref, search, databaseBase) {
+  const locationUrl = new URL(locationHref);
+  if (!isLoopbackHostname(locationUrl.hostname)) return new URL(DEFAULT_AVAILABILITY);
+  const override = new URLSearchParams(search).get("availability");
+  const candidate = override
+    ? new URL(override, locationUrl)
+    : new URL("source-availability.json", databaseBase);
+  if (!["http:", "https:"].includes(candidate.protocol) || candidate.username || candidate.password) {
+    throw new Error("local availability fixture must use an HTTP(S) URL without credentials");
+  }
+  return candidate;
+}
+
 export function safeExternalUrl(value) {
   const url = new URL(value);
   if (url.protocol !== "https:" || url.username || url.password) {
@@ -171,6 +189,74 @@ export function validateIndex(index) {
   return index;
 }
 
+function availabilityEndpoint(value, field) {
+  const endpoint = object(value, field);
+  if (!["available", "missing", "unknown"].includes(endpoint.status)) {
+    fail(`${field}.status is unsupported`);
+  }
+  if (endpoint.checked_at !== null && endpoint.checked_at !== undefined) {
+    if (!TIMESTAMP_RE.test(endpoint.checked_at) || Number.isNaN(Date.parse(endpoint.checked_at))) {
+      fail(`${field}.checked_at is malformed`);
+    }
+  }
+  if (!TIMESTAMP_RE.test(endpoint.last_attempt_at) || Number.isNaN(Date.parse(endpoint.last_attempt_at))) {
+    fail(`${field}.last_attempt_at is malformed`);
+  }
+  if (!Number.isSafeInteger(endpoint.consecutive_missing) || endpoint.consecutive_missing < 0) {
+    fail(`${field}.consecutive_missing is malformed`);
+  }
+  if (endpoint.last_error !== null && endpoint.last_error !== undefined &&
+      typeof endpoint.last_error !== "string") {
+    fail(`${field}.last_error is malformed`);
+  }
+  return endpoint;
+}
+
+export function validateAvailability(manifest) {
+  object(manifest, "availability");
+  if (manifest.schema_version !== 1) fail("availability schema_version is unsupported");
+  if (!TIMESTAMP_RE.test(manifest.generated_at) || Number.isNaN(Date.parse(manifest.generated_at))) {
+    fail("availability.generated_at is malformed");
+  }
+  if (manifest.database_commit !== undefined) {
+    commit(manifest.database_commit, "availability.database_commit");
+  }
+  const seen = new Set();
+  for (const [position, value] of array(
+    manifest.repositories,
+    "availability.repositories",
+  ).entries()) {
+    const row = object(value, `availability.repositories[${position}]`);
+    if (!REPOSITORY_RE.test(row.source_repository)) {
+      fail(`availability.repositories[${position}].source_repository is malformed`);
+    }
+    if (!REPOSITORY_RE.test(row.fork_repository) ||
+        !row.fork_repository.startsWith("PalomarArchive/")) {
+      fail(`availability.repositories[${position}].fork_repository is malformed`);
+    }
+    commit(row.commit, `availability.repositories[${position}].commit`);
+    const key = `${row.source_repository.toLowerCase()}\0${row.commit}`;
+    if (seen.has(key)) fail(`availability.repositories[${position}] is duplicated`);
+    seen.add(key);
+    availabilityEndpoint(row.original, `availability.repositories[${position}].original`);
+    availabilityEndpoint(row.archive, `availability.repositories[${position}].archive`);
+  }
+  return manifest;
+}
+
+export function availabilityRecord(manifest, repository, revision, now = Date.now()) {
+  if (!manifest) return null;
+  const generated = Date.parse(manifest.generated_at);
+  if (!Number.isFinite(generated) || generated > now + 5 * 60 * 1000 ||
+      now - generated > AVAILABILITY_MAX_AGE_MS) {
+    return null;
+  }
+  return manifest.repositories.find(
+    (row) => row.source_repository.toLowerCase() === repository.toLowerCase() &&
+      row.commit === revision,
+  ) || null;
+}
+
 export function entryRecordUrl(summary, databaseBase) {
   object(summary, "entry summary");
   const id = string(summary.id, "entry summary id");
@@ -184,6 +270,35 @@ export function entryRecordUrl(summary, databaseBase) {
     fail("entry path escaped the canonical database prefix");
   }
   return resolved;
+}
+
+export function tombstoneUrl(id, version, databaseBase) {
+  if (typeof id !== "string" || !ID_RE.test(id)) fail("tombstone ID is malformed");
+  integer(version, "tombstone version");
+  const base = new URL(databaseBase);
+  const expected = new URL(`tombstones/${id}-v${version}.json`, base);
+  if (expected.origin !== base.origin) fail("tombstone path escaped the database origin");
+  return expected;
+}
+
+export function validateTombstone(value, id, version) {
+  const tombstone = object(value, "tombstone");
+  if (Object.keys(tombstone).sort().join(",") !== "id,taken_down_on,version") {
+    fail("tombstone contains unexpected fields");
+  }
+  if (tombstone.id !== id || tombstone.version !== version) {
+    fail("tombstone identity does not match the requested version");
+  }
+  const timestamp = `${tombstone.taken_down_on}T00:00:00Z`;
+  const parsed = new Date(timestamp);
+  if (
+    !DATE_RE.test(tombstone.taken_down_on) ||
+    Number.isNaN(parsed.getTime()) ||
+    parsed.toISOString().slice(0, 10) !== tombstone.taken_down_on
+  ) {
+    fail("tombstone date is malformed");
+  }
+  return tombstone;
 }
 
 export function safeRepositoryPath(value, field = "repository path") {
@@ -260,7 +375,7 @@ function validateCanonicalRecordLinks(entry) {
 export function validateEntry(entry, summary) {
   object(entry, "entry");
   object(summary, "entry summary");
-  if (entry.schema_version !== ENTRY_SCHEMA_VERSION) {
+  if (!ENTRY_SCHEMA_VERSIONS.has(entry.schema_version)) {
     fail(`unsupported entry schema_version ${String(entry.schema_version)}`);
   }
   if (entry.status !== "accepted") fail("entry status is not accepted");
@@ -470,6 +585,60 @@ export function validateEntry(entry, summary) {
     }
   }
 
+  if (entry.schema_version >= 2 || entry.preservation !== undefined) {
+    const preservation = object(entry.preservation, "entry.preservation");
+    if (preservation.archive_owner !== "PalomarArchive") {
+      fail("entry.preservation.archive_owner is unsupported");
+    }
+    if (!TIMESTAMP_RE.test(preservation.archived_at) ||
+        Number.isNaN(Date.parse(preservation.archived_at))) {
+      fail("entry.preservation.archived_at is malformed");
+    }
+    digest(preservation.receipt_sha256, "entry.preservation.receipt_sha256");
+    const expected = new Map();
+    const addExpected = (repository, revision) => {
+      expected.set(`${repository.toLowerCase()}\0${revision}`, [repository, revision]);
+    };
+    addExpected(source.repository, source.commit);
+    for (const dependency of formalization.project_dependencies) {
+      if (dependency.path === undefined) addExpected(dependency.repository, dependency.revision);
+    }
+    const substantive = entry.provenance.substantive_formalization;
+    if (substantive) addExpected(substantive.repository, substantive.commit);
+    const expectedRows = [...expected.values()].sort((left, right) => {
+      const leftKey = `${left[0].toLowerCase()}\0${left[1]}`;
+      const rightKey = `${right[0].toLowerCase()}\0${right[1]}`;
+      return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+    });
+    const actualRows = [];
+    const seen = new Set();
+    for (const [position, value] of array(
+      preservation.repositories,
+      "entry.preservation.repositories",
+    ).entries()) {
+      const row = object(value, `entry.preservation.repositories[${position}]`);
+      if (!REPOSITORY_RE.test(row.source_repository)) {
+        fail(`entry.preservation.repositories[${position}].source_repository is malformed`);
+      }
+      commit(row.commit, `entry.preservation.repositories[${position}].commit`);
+      if (!REPOSITORY_RE.test(row.fork_repository) ||
+          !row.fork_repository.startsWith("PalomarArchive/")) {
+        fail(`entry.preservation.repositories[${position}].fork_repository is malformed`);
+      }
+      const key = `${row.source_repository.toLowerCase()}\0${row.commit}`;
+      if (seen.has(key)) fail(`entry.preservation.repositories[${position}] is duplicated`);
+      seen.add(key);
+      const expectedRef = `refs/tags/palomar/${entry.id}-v${entry.version}/${row.commit}`;
+      if (row.ref !== expectedRef) {
+        fail(`entry.preservation.repositories[${position}].ref is not canonical`);
+      }
+      actualRows.push([row.source_repository, row.commit]);
+    }
+    if (JSON.stringify(actualRows) !== JSON.stringify(expectedRows)) {
+      fail("entry.preservation.repositories does not exactly cover the source graph");
+    }
+  }
+
   const verification = object(entry.verification, "entry.verification");
   string(verification.verified_at, "entry.verification.verified_at");
   string(verification.workflow_url, "entry.verification.workflow_url");
@@ -570,6 +739,23 @@ export function pinnedSourceFileUrl(entry, path) {
   }
   const encodedPath = encodedRepositoryPath(path);
   return safeExternalUrl(`${expectedRepository}/blob/${entry.source.commit}/${encodedPath}`);
+}
+
+export function pinnedRepositoryFileUrl(repository, revision, path) {
+  if (!REPOSITORY_RE.test(repository)) fail("source repository is malformed");
+  commit(revision, "source commit");
+  safeRepositoryPath(path, "source file path");
+  return safeExternalUrl(
+    `https://github.com/${repository}/blob/${revision}/${encodedRepositoryPath(path)}`,
+  );
+}
+
+export function pinnedRepositoryDirectoryUrl(repository, revision, path = ".") {
+  if (!REPOSITORY_RE.test(repository)) fail("source repository is malformed");
+  commit(revision, "source commit");
+  safeDependencyPath(path, "source directory path");
+  const suffix = path === "." ? "" : `/${encodedRepositoryPath(path)}`;
+  return safeExternalUrl(`https://github.com/${repository}/tree/${revision}${suffix}`);
 }
 
 export function pinnedSourceDirectoryUrl(entry, path) {

--- a/assets/style.css
+++ b/assets/style.css
@@ -979,3 +979,54 @@ pre {
     max-height: none;
   }
 }
+.source-availability {
+  border: 1px solid var(--line, #d9d6cc);
+  border-left: 0.35rem solid #52714f;
+  border-radius: 0.45rem;
+  margin: 1rem 0 1.5rem;
+  padding: 0.9rem 1rem;
+}
+
+.source-availability p {
+  margin: 0.35rem 0;
+}
+
+.source-availability.original-missing,
+.source-availability.archive-missing {
+  border-left-color: #9a6700;
+  background: #fff8df;
+}
+
+.source-availability.unrecoverable {
+  border-left-color: #b42318;
+  background: #fff1f0;
+}
+
+.source-status.missing {
+  color: #9a6700;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.exact-tombstone {
+  min-height: 100vh;
+}
+
+.exact-tombstone .entry-page {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 2rem;
+  text-align: center;
+}
+
+.tombstone-record h1,
+.tombstone-record p {
+  margin: 0;
+}
+
+.tombstone-record p {
+  color: var(--muted);
+  margin-top: 0.65rem;
+}

--- a/entry.html
+++ b/entry.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#ffffff">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Registry entry — Palomar</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="assets/style.css">
@@ -22,15 +22,15 @@
         <noscript>
           <br>
           Entry pages require JavaScript because they read immutable records from
-          PalomarDatabase at runtime. You can instead
-          <a href="https://github.com/PalomarRegistry/PalomarDatabase/tree/main/entries">browse the JSON records directly</a>.
+          the machine-readable registry at runtime. You can instead
+          <a href="https://data.palomar-registry.org/index.json">open the JSON index</a>.
         </noscript>
       </div>
       <article id="entry-content" hidden></article>
     </main>
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="https://github.com/PalomarRegistry/PalomarDatabase">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="https://data.palomar-registry.org/index.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/app.js"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="A public registry of Lean-verified mathematical results.">
     <meta name="theme-color" content="#ffffff">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Palomar — Lean-verified mathematics</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="assets/style.css">
@@ -40,8 +40,8 @@
       <section class="registry-section" id="registry" aria-labelledby="registry-heading">
         <div class="section-heading">
           <h2 id="registry-heading">Accepted results</h2>
-          <a class="data-link" href="https://github.com/PalomarRegistry/PalomarDatabase">
-            Raw data and schema
+          <a class="data-link" href="https://data.palomar-registry.org/index.json">
+            Machine-readable index
           </a>
         </div>
 
@@ -72,9 +72,9 @@
           Reading the Palomar database…
           <noscript>
             <br>
-            The registry requires JavaScript because it reads PalomarDatabase at
-            runtime. You can instead
-            <a href="https://github.com/PalomarRegistry/PalomarDatabase/tree/main/entries">browse the JSON records directly</a>.
+            The registry requires JavaScript because it reads the machine-readable
+            registry at runtime. You can instead
+            <a href="https://data.palomar-registry.org/index.json">open the JSON index</a>.
           </noscript>
         </div>
         <div id="entry-grid" class="entry-grid" aria-live="polite"></div>
@@ -89,7 +89,7 @@
       <div class="footer-links">
         <a href="https://data.palomar-registry.org/feed.xml">RSS</a>
         <a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a>
-        <a href="https://github.com/PalomarRegistry/PalomarDatabase">Data</a>
+        <a href="https://data.palomar-registry.org/index.json">Data</a>
         <a href="https://github.com/leanprover/comparator">Comparator</a>
         <a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a>
       </div>

--- a/render.html
+++ b/render.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#ffffff">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Named compared declarations — Palomar</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="assets/style.css">
@@ -21,7 +21,7 @@
     </main>
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="https://github.com/PalomarRegistry/PalomarDatabase">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="https://data.palomar-registry.org/index.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/app.js"></script>
   </body>

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import pathlib
 import re
@@ -23,7 +24,7 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
         else {"arxiv": ["math.NT"], "msc2020": ["11N13"]}
     )
     record = {
-        "schema_version": 1,
+        "schema_version": 2,
         "id": identifier,
         "accepted_at": "2026-07-29",
         "version": version,
@@ -142,6 +143,31 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
                 ],
             }
         )
+    sources = [(record["source"]["repository"], record["source"]["commit"])]
+    sources.extend(
+        (dependency["repository"], dependency["revision"])
+        for dependency in record["formalization"]["project_dependencies"]
+        if "path" not in dependency
+    )
+    unique = {}
+    for repository, commit in sources:
+        unique.setdefault((repository.casefold(), commit), (repository, commit))
+    record["preservation"] = {
+        "archive_owner": "PalomarArchive",
+        "archived_at": "2026-07-29T09:01:00Z",
+        "receipt_sha256": "f" * 64,
+        "repositories": [
+            {
+                "source_repository": repository,
+                "commit": commit,
+                "fork_repository": "PalomarArchive/" + repository.replace("/", "--"),
+                "ref": f"refs/tags/palomar/{identifier}-v{version}/{commit}",
+            }
+            for repository, commit in sorted(
+                unique.values(), key=lambda item: (item[0].casefold(), item[1])
+            )
+        ],
+    }
     return record
 
 
@@ -186,9 +212,45 @@ class Handler(SimpleHTTPRequestHandler):
 
     def do_GET(self) -> None:  # noqa: N802 - inherited HTTP method name
         path = self.path.split("?", 1)[0]
+        if path in {
+            "/database/source-availability.json",
+            "/database/source-availability-missing.json",
+        }:
+            original_status = "missing" if path.endswith("-missing.json") else "available"
+            mappings = {}
+            for record in ENTRIES.values():
+                for row in record["preservation"]["repositories"]:
+                    key = (row["source_repository"].casefold(), row["commit"])
+                    mappings.setdefault(key, row)
+            checked_at = dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace(
+                "+00:00", "Z"
+            )
+            endpoint = lambda status: {
+                "status": status,
+                "checked_at": checked_at,
+                "last_attempt_at": checked_at,
+                "consecutive_missing": 2 if status == "missing" else 0,
+                "last_error": None,
+            }
+            payload = {
+                "schema_version": 1,
+                "generated_at": checked_at,
+                "repositories": [
+                    {
+                        "source_repository": row["source_repository"],
+                        "commit": row["commit"],
+                        "fork_repository": row["fork_repository"],
+                        "original": endpoint(original_status),
+                        "archive": endpoint("available"),
+                    }
+                    for row in mappings.values()
+                ],
+            }
+            self.send_bytes(json.dumps(payload).encode(), "application/json")
+            return
         if path == "/database/index.json":
             payload = {
-                "schema_version": 2,
+                "schema_version": 3,
                 "generated_at": "2026-07-29T09:00:00Z",
                 "entries": [
                     {
@@ -202,6 +264,22 @@ class Handler(SimpleHTTPRequestHandler):
                 ]
             }
             self.send_bytes(json.dumps(payload).encode(), "application/json")
+            return
+        tombstone = re.fullmatch(
+            r"/database/tombstones/(PALOMAR-2026-07-29-000125)-v(1)\.json",
+            path,
+        )
+        if tombstone:
+            self.send_bytes(
+                json.dumps(
+                    {
+                        "id": tombstone.group(1),
+                        "version": int(tombstone.group(2)),
+                        "taken_down_on": "2026-08-06",
+                    }
+                ).encode(),
+                "application/json",
+            )
             return
         match = re.fullmatch(
             r"/database/entries/(PALOMAR-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6})-v([1-9][0-9]*)\.json",

--- a/tests/rendering.test.js
+++ b/tests/rendering.test.js
@@ -18,6 +18,15 @@ function entry(overrides = {}) {
       repository_url: "https://github.com/example/challenge",
       commit: "1".repeat(40),
     },
+    preservation: {
+      repositories: [
+        {
+          source_repository: "example/challenge",
+          commit: "1".repeat(40),
+          fork_repository: "PalomarArchive/challenge",
+        },
+      ],
+    },
     formalization: {
       challenge_path: "Challenge.lean",
       theorem_names: ["Example.theorem"],
@@ -77,6 +86,10 @@ test("source URL is always the immutable canonical GitHub file", () => {
   assert.equal(
     challengeSourceUrl(nested),
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/project/Comparator/Task.lean`,
+  );
+  assert.equal(
+    challengeSourceUrl(entry(), "PalomarArchive/challenge"),
+    `https://github.com/PalomarArchive/challenge/blob/${"1".repeat(40)}/Challenge.lean`,
   );
 
   const traversal = entry();

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -6,9 +6,11 @@ import { htmlFiles } from "../scripts/build-site.mjs";
 
 import {
   DEFAULT_DATABASE,
+  DEFAULT_AVAILABILITY,
   ENTRY_SCHEMA_VERSION,
   DEFAULT_RENDER_BASE,
   databaseBaseFor,
+  availabilityRecord,
   RESULT_ORIGIN_LABELS,
   REPOSITORY_ROLE_LABELS,
   entryRecordUrl,
@@ -19,9 +21,13 @@ import {
   safeExternalUrl,
   safeInternalUrl,
   selectDatabaseUrl,
+  selectAvailabilityUrl,
   selectRenderBase,
+  tombstoneUrl,
   validateEntry,
+  validateAvailability,
   validateIndex,
+  validateTombstone,
 } from "../assets/security.mjs";
 
 // The website's own origin, for the cross-origin assertion below.
@@ -42,13 +48,13 @@ function summary(overrides = {}) {
 }
 
 function index(entries = [summary()], overrides = {}) {
-  return { schema_version: 2, entries, ...overrides };
+  return { schema_version: 3, entries, ...overrides };
 }
 
 function entry(overrides = {}) {
   const evidenceTree = "c".repeat(64);
   const value = {
-    schema_version: 1,
+    schema_version: 2,
     id: "PALOMAR-2026-07-29-000123",
     accepted_at: "2026-07-29",
     version: 1,
@@ -79,6 +85,25 @@ function entry(overrides = {}) {
         declared_identifier: "Apache-2.0",
         detected_identifier: "Apache-2.0",
       },
+    },
+    preservation: {
+      archive_owner: "PalomarArchive",
+      archived_at: "2026-07-29T09:01:00Z",
+      receipt_sha256: "f".repeat(64),
+      repositories: [
+        {
+          source_repository: "example/challenge",
+          commit: COMMIT,
+          fork_repository: "PalomarArchive/example--challenge--fixture",
+          ref: `refs/tags/palomar/PALOMAR-2026-07-29-000123-v1/${COMMIT}`,
+        },
+        {
+          source_repository: "leanprover-community/mathlib4",
+          commit: COMMIT,
+          fork_repository: "PalomarArchive/mathlib4--fixture",
+          ref: `refs/tags/palomar/PALOMAR-2026-07-29-000123-v1/${COMMIT}`,
+        },
+      ],
     },
     formalization: {
       challenge_path: "Challenge.lean",
@@ -178,6 +203,25 @@ test("production also pins the rendered-Challenge origin", () => {
   );
 });
 
+test("production pins availability while loopback can select a fixture", () => {
+  assert.equal(
+    selectAvailabilityUrl(
+      "https://palomar-registry.org/",
+      "?availability=https://attacker.invalid/status.json",
+      "https://attacker.invalid/database/",
+    ).href,
+    DEFAULT_AVAILABILITY,
+  );
+  assert.equal(
+    selectAvailabilityUrl(
+      "http://127.0.0.1:8000/",
+      "?availability=/fixtures/status.json",
+      "http://127.0.0.1:8000/database/",
+    ).href,
+    "http://127.0.0.1:8000/fixtures/status.json",
+  );
+});
+
 test("loopback development can select an HTTP fixture", () => {
   assert.equal(isLoopbackHostname("localhost"), true);
   assert.equal(isLoopbackHostname("127.9.8.7"), true);
@@ -211,13 +255,34 @@ test("index entry paths are exact descendants of the database prefix", () => {
 });
 
 test("index validation rejects unsupported, rejected, and duplicate summaries", () => {
-  assert.throws(() => validateIndex(index([], { schema_version: 3 })), /unsupported index/);
+  assert.throws(() => validateIndex(index([], { schema_version: 2 })), /unsupported index/);
   assert.throws(
     () => validateIndex(index([summary({ status: "draft" })])),
     /status is not accepted/,
   );
   assert.throws(() => validateIndex(index([summary(), summary()])), /duplicate index entry/);
   assert.equal(validateIndex(index()).entries.length, 1);
+});
+
+test("exact tombstones are closed, date-only, and bound to their URL", () => {
+  const base = databaseBaseFor("https://example.test/database/index.json");
+  const id = "PALOMAR-2026-07-29-000123";
+  assert.equal(
+    tombstoneUrl(id, 2, base).href,
+    `https://example.test/database/tombstones/${id}-v2.json`,
+  );
+  assert.deepEqual(
+    validateTombstone({ id, version: 2, taken_down_on: "2026-08-06" }, id, 2),
+    { id, version: 2, taken_down_on: "2026-08-06" },
+  );
+  assert.throws(
+    () => validateTombstone({ id, version: 2, taken_down_on: "2026-02-30" }, id, 2),
+    /date is malformed/,
+  );
+  assert.throws(
+    () => validateTombstone({ id, version: 2, taken_down_on: "2026-08-06", reason: "secret" }, id, 2),
+    /unexpected fields/,
+  );
 });
 
 test("active-content and insecure data-derived links are never allowed", () => {
@@ -253,6 +318,59 @@ test("a canonical accepted record validates", () => {
   );
 });
 
+test("preservation must cover every immutable source", () => {
+  const missing = entry();
+  missing.preservation.repositories.pop();
+  assert.throws(() => validateEntry(missing, summary()), /does not exactly cover/);
+
+  const moving = entry();
+  moving.preservation.repositories[0].ref = "refs/tags/latest";
+  assert.throws(() => validateEntry(moving, summary()), /ref is not canonical/);
+});
+
+test("legacy schema v1 records remain readable without an archive mapping", () => {
+  const legacy = entry({ schema_version: 1 });
+  delete legacy.preservation;
+  assert.equal(validateEntry(legacy, summary()).schema_version, 1);
+});
+
+test("availability is validated and stale state becomes unknown", () => {
+  const manifest = validateAvailability({
+    schema_version: 1,
+    generated_at: "2026-08-06T00:00:00Z",
+    repositories: [
+      {
+        source_repository: "example/challenge",
+        commit: COMMIT,
+        fork_repository: "PalomarArchive/example--challenge--fixture",
+        original: {
+          status: "missing",
+          checked_at: "2026-08-06T00:00:00Z",
+          last_attempt_at: "2026-08-06T00:00:00Z",
+          consecutive_missing: 2,
+          last_error: null,
+        },
+        archive: {
+          status: "available",
+          checked_at: "2026-08-06T00:00:00Z",
+          last_attempt_at: "2026-08-06T00:00:00Z",
+          consecutive_missing: 0,
+          last_error: null,
+        },
+      },
+    ],
+  });
+  assert.equal(
+    availabilityRecord(manifest, "EXAMPLE/challenge", COMMIT, Date.parse("2026-08-06T12:00:00Z"))
+      .original.status,
+    "missing",
+  );
+  assert.equal(
+    availabilityRecord(manifest, "example/challenge", COMMIT, Date.parse("2026-08-07T00:00:00Z")),
+    null,
+  );
+});
+
 test("withdrawn palomar-indexed provenance is rejected", () => {
   const trust = {
     ...entry().trust,
@@ -280,7 +398,7 @@ test("withdrawn palomar-indexed provenance is rejected", () => {
 });
 
 test("entry schema, acceptance state, verdict, and selected identity fail closed", () => {
-  assert.throws(() => validateEntry(entry({ schema_version: 2 }), summary()), /unsupported entry/);
+  assert.throws(() => validateEntry(entry({ schema_version: 99 }), summary()), /unsupported entry/);
   assert.throws(() => validateEntry(entry({ status: "draft" }), summary()), /not accepted/);
   const rejected = entry();
   rejected.review.verdict = "reject";
@@ -387,10 +505,8 @@ test("every HTML entry point carries the restrictive CSP", async () => {
     // challenge-metadata.json from it. While the site and the renders shared
     // an origin, connect-src 'self' covered that silently. It does not now,
     // and omitting it fails only in the browser console.
-    assert.match(
-      html,
-      /connect-src 'self' https:\/\/raw\.githubusercontent\.com https:\/\/data\.palomar-registry\.org/,
-    );
+    assert.match(html, /connect-src 'self' https:\/\/data\.palomar-registry\.org/);
+    assert.doesNotMatch(html, /raw\.githubusercontent\.com/);
     assert.match(html, /object-src 'none'/);
   }
 });
@@ -449,7 +565,7 @@ test("every provenance value the schema allows has an explicit label", async () 
   const checkout = process.env.PALOMAR_DATABASE_CHECKOUT
     ?? new URL("../../PalomarDatabase/", import.meta.url).pathname;
   const schema = JSON.parse(
-    await readFile(new URL("schema-v1.json", `file://${checkout}/`), "utf8"),
+    await readFile(new URL("schema-v2.json", `file://${checkout}/`), "utf8"),
   );
   const provenance = schema.properties.provenance.properties;
   for (const [field, labels] of [
@@ -468,7 +584,7 @@ test("the site validates exactly the schema version the database publishes", asy
   const checkout = process.env.PALOMAR_DATABASE_CHECKOUT
     ?? new URL("../../PalomarDatabase/", import.meta.url).pathname;
   const schema = JSON.parse(
-    await readFile(new URL("schema-v1.json", `file://${checkout}/`), "utf8"),
+    await readFile(new URL("schema-v2.json", `file://${checkout}/`), "utf8"),
   );
   assert.strictEqual(schema.properties.schema_version.const, ENTRY_SCHEMA_VERSION);
 });

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -4,6 +4,9 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 const database = encodeURIComponent("http://127.0.0.1:4173/database/index.json");
+const missingAvailability = encodeURIComponent(
+  "http://127.0.0.1:4173/database/source-availability-missing.json",
+);
 const previousRef = process.env.PALOMAR_PREVIOUS_REF;
 const currentIndex = readFileSync(fileURLToPath(new URL("../index.html", import.meta.url)), "utf8");
 
@@ -242,6 +245,30 @@ test("a thin wrapper says where the mathematics is before anything else", async 
   }
 });
 
+test("a missing original automatically switches source links to the Palomar copy", async ({ page }) => {
+  await page.goto(
+    `/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}` +
+      `&availability=${missingAvailability}`,
+  );
+  const notice = page.locator(".source-availability.original-missing");
+  await expect(notice).toContainText("Original source unavailable");
+  await expect(notice.getByRole("link", { name: "Palomar preserved copy" })).toHaveAttribute(
+    "href",
+    /github\.com\/PalomarArchive\/example--challenge\/tree\/1{40}\/project$/,
+  );
+  await expect(
+    page.getByRole("link", { name: /View full pinned statement file/ }),
+  ).toHaveAttribute(
+    "href",
+    /github\.com\/PalomarArchive\/example--challenge\/blob\/1{40}\/project\/Comparator\/Task\.lean$/,
+  );
+  await page.locator("details.solution-dependencies > summary").click();
+  await expect(page.getByRole("link", { name: "example/dependency (Palomar copy)" })).toHaveAttribute(
+    "href",
+    /github\.com\/PalomarArchive\/example--dependency\/tree\/3{40}$/,
+  );
+});
+
 test("entry pages list immutable versions and flag superseded snapshots", async ({ page }) => {
   await page.goto(
     `/entry.html?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`,
@@ -311,6 +338,33 @@ test("entry version parameters use canonical positive-integer spelling", async (
   );
   await expect(page.locator("#status")).toContainText("missing or invalid Palomar ID or version");
   await expect(page.locator("#entry-content")).toBeHidden();
+});
+
+test("an exact unavailable entry shows only its target and public date", async ({ page }) => {
+  const id = "PALOMAR-2026-07-29-000125";
+  await page.goto(`/entry.html?id=${id}&version=1&database=${database}`);
+
+  await expect(page.locator(".tombstone-record h1")).toHaveText(`${id} v1`);
+  await expect(page.locator(".tombstone-record p")).toHaveText("6 August 2026");
+  await expect(page.locator("a:visible")).toHaveCount(0);
+  await expect(page.locator("body")).not.toContainText(/reason|takedown|withdraw/i);
+});
+
+test("an exact unavailable render uses the same minimal disclosure", async ({ page }) => {
+  const id = "PALOMAR-2026-07-29-000125";
+  await page.goto(`/render.html?id=${id}&version=1&database=${database}`);
+
+  await expect(page.locator(".tombstone-record h1")).toHaveText(`${id} v1`);
+  await expect(page.locator(".tombstone-record p")).toHaveText("6 August 2026");
+  await expect(page.locator("a:visible")).toHaveCount(0);
+});
+
+test("unknown exact versions remain generic not-found pages", async ({ page }) => {
+  await page.goto(
+    `/entry.html?id=PALOMAR-2026-07-29-999999&version=1&database=${database}`,
+  );
+  await expect(page.locator("#status")).toContainText("entry not found");
+  await expect(page.locator(".tombstone-record")).toHaveCount(0);
 });
 
 test("the index version-history link reaches history loaded at runtime", async ({ page }) => {
@@ -501,4 +555,3 @@ test("current JavaScript preserves represented deep links with cached HTML", asy
   await expect(page.locator(".entry-card:visible")).toContainText("000124");
   await expect(page.locator("#status")).not.toContainText("could not be loaded");
 });
-


### PR DESCRIPTION
## Summary

- replace raw canonical-database URLs with the filtered public data origin
- support public index v3 and date-only exact-version tombstones
- preserve schema-v1 and schema-v2 source rendering behavior
- keep takedowns undiscoverable from unversioned lookups and ordinary pages

## Verification

- 33 unit tests passed
- 22 browser tests passed; 2 skipped by design