### PR TITLE
fix: space the classification codes, and make the description a hover

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -966,8 +966,9 @@ function classificationSection(entry) {
       // The code itself is the link: a reader who wants the other entries in
       // a subject clicks the subject, rather than a separate word beside it.
       const link = internalLink(code, classificationSearchUrl(scheme, code), "category-link");
-      link.append(el("span", "visually-hidden", ` — other entries classified ${code}`));
-      if (scheme === "msc") glossed.push({ code, link });
+      const spoken = el("span", "visually-hidden", ` — other entries classified ${code}`);
+      link.append(spoken);
+      if (scheme === "msc") glossed.push({ code, link, spoken });
       value.append(link);
     }
     if (!values.length) value.append(el("span", "unclassified", "Not recorded for this older entry"));
@@ -985,12 +986,15 @@ function classificationSection(entry) {
   // and the section is correct without one.
   if (glossed.length) {
     mscGlossary().then((table) => {
-      for (const { code, link } of glossed) {
+      for (const { code, link, spoken } of glossed) {
         const description = table[code];
         if (!description) continue;
+        // A hover, not a second column: the codes are a compact row, and the
+        // descriptions are long enough to swamp them. Given to assistive
+        // technology as text, since a title attribute alone reaches nobody
+        // who is not holding a mouse.
         link.title = `${code} — ${description}`;
-        const gloss = el("span", "category-gloss", description);
-        link.after(gloss);
+        spoken.textContent = ` — ${description}. Other entries classified ${code}`;
       }
     });
   }

--- a/assets/style.css
+++ b/assets/style.css
@@ -832,6 +832,19 @@ pre {
   text-transform: uppercase;
 }
 
+.category-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .3rem .7rem;
+}
+
+.category-link {
+  font-family: var(--mono);
+  font-size: .85rem;
+  text-decoration-style: dotted;
+  text-underline-offset: .2em;
+}
+
 .detail-note {
   font: .72rem/1.3 var(--mono);
   color: var(--muted);

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -595,6 +595,44 @@ test("current JavaScript preserves represented deep links with cached HTML", asy
   await expect(page.locator("#status")).not.toContainText("could not be loaded");
 });
 
+test("classification codes are spaced, and their descriptions are hovers", async ({ page }) => {
+  await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}`);
+  const section = page.locator(".entry-classification");
+  await expect(section).toBeVisible();
+
+  // Codes ran together as "math.COcs.DM" when they were appended with nothing
+  // between them, and the row had no styling because the class had been
+  // renamed away from the one that was styled.
+  const gaps = await page.evaluate(() => {
+    const out = [];
+    document.querySelectorAll(".entry-classification .category-list").forEach((list) => {
+      const links = [...list.querySelectorAll(".category-link")];
+      for (let i = 1; i < links.length; i += 1) {
+        const a = links[i - 1].getBoundingClientRect();
+        const b = links[i].getBoundingClientRect();
+        if (Math.abs(a.top - b.top) < 2) out.push(b.left - a.right);
+      }
+    });
+    return out;
+  });
+  expect(gaps.length).toBeGreaterThan(0);
+  for (const gap of gaps) expect(gap).toBeGreaterThan(4);
+
+  // The description is a hover, not a second column: the codes are a compact
+  // row and the descriptions are long enough to swamp them.
+  const msc = section.locator(".category-link", { hasText: "05C10" });
+  await expect(msc).toHaveAttribute("title", /^05C10 — .+/);
+  const visible = await page.evaluate(() => {
+    const section = document.querySelector(".entry-classification");
+    return [...section.querySelectorAll("*")]
+      .filter((node) => !node.classList.contains("visually-hidden"))
+      .filter((node) => node.children.length === 0)
+      .map((node) => node.textContent)
+      .join(" ");
+  });
+  expect(visible).not.toContain("Planar graphs");
+});
+
 test("an entry shows the decision and the comments, never the scores", async ({ page }) => {
   await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}`);
   const editorial = page.locator(".entry-editorial");


### PR DESCRIPTION
This PR fixes two faults in the subject classification row, both visible on the page and neither caught by a test.

**The codes ran together.** They were appended with nothing between them, and the row's class had been renamed from `category-feed-list` to `category-list` without carrying the styling over, so nothing spaced them either. It rendered as `math.COcs.DM`.

**The MSC description was rendered as text.** It was set as a `title` *and* appended as a visible span, so the description sat as body text jammed against the code. The request was for a hover, and it is now a hover alone. The description is still given to assistive technology, as text inside the link, because a `title` attribute reaches nobody who is not holding a mouse.

Verified in a browser rather than by reading the diff: adjacent codes now sit 11px apart, the MSC link carries `title="05C10 — Planar graphs; geometric and topological aspects of graph theory"`, and no visible element in the section contains the description. The accompanying test asserts all three, including measuring the gap, so this cannot silently regress.

🤖 Prepared with Claude Code