### PR TITLE
feat: show the decision and the comments, not the scores

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1257,20 +1257,27 @@ async function renderEntry(
   editorialBlock.append(el("div", "eyebrow", "Editorial record"), el("h2", "", "Automated review"));
   editorialTitle.append(editorialBlock, el("span", "decision", "Accepted"));
   editorial.append(editorialTitle);
-  const scores = el("div", "score-grid");
-  for (const [name, score] of Object.entries(entry.review.scores)) {
-    const item = el("div", "score");
-    item.append(el("span", "", name.replaceAll("_", " ")), el("strong", "", `${score}/5`));
-    scores.append(item);
-  }
-  editorial.append(scores);
+  // No scores. They decide whether a submission is accepted and they are kept
+  // with the record, but they are not shown: the same repository at the same
+  // commit has scored 5 and then 4 on the same axis across two runs, and a
+  // number that moves like that reads as a judgement it cannot support. What
+  // it can support is the decision, which is above.
+  editorial.append(
+    el(
+      "p",
+      "review-explanation",
+      "An AI review compared the informal claim with the formal statement under " +
+        "the recorded policy, and its comments are below. It is not human peer " +
+        "review and not a novelty certificate.",
+    ),
+  );
   if (entry.review.warnings.length) {
-    editorial.append(el("h3", "", "Permanent warnings"));
-    const warnings = el("ul", "warning-list");
-    for (const warning of entry.review.warnings) warnings.append(el("li", "", warning));
-    editorial.append(warnings);
+    editorial.append(el("h3", "", "AI review comments"));
+    const comments = el("ul", "review-comments");
+    for (const comment of entry.review.warnings) comments.append(el("li", "", comment));
+    editorial.append(comments);
   } else {
-    editorial.append(el("p", "no-warnings", "No permanent editorial warnings were recorded."));
+    editorial.append(el("p", "no-warnings", "The review recorded no comments on this result."));
   }
   editorial.append(
     dataLink(

--- a/assets/style.css
+++ b/assets/style.css
@@ -832,36 +832,21 @@ pre {
   text-transform: uppercase;
 }
 
-.score-grid {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
+.review-explanation {
   margin-bottom: 1rem;
-  border-block: 1px solid var(--line);
-}
-
-.score {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  padding: .55rem;
-  border-right: 1px dotted var(--line);
-}
-
-.score:last-child {
-  border-right: 0;
-}
-
-.score span {
-  display: block;
-  margin-bottom: .35rem;
+  padding-bottom: .8rem;
+  border-bottom: 1px solid var(--line);
   color: var(--muted);
-  font: .7rem/1.3 var(--sans);
-  text-transform: uppercase;
 }
 
-.score strong {
-  font: bold 1.1rem/1.3 var(--mono);
+.review-comments {
+  padding-left: 1.1rem;
 }
+
+.review-comments li {
+  margin: .45rem 0;
+}
+
 
 .no-warnings {
   color: var(--muted);
@@ -929,13 +914,6 @@ pre {
     grid-template-columns: 1fr;
   }
 
-  .score-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .score:nth-child(2n) {
-    border-right: 0;
-  }
 }
 
 @media print {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -584,3 +584,26 @@ test("current JavaScript preserves represented deep links with cached HTML", asy
   await expect(page.locator(".entry-card:visible")).toContainText("000124");
   await expect(page.locator("#status")).not.toContainText("could not be loaded");
 });
+
+test("an entry shows the decision and the comments, never the scores", async ({ page }) => {
+  await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}`);
+  const editorial = page.locator(".entry-editorial");
+  await expect(editorial).toBeVisible();
+
+  // The scores decide acceptance and stay with the record. They are not shown:
+  // the same repository at the same commit scored 5 and then 4 on the same
+  // axis across two runs, and a number that moves like that reads as a
+  // judgement it cannot support.
+  await expect(editorial).not.toContainText("/5");
+  for (const axis of ["statement alignment", "definition fidelity", "notability", "literature"]) {
+    await expect(editorial).not.toContainText(axis);
+  }
+  await expect(page.locator(".score-grid")).toHaveCount(0);
+
+  // What is shown is the decision, and the comments under one heading.
+  await expect(editorial.locator(".decision")).toBeVisible();
+  const commentary = editorial.locator("h3", { hasText: "AI review comments" });
+  const none = editorial.locator(".no-warnings");
+  expect(await commentary.count() + await none.count()).toBeGreaterThan(0);
+  await expect(editorial).not.toContainText("Permanent warnings");
+});


### PR DESCRIPTION
This PR removes the five-number score grid from an entry page and presents the review's remarks under one heading.

The scores decide whether a submission is accepted, and they are kept with the record, but they do not mean what a reader would take them to mean. The same repository at the same commit scored `statement alignment` 5 on one run and 4 on the next, under the same policy; the decision was `accept` both times. A number that moves like that, displayed as "4/5", reads as a judgement it cannot support. The decision it produced is shown instead, and it is stable.

The remarks were headed "Permanent warnings", which presented a severity sorting that a reader cannot act on differently. They are now "AI review comments", with a sentence saying what produced them and what they are not.

Paired with https://github.com/PalomarRegistry/PalomarDatabase/pull/45, which stops publishing the scores at all, so this is not merely a matter of not drawing them.

🤖 Prepared with Claude Code