### PR TITLE
feat: refuse a served record that carries review scores

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1341,8 +1341,8 @@ async function renderEntry(
   editorialTitle.append(editorialBlock, el("span", "decision", "Accepted"));
   editorial.append(editorialTitle);
   // No scores. They decide whether a submission is accepted and they are kept
-  // with the record, but they are not shown: the same repository at the same
-  // commit has scored 5 and then 4 on the same axis across two runs, and a
+  // beside the database, but they never reach here: the same repository at
+  // the same commit has scored 5 and then 4 on the same axis across runs, and a
   // number that moves like that reads as a judgement it cannot support. What
   // it can support is the decision, which is above.
   editorial.append(

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -704,11 +704,12 @@ export function validateEntry(entry, summary) {
     safeExternalUrl(string(review.report.source_url, "entry.review.report.source_url"));
   }
   stringArray(review.reviewer_models, "entry.review.reviewer_models");
-  // Scores are required in the canonical registry record, but the public
-  // snapshot deliberately removes them. Accept both forms here so this
-  // validator describes the data the website actually receives. If scores
-  // are ever published, they must still have the canonical object shape.
-  if (review.scores !== undefined) object(review.scores, "entry.review.scores");
+  // A record is served exactly as it was committed, and a committed record has
+  // no scores: they are recorded beside the database, in a directory nothing
+  // stages. This tolerated them while the release tooling stripped them on the
+  // way out, which meant a release that forgot to strip would have rendered
+  // without complaint. Refusing them makes the browser the last check.
+  if (review.scores !== undefined) fail("entry.review.scores is not published");
   stringArray(review.warnings, "entry.review.warnings");
 
   const render = object(entry.challenge_render, "entry.challenge_render");

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -150,7 +150,6 @@ function entry(overrides = {}) {
       policy_commit: "5".repeat(40),
       verdict: "accept",
       report: { sha256: "e".repeat(64) },
-      scores: { clarity: 5 },
       reviewer_models: ["fixture:model"],
       warnings: [],
     },
@@ -413,16 +412,19 @@ test("entry schema, acceptance state, verdict, and selected identity fail closed
   );
 });
 
-test("the public review projection may omit private scores", () => {
-  const published = entry();
-  delete published.review.scores;
-  assert.equal(validateEntry(published, summary()), published);
-
-  published.review.scores = [];
+test("a record carrying review scores is refused, not rendered", () => {
+  // A record is served exactly as it was committed, and a committed record
+  // has no scores. While the release tooling stripped them on the way out,
+  // one forgotten call would have put them on the page; now the last thing
+  // between the numbers and a reader is this check.
+  const leaked = entry();
+  leaked.review.scores = { clarity: 5 };
   assert.throws(
-    () => validateEntry(published, summary()),
-    /entry\.review\.scores must be an object/,
+    () => validateEntry(leaked, summary()),
+    /entry\.review\.scores is not published/,
   );
+  const clean = entry();
+  assert.equal(validateEntry(clean, summary()), clean);
 });
 
 test("record evidence links must agree with their canonical values", () => {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -638,7 +638,8 @@ test("an entry shows the decision and the comments, never the scores", async ({ 
   const editorial = page.locator(".entry-editorial");
   await expect(editorial).toBeVisible();
 
-  // The scores decide acceptance and stay with the record. They are not shown:
+  // The scores decide acceptance and stay beside the database. Not shown, and
+  // as of the record-is-the-committed-file change, not served at all:
   // the same repository at the same commit scored 5 and then 4 on the same
   // axis across two runs, and a number that moves like that reads as a
   // judgement it cannot support.


### PR DESCRIPTION
This PR makes the browser refuse a record carrying `review.scores` rather than tolerating it.

The validator accepted them when present, because the release tooling stripped them on the way out and this file described what the website actually received. That made the browser tolerant of exactly the failure worth catching: a release that forgot to strip would have rendered without complaint.

A record is now served exactly as it was committed, and a committed record has no scores — they are recorded beside the database, in a directory nothing stages. So the tolerance has nothing left to cover, and refusing them makes this the last check between the numbers and a reader.

Companion to https://github.com/PalomarRegistry/PalomarDatabase/pull/66 — "refactor: publish a record as it was committed, not as a projection". This is independent of it: nothing has ever served scores, so it can merge in either order.

🤖 Prepared with Claude Code