### PR TITLE
Accept the public review projection

### DIFF
--- a/.github/workflows/publish-health.yml
+++ b/.github/workflows/publish-health.yml
@@ -44,6 +44,12 @@ jobs:
         env:
           SITE: https://palomar-registry.org
 
+      - name: Can the website contract read every live public record
+        if: steps.check.outputs.stale == 'false'
+        run: node scripts/check-published.mjs --data "$DATA"
+        env:
+          DATA: https://data.palomar-registry.org
+
       # One attempt, with the traps that cost a day written into the guards.
       # A deployment is identified by its commit, so a second one for a commit
       # already deploying is cancelled rather than queued; and re-running a

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -704,7 +704,11 @@ export function validateEntry(entry, summary) {
     safeExternalUrl(string(review.report.source_url, "entry.review.report.source_url"));
   }
   stringArray(review.reviewer_models, "entry.review.reviewer_models");
-  object(review.scores, "entry.review.scores");
+  // Scores are required in the canonical registry record, but the public
+  // snapshot deliberately removes them. Accept both forms here so this
+  // validator describes the data the website actually receives. If scores
+  // are ever published, they must still have the canonical object shape.
+  if (review.scores !== undefined) object(review.scores, "entry.review.scores");
   stringArray(review.warnings, "entry.review.warnings");
 
   const render = object(entry.challenge_render, "entry.challenge_render");

--- a/scripts/check-published.mjs
+++ b/scripts/check-published.mjs
@@ -11,6 +11,8 @@
  * the check is a comparison rather than new machinery.
  */
 
+import { validateEntry, validateIndex } from "../assets/security.mjs";
+
 const STAMP = /assets\/app\.js\?v=([A-Za-z0-9._-]+)/;
 
 /** The commit a served page was built from, or null if it carries no stamp. */
@@ -38,6 +40,39 @@ export function publishState(html, expected) {
   return { fresh: true, published, reason: `serving ${published.slice(0, 12)}` };
 }
 
+/**
+ * Can the current website contract load every active public registry entry?
+ * This deliberately uses the same validators as the browser. It catches a
+ * valid publication whose shape has drifted away from what the UI accepts.
+ */
+export async function publicDataState(
+  databaseUrl,
+  fetcher = fetch,
+  validators = { validateIndex, validateEntry },
+) {
+  const base = new URL(databaseUrl.endsWith("/") ? databaseUrl : `${databaseUrl}/`);
+  const indexUrl = new URL("index.json", base);
+  try {
+    const indexResponse = await fetcher(indexUrl, { cache: "no-store" });
+    if (!indexResponse.ok) {
+      return { healthy: false, reason: `${indexUrl} responded ${indexResponse.status}` };
+    }
+    const index = validators.validateIndex(await indexResponse.json());
+    await Promise.all(index.entries.map(async (summary) => {
+      const entryUrl = new URL(summary.path, base);
+      const response = await fetcher(entryUrl, { cache: "no-store" });
+      if (!response.ok) throw new Error(`${entryUrl} responded ${response.status}`);
+      validators.validateEntry(await response.json(), summary);
+    }));
+    return {
+      healthy: true,
+      reason: `the website contract accepts all ${index.entries.length} public entries`,
+    };
+  } catch (error) {
+    return { healthy: false, reason: `public registry data is incompatible: ${error.message}` };
+  }
+}
+
 async function main(argv) {
   const options = new Map();
   for (let index = 0; index < argv.length; index += 2) {
@@ -45,8 +80,16 @@ async function main(argv) {
   }
   const url = options.get("url");
   const expected = options.get("expect");
+  const data = options.get("data");
+  if (data && !url && !expected) {
+    const state = await publicDataState(data);
+    console.log(`${data}: ${state.reason}`);
+    return state.healthy ? 0 : 1;
+  }
   if (!url || !expected) {
-    console.error("usage: check-published.mjs --url <site> --expect <commit>");
+    console.error(
+      "usage: check-published.mjs --url <site> --expect <commit> | --data <registry-data>",
+    );
     return 2;
   }
   const page = new URL("index.html", url.endsWith("/") ? url : `${url}/`);

--- a/tests/check-published.test.js
+++ b/tests/check-published.test.js
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { publishState, publishedVersion } from "../scripts/check-published.mjs";
+import {
+  publicDataState,
+  publishState,
+  publishedVersion,
+} from "../scripts/check-published.mjs";
 
 const sha = "b500f02dec58268ea22de28332f63136dac092d9";
 const page = (version) =>
@@ -41,4 +45,47 @@ test("the stamp is read from the asset URL the build actually writes", async () 
   } finally {
     await rm(output, { recursive: true, force: true });
   }
+});
+
+test("live-data health fetches and validates every indexed public entry", async () => {
+  const calls = [];
+  const responses = new Map([
+    ["https://data.example/index.json", { entries: [{ path: "entries/one.json" }] }],
+    ["https://data.example/entries/one.json", { id: "one" }],
+  ]);
+  const fetcher = async (url) => {
+    calls.push(String(url));
+    return {
+      ok: true,
+      async json() { return responses.get(String(url)); },
+    };
+  };
+  const validated = [];
+  const state = await publicDataState("https://data.example", fetcher, {
+    validateIndex(index) {
+      validated.push("index");
+      return index;
+    },
+    validateEntry(value, summary) {
+      validated.push(`${value.id}:${summary.path}`);
+    },
+  });
+
+  assert.equal(state.healthy, true);
+  assert.deepEqual(calls, [
+    "https://data.example/index.json",
+    "https://data.example/entries/one.json",
+  ]);
+  assert.deepEqual(validated, ["index", "one:entries/one.json"]);
+});
+
+test("live-data health fails on the same contract error a visitor would see", async () => {
+  const fetcher = async () => ({ ok: true, async json() { return { entries: [] }; } });
+  const state = await publicDataState("https://data.example", fetcher, {
+    validateIndex() { throw new Error("entry.review.scores must be an object"); },
+    validateEntry() {},
+  });
+
+  assert.equal(state.healthy, false);
+  assert.match(state.reason, /entry\.review\.scores must be an object/);
 });

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -105,13 +105,6 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
             "policy_commit": "5" * 40,
             "verdict": "accept",
             "reviewer_models": ["fixture:model"],
-            "scores": {
-                "statement_alignment": 5,
-                "definition_fidelity": 5,
-                "notability": 5,
-                "literature": 5,
-                "clarity": 5,
-            },
             "warnings": [],
             "report": {"sha256": "e" * 64},
         },

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -413,6 +413,18 @@ test("entry schema, acceptance state, verdict, and selected identity fail closed
   );
 });
 
+test("the public review projection may omit private scores", () => {
+  const published = entry();
+  delete published.review.scores;
+  assert.equal(validateEntry(published, summary()), published);
+
+  published.review.scores = [];
+  assert.throws(
+    () => validateEntry(published, summary()),
+    /entry\.review\.scores must be an object/,
+  );
+});
+
 test("record evidence links must agree with their canonical values", () => {
   const wrongDate = entry({ accepted_at: "2026-07-30" });
   assert.throws(() => validateEntry(wrongDate, summary()), /ID date does not match/);


### PR DESCRIPTION
Fix the public entry failure caused by requiring review scores that publication deliberately removes.

- accept scoreless public reviews while validating scores when present
- make the browser fixture match the real public projection
- make hourly health validate the live index and every public entry with the browser contract

Validated locally with all 42 unit/contract tests and against https://data.palomar-registry.org. The browser suite will run in CI; this host lacks its system libraries.