### PR TITLE
Reorder preservation and registry details

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1176,6 +1176,11 @@ async function renderEntry(
       `Actions run ${workflowRunId(entry.verification.workflow_url)}`,
       entry.verification.workflow_url,
     ),
+    dataDetailRow(
+      "Full registry record",
+      `${entry.id}-v${entry.version}.json`,
+      canonicalUrl.href,
+    ),
   );
   {
     details.append(
@@ -1286,20 +1291,16 @@ async function renderEntry(
     ),
   );
 
-  const machine = el("section", "machine-record");
-  machine.append(el("div", "eyebrow", "Full record"), el("h2", "", "Registry data"));
-  const machineLinks = el("p");
-  machineLinks.append(dataLink(`Open ${entry.id}-v${entry.version}.json`, canonicalUrl.href));
-  machine.append(machineLinks);
-  const pre = el("pre");
-  pre.append(el("code", "", JSON.stringify(entry, null, 2)));
-  machine.append(pre);
-
   const challenge = await challengePresentation(entry, renderBase, {
     dependenciesOnThisPage: true,
     availability,
   });
-  content.append(heading, sourceAvailabilityNotice(entry, availability));
+  const sourceNotice = sourceAvailabilityNotice(entry, availability);
+  content.append(heading);
+  // A broken or degraded source affects every link on the page and remains a
+  // warning at the top. The ordinary preservation confirmation is provenance,
+  // not an alert, so keep it with the registry history near the bottom.
+  if (!sourceNotice.classList.contains("preserved")) content.append(sourceNotice);
   const notice = versionNotice(entry, currentVersion);
   if (notice) content.append(notice);
   // The statement first, then what was checked about it, then what it rests
@@ -1314,8 +1315,8 @@ async function renderEntry(
     provenanceSection(entry, availability),
     classificationSection(entry),
     editorial,
+    ...(sourceNotice.classList.contains("preserved") ? [sourceNotice] : []),
     versionHistory(entry, versions, currentVersion),
-    machine,
   );
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -852,17 +852,6 @@ pre {
   color: var(--muted);
 }
 
-.machine-record pre {
-  max-height: 34rem;
-  overflow: auto;
-  padding: .75rem;
-  border: 1px solid var(--line);
-  background: var(--shade);
-  font-size: .75rem;
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-}
-
 [hidden] {
   display: none !important;
 }
@@ -953,9 +942,6 @@ pre {
     break-inside: avoid;
   }
 
-  .machine-record pre {
-    max-height: none;
-  }
 }
 .entry-page .source-availability {
   border: 1px solid var(--line, #d9d6cc);

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -228,6 +228,8 @@ test("an entry answers its reader's first three questions first", async ({ page 
   expect(position("entry-evidence")).toBeLessThan(position("entry-trust"));
   expect(position("entry-trust")).toBeLessThan(position("entry-classification"));
   expect(position("entry-trust")).toBeLessThan(position("entry-provenance"));
+  expect(position("source-availability")).toBeGreaterThan(position("entry-editorial"));
+  expect(position("source-availability") + 1).toBe(position("version-history"));
 
   // The dependencies are further down this page, so following the link scrolls
   // rather than loading anything. (The href is absolute either way, so what is
@@ -323,8 +325,12 @@ test("entry pages list immutable versions and flag superseded snapshots", async 
   await expect(page.locator(".entry-heading h1")).toHaveText(
     "Fixture PALOMAR-2026-07-29-000123 version 1",
   );
-  await expect(page.locator(".machine-record a")).toHaveText(
-    "Open PALOMAR-2026-07-29-000123-v1.json",
+  await expect(page.locator(".machine-record")).toHaveCount(0);
+  const fullRecord = page.locator(".entry-evidence .detail-row", {
+    has: page.getByText("Full registry record", { exact: true }),
+  });
+  await expect(fullRecord.getByRole("link")).toHaveText(
+    "PALOMAR-2026-07-29-000123-v1.json",
   );
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
     "href",


### PR DESCRIPTION
Move the routine source-preservation confirmation from the top of an entry to immediately before Versions, while leaving degraded or missing-source warnings at the top.

Remove the inline JSON section and expose the full public record as a row in the main verification table instead.

Adds browser assertions for both layout changes; all 42 unit and contract tests pass locally.