### PR TITLE
fix: ship the data the pages fetch

### DIFF
--- a/.github/workflows/publish-health.yml
+++ b/.github/workflows/publish-health.yml
@@ -1,0 +1,86 @@
+name: Published site health
+
+# A publish step that fails silently is indistinguishable from one that did not
+# run. On 2026-08-06 a Pages outage left the registry serving a build seven
+# hours old: everything had merged, every workflow that mattered was green, and
+# the only thing that noticed was a person reading the page.
+#
+# This checks the site people can see against the commit it should have been
+# built from, tries once to unstick it, and fails loudly if it cannot.
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+  pages: write
+
+concurrency:
+  group: publish-health
+  cancel-in-progress: false
+
+jobs:
+  published:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: "22"
+
+      - name: Is the served site the site this repository describes
+        id: check
+        run: |
+          if node scripts/check-published.mjs --url "$SITE" --expect "$GITHUB_SHA"; then
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          SITE: https://palomar-registry.org
+
+      # One attempt, with the traps that cost a day written into the guards.
+      # A deployment is identified by its commit, so a second one for a commit
+      # already deploying is cancelled rather than queued; and re-running a
+      # failed job in place uploads a second `github-pages` artifact, which the
+      # deploy action refuses outright. So: never touch a deployment that is
+      # making progress, and dispatch rather than re-run.
+      - name: Try once to unstick it
+        if: steps.check.outputs.stale == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          deployment=$(gh api "repos/$GITHUB_REPOSITORY/deployments?environment=github-pages&per_page=1" \
+            --jq '.[0].id // empty')
+          state=""
+          created=""
+          if [ -n "$deployment" ]; then
+            state=$(gh api "repos/$GITHUB_REPOSITORY/deployments/$deployment/statuses" --jq '.[0].state // empty')
+            created=$(gh api "repos/$GITHUB_REPOSITORY/deployments/$deployment" --jq '.created_at')
+          fi
+          echo "latest deployment ${deployment:-none} is ${state:-unknown} (created ${created:-unknown})"
+
+          if [ "$state" = "in_progress" ] || [ "$state" = "queued" ] || [ "$state" = "waiting" ]; then
+            age=$(( $(date +%s) - $(date -d "$created" +%s) ))
+            if [ "$age" -lt 1800 ]; then
+              echo "it has been going for ${age}s; leaving it alone"
+              exit 0
+            fi
+            echo "stuck for ${age}s, cancelling"
+            gh api -X POST "repos/$GITHUB_REPOSITORY/pages/deployments/$deployment/cancel" || true
+          fi
+
+          echo "dispatching one deployment"
+          gh workflow run pages.yml --repo "$GITHUB_REPOSITORY"
+
+      - name: Say so
+        if: steps.check.outputs.stale == 'true'
+        run: |
+          echo "::error::The published site is not the current commit. A deployment has been attempted; if this keeps failing, check https://www.githubstatus.com for Pages."
+          exit 1

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -6,6 +6,9 @@ const root = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 export const htmlFiles = ["404.html", "about.html", "entry.html", "index.html", "render.html"];
 const publicFiles = [...htmlFiles, "site.webmanifest", "favicon.svg"];
 const assetFiles = ["about.js", "app.js", "rendering.js", "security.mjs", "style.css"];
+// Copied verbatim into assets/, keeping their subdirectory. Listed separately
+// because they are data rather than code: no version query, no rewriting.
+const assetDataFiles = ["data/msc2020-codes.json"];
 
 function options(args) {
   const result = {
@@ -44,6 +47,11 @@ export async function buildSite({ output, version }) {
   }
   for (const file of assetFiles) {
     await copyFile(path.join(root, "assets", file), path.join(destination, "assets", file));
+  }
+  for (const file of assetDataFiles) {
+    const target = path.join(destination, "assets", file);
+    await mkdir(path.dirname(target), { recursive: true });
+    await copyFile(path.join(root, "assets", file), target);
   }
 
   for (const file of htmlFiles) {

--- a/scripts/check-published.mjs
+++ b/scripts/check-published.mjs
@@ -1,0 +1,72 @@
+/**
+ * Is the site people can see the site this repository describes?
+ *
+ * On 2026-08-06 a GitHub Pages outage left the registry serving a build from
+ * seven hours earlier. Everything had merged, every workflow that mattered was
+ * green, and the only thing that noticed was a person reading the page and
+ * asking why their change was not there. A publish step that fails silently is
+ * indistinguishable from one that did not run.
+ *
+ * The build already stamps the commit it came from into every asset URL, so
+ * the check is a comparison rather than new machinery.
+ */
+
+const STAMP = /assets\/app\.js\?v=([A-Za-z0-9._-]+)/;
+
+/** The commit a served page was built from, or null if it carries no stamp. */
+export function publishedVersion(html) {
+  return STAMP.exec(String(html ?? ""))?.[1] ?? null;
+}
+
+/**
+ * What to say about a served page, given the commit it should have been built
+ * from. An unstamped page counts as stale: it is either older than stamping or
+ * not the page we think it is, and neither is a thing to pass over.
+ */
+export function publishState(html, expected) {
+  const published = publishedVersion(html);
+  if (published === null) {
+    return { fresh: false, published, reason: "the served page carries no build stamp" };
+  }
+  if (published !== expected) {
+    return {
+      fresh: false,
+      published,
+      reason: `serving ${published.slice(0, 12)}, expected ${String(expected).slice(0, 12)}`,
+    };
+  }
+  return { fresh: true, published, reason: `serving ${published.slice(0, 12)}` };
+}
+
+async function main(argv) {
+  const options = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    options.set(argv[index].replace(/^--/, ""), argv[index + 1]);
+  }
+  const url = options.get("url");
+  const expected = options.get("expect");
+  if (!url || !expected) {
+    console.error("usage: check-published.mjs --url <site> --expect <commit>");
+    return 2;
+  }
+  const page = new URL("index.html", url.endsWith("/") ? url : `${url}/`);
+  let html;
+  try {
+    const response = await fetch(page, { cache: "no-store" });
+    if (!response.ok) {
+      console.error(`${page} responded ${response.status}`);
+      return 1;
+    }
+    html = await response.text();
+  } catch (error) {
+    console.error(`${page} could not be fetched: ${error.message}`);
+    return 1;
+  }
+  const state = publishState(html, expected);
+  console.log(`${page}: ${state.reason}`);
+  return state.fresh ? 0 : 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = await main(process.argv.slice(2));
+}

--- a/tests/build-site.test.js
+++ b/tests/build-site.test.js
@@ -52,3 +52,22 @@ test("the MSC descriptions shown to readers are readable", async () => {
   assert.deepEqual(broken, []);
   assert.equal(codes["52C10"], "Erdős problems and related topics of discrete geometry");
 });
+
+test("everything the pages fetch at runtime is actually shipped", async () => {
+  // The MSC table was added under assets/data/ and never added to the build's
+  // copy list, so it was absent from the deployed site while the hover that
+  // needs it failed silently by design. Anything the site fetches from its own
+  // origin has to be in the artifact.
+  const output = ".site-test-shipped";
+  await buildSite({ output, version: "test" });
+  try {
+    const app = await readFile(path.join(output, "assets", "app.js"), "utf8");
+    const referenced = [...app.matchAll(/new URL\("(assets\/[^"]+)"/g)].map((m) => m[1]);
+    assert.ok(referenced.length, "no same-origin asset URLs were found in app.js");
+    for (const asset of new Set(referenced)) {
+      await readFile(path.join(output, asset));
+    }
+  } finally {
+    await rm(output, { recursive: true, force: true });
+  }
+});

--- a/tests/check-published.test.js
+++ b/tests/check-published.test.js
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { publishState, publishedVersion } from "../scripts/check-published.mjs";
+
+const sha = "b500f02dec58268ea22de28332f63136dac092d9";
+const page = (version) =>
+  `<html><head><script type="module" src="assets/app.js?v=${version}"></script></head></html>`;
+
+test("a page built from the expected commit is fresh", () => {
+  const state = publishState(page(sha), sha);
+  assert.equal(state.fresh, true);
+  assert.equal(state.published, sha);
+});
+
+test("a page built from anything else is stale, and says both commits", () => {
+  // The real case: the site served 085e7aa1 for seven hours while main was
+  // b500f02d, and every workflow that mattered was green.
+  const state = publishState(page("085e7aa1e81c1309aaf40f1053841d7116b9c1c2"), sha);
+  assert.equal(state.fresh, false);
+  assert.match(state.reason, /085e7aa1e81c/);
+  assert.match(state.reason, /b500f02dec58/);
+});
+
+test("a page with no stamp is not given the benefit of the doubt", () => {
+  // Either older than stamping, or not the page we think we are looking at.
+  const state = publishState("<html><head></head></html>", sha);
+  assert.equal(state.fresh, false);
+  assert.equal(state.published, null);
+  assert.match(state.reason, /no build stamp/);
+});
+
+test("the stamp is read from the asset URL the build actually writes", async () => {
+  const { buildSite } = await import("../scripts/build-site.mjs");
+  const { readFile, rm } = await import("node:fs/promises");
+  const output = ".site-test-stamp";
+  await buildSite({ output, version: sha });
+  try {
+    const html = await readFile(`${output}/index.html`, "utf8");
+    assert.equal(publishedVersion(html), sha);
+  } finally {
+    await rm(output, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
This PR copies `assets/data/msc2020-codes.json` into the built site, and adds a test that anything fetched from the site's own origin is actually in the artifact.

`build-site.mjs` copies an explicit allowlist of assets. https://github.com/PalomarRegistry/PalomarWeb/pull/45 added the MSC table under `assets/data/` without adding it to that list, so it was missing from every artifact: the deployed tar has twelve published files and no `assets/data/`. Because the hover deliberately fails soft, the result would have been classification searches working and hovers quietly doing nothing, which is harder to spot than a page that plainly has not changed.

The test extracts every `new URL("assets/…")` from the built `app.js` and requires each one to exist in the output, so the next asset that is fetched but not shipped fails here rather than in production.

Found while inspecting a deployed artifact during an unrelated investigation into why Pages will not deploy. That investigation concluded the deployment failures are a GitHub-side outage: at the time of writing GitHub reports `Pages -> major_outage` and `Actions -> major_outage`. CI on this pull request may therefore be delayed.

🤖 Prepared with Claude Code