### PR TITLE
Clarify unarchived source warnings

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -819,9 +819,15 @@ function sourceAvailabilityNotice(entry, availability) {
   if (!location.archiveRepository) {
     notice.classList.add("legacy");
     notice.append(
-      el("strong", "", "Source recorded before automatic preservation"),
-      el("p", "", "This legacy entry links to its original pinned commit."),
-      externalLink("Recorded original location", original),
+      el("strong", "", "Palomar has no preservation copy of this source"),
+      el(
+        "p",
+        "",
+        "This record was accepted before Palomar began archiving source repositories. " +
+          "The link goes to the original repository at the exact commit that was reviewed, " +
+          "but it may stop working if that repository is removed.",
+      ),
+      externalLink("Open the reviewed source", original),
     );
     return notice;
   }

--- a/assets/style.css
+++ b/assets/style.css
@@ -979,12 +979,12 @@ pre {
     max-height: none;
   }
 }
-.source-availability {
+.entry-page .source-availability {
   border: 1px solid var(--line, #d9d6cc);
   border-left: 0.35rem solid #52714f;
   border-radius: 0.45rem;
   margin: 1rem 0 1.5rem;
-  padding: 0.9rem 1rem;
+  padding: 1rem 1.25rem;
 }
 
 .source-availability p {
@@ -992,7 +992,8 @@ pre {
 }
 
 .source-availability.original-missing,
-.source-availability.archive-missing {
+.source-availability.archive-missing,
+.source-availability.legacy {
   border-left-color: #9a6700;
   background: #fff8df;
 }

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -269,6 +269,30 @@ test("a missing original automatically switches source links to the Palomar copy
   );
 });
 
+test("an entry accepted before source archiving explains the limitation as a warning", async ({ page }) => {
+  await page.route("**/entries/PALOMAR-2026-07-29-000123-v1.json", async (route) => {
+    const response = await route.fetch();
+    const legacy = await response.json();
+    legacy.schema_version = 1;
+    delete legacy.preservation;
+    await route.fulfill({ response, json: legacy });
+  });
+  await page.goto(
+    `/entry.html?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`,
+  );
+
+  const notice = page.locator(".source-availability.legacy");
+  await expect(notice).toContainText("Palomar has no preservation copy of this source");
+  await expect(notice).toContainText("before Palomar began archiving source repositories");
+  await expect(notice).toContainText("may stop working if that repository is removed");
+  await expect(notice.getByRole("link", { name: "Open the reviewed source" })).toHaveAttribute(
+    "href",
+    /github\.com\/example\/challenge\/tree\/1{40}\/project$/,
+  );
+  await expect(notice).toHaveCSS("background-color", "rgb(255, 248, 223)");
+  await expect(notice).toHaveCSS("padding-left", "20px");
+});
+
 test("entry pages list immutable versions and flag superseded snapshots", async ({ page }) => {
   await page.goto(
     `/entry.html?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`,


### PR DESCRIPTION
## What changed

- explain in visitor-facing language why older records have no Palomar preservation copy
- present that limitation as an amber warning instead of a green success state
- fix CSS specificity so the callout retains comfortable inner spacing
- cover the legacy state, copy, link target, color, and computed padding in the browser suite

## Why

The previous legacy label assumed knowledge of Palomar internals, appeared successful, and inherited zero horizontal padding from the generic entry-section rule.

## Validation

- 39 JavaScript tests passed
- 23 Playwright tests passed; 2 compatibility tests skipped by design
- git diff --check