### PR TITLE
perf: an entry page reads one result, not the whole registry

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -23,6 +23,8 @@ import {
   validateEntry,
   validateAvailability,
   validateIndex,
+  validateVersions,
+  versionsUrl,
   validateTombstone,
   workflowRunId,
 } from "./security.mjs";
@@ -1401,14 +1403,22 @@ async function renderEntry(
 async function loadEntry(id, requestedVersion) {
   const { databaseUrl, databaseBase, renderBase, availabilityUrl } = dataSource();
   const availabilityPromise = loadAvailability(availabilityUrl);
-  const index = validateIndex(await fetchJson(databaseUrl));
-  const versions = index.entries
-    .filter((item) => item.id === id)
-    .sort((left, right) => left.version - right.version);
+  // The versions of this one result, not the whole registry. Reading
+  // `index.json` here meant fetching every record ever registered to render
+  // one page, and paying for it again every time anyone else published.
+  let versions = [];
+  try {
+    versions = validateVersions(await fetchJson(versionsUrl(id, databaseBase)), id).entries;
+  } catch (error) {
+    // Absent means no active version of this result, which is either an
+    // unknown identifier or one withdrawn entirely. Both are answered below,
+    // by the tombstone if there is one and by "not found" if there is not.
+    if (error.status !== 404) throw error;
+  }
   const currentVersion = versions.length ? versions.at(-1).version : null;
   const version = requestedVersion ?? currentVersion;
-  if (version === null) throw new Error("entry not found");
-  const summary = index.entries.find((item) => item.id === id && item.version === version);
+  if (version === null && requestedVersion === undefined) throw new Error("entry not found");
+  const summary = versions.find((item) => item.version === version);
   if (!summary) {
     if (requestedVersion === null || requestedVersion === undefined) {
       throw new Error("entry not found");

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -1,4 +1,8 @@
 export const INDEX_SCHEMA_VERSION = 3;
+export const VERSIONS_SCHEMA_VERSION = 1;
+// A result with five hundred registered versions is a bug, not a history, and
+// this is the one read surface whose size is not bounded by anything else.
+const MAX_VERSIONS_PER_ID = 500;
 export const ENTRY_SCHEMA_VERSION = 2;
 export const ENTRY_SCHEMA_VERSIONS = new Set([1, 2]);
 export const DEFAULT_DATABASE =
@@ -270,6 +274,52 @@ export function entryRecordUrl(summary, databaseBase) {
     fail("entry path escaped the canonical database prefix");
   }
   return resolved;
+}
+
+export function versionsUrl(id, databaseBase) {
+  if (typeof id !== "string" || !ID_RE.test(id)) fail("version index ID is malformed");
+  const base = new URL(databaseBase);
+  const expected = new URL(`versions/${id}.json`, base);
+  if (expected.origin !== base.origin) fail("version index path escaped the database origin");
+  return expected;
+}
+
+/**
+ * The versions of one result, from `versions/<id>.json`.
+ *
+ * The rows are the ones `index.json` carries, so the row grammar and
+ * `entryRecordUrl` apply unchanged. What is new is coverage and ordering: this
+ * document claims to be *every* active version of one identifier, so a row
+ * belonging to another identifier means it is not what it says it is, and
+ * reading it as if it were would show one result's history under another
+ * result's name.
+ */
+export function validateVersions(value, id) {
+  const document = object(value, "version index");
+  if (document.schema_version !== VERSIONS_SCHEMA_VERSION) {
+    fail(`unsupported version index schema_version ${String(document.schema_version)}`);
+  }
+  if (document.id !== id) fail("version index is for a different result");
+  const entries = array(document.entries, "version index entries");
+  if (entries.length === 0) fail("version index carries no versions");
+  if (entries.length > MAX_VERSIONS_PER_ID) fail("version index is implausibly long");
+  let previous = 0;
+  for (const [position, row] of entries.entries()) {
+    const summary = object(row, `version index entries[${position}]`);
+    if (summary.id !== id) fail(`version index entries[${position}] is a different result`);
+    const version = integer(summary.version, `version index entries[${position}].version`);
+    if (version <= previous) fail("version index is not in increasing version order");
+    previous = version;
+    string(summary.title, `version index entries[${position}].title`);
+    if (summary.status !== "accepted") {
+      fail(`version index entries[${position}].status is not accepted`);
+    }
+    const expectedPath = `entries/${id}-v${version}.json`;
+    if (summary.path !== expectedPath) {
+      fail(`version index entries[${position}].path must be ${expectedPath}`);
+    }
+  }
+  return document;
 }
 
 export function tombstoneUrl(id, version, databaseBase) {

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -258,6 +258,37 @@ class Handler(SimpleHTTPRequestHandler):
             }
             self.send_bytes(json.dumps(payload).encode(), "application/json")
             return
+        # The versions of one result, which is what an entry page reads instead
+        # of the whole index.
+        versions = re.fullmatch(
+            r"/database/versions/(PALOMAR-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6})\.json",
+            path,
+        )
+        if versions:
+            identifier = versions.group(1)
+            rows = [
+                {
+                    "id": item["id"],
+                    "version": item["version"],
+                    "title": item["title"],
+                    "status": "accepted",
+                    "path": f"entries/{item['id']}-v{item['version']}.json",
+                }
+                for item in ENTRIES.values()
+                if item["id"] == identifier
+            ]
+            if not rows:
+                self.send_error(404)
+                return
+            self.send_bytes(
+                json.dumps({
+                    "schema_version": 1,
+                    "id": identifier,
+                    "entries": sorted(rows, key=lambda row: row["version"]),
+                }).encode(),
+                "application/json",
+            )
+            return
         tombstone = re.fullmatch(
             r"/database/tombstones/(PALOMAR-2026-07-29-000125)-v(1)\.json",
             path,

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -28,6 +28,8 @@ import {
   validateAvailability,
   validateIndex,
   validateTombstone,
+  validateVersions,
+  versionsUrl,
 } from "../assets/security.mjs";
 
 // The website's own origin, for the cross-origin assertion below.
@@ -616,4 +618,44 @@ test("the favicon ships with the site and every page asks for it", async () => {
   // One flat colour per scheme, and nothing that a strict policy would refuse.
   assert.match(icon, /prefers-color-scheme: dark/);
   assert.doesNotMatch(icon, /<script|xlink:href|href="http/);
+});
+
+test("a version index must be every version of the result it names", () => {
+  // The document claims to be complete for one identifier. A row belonging to
+  // another would show one result's history under another result's name, and
+  // the row validator alone would not notice: the rows are well formed.
+  const id = "PALOMAR-2026-07-29-000123";
+  const row = (version) => ({
+    id,
+    version,
+    title: "A result",
+    status: "accepted",
+    path: `entries/${id}-v${version}.json`,
+  });
+  const document = { schema_version: 1, id, entries: [row(1), row(2)] };
+  assert.equal(validateVersions(structuredClone(document), id).entries.length, 2);
+
+  assert.throws(() => validateVersions({ ...document, id: "PALOMAR-2026-07-29-000999" }, id),
+    /different result/);
+  assert.throws(() => validateVersions(document, "PALOMAR-2026-07-29-000999"),
+    /different result/);
+  assert.throws(
+    () => validateVersions({ ...document, entries: [row(2), row(1)] }, id),
+    /increasing version order/,
+  );
+  assert.throws(() => validateVersions({ ...document, entries: [] }, id), /carries no versions/);
+  assert.throws(() => validateVersions({ ...document, schema_version: 2 }, id), /schema_version/);
+
+  const foreign = { id: "PALOMAR-2026-07-29-000999", version: 3, title: "t", status: "accepted",
+    path: "entries/PALOMAR-2026-07-29-000999-v3.json" };
+  assert.throws(() => validateVersions({ ...document, entries: [row(1), foreign] }, id),
+    /is a different result/);
+});
+
+test("a version index URL cannot leave the database origin", () => {
+  const base = "https://data.example.org/";
+  assert.equal(versionsUrl("PALOMAR-2026-07-29-000123", base).href,
+    "https://data.example.org/versions/PALOMAR-2026-07-29-000123.json");
+  assert.throws(() => versionsUrl("../../etc/passwd", base), /malformed/);
+  assert.throws(() => versionsUrl("PALOMAR-2026-07-29-00012", base), /malformed/);
 });


### PR DESCRIPTION
This PR makes an entry page fetch `versions/<id>.json` rather than `index.json`.

`loadEntry` read the whole index to find the versions of one identifier. That means downloading every record ever registered to render one page, and paying for it again every time anyone else registers something: tens of megabytes for four hundred bytes of answer at a hundred thousand results. `entryRecordUrl`, `validateEntry` and the tombstone path are untouched and run at full strength.

`validateVersions` is a validator of its own rather than a reuse of `validateIndex`, because what is new is not the rows but the claim about them: this document says it is *every* active version of one identifier. A row belonging to another identifier is well formed and would pass the row grammar, and reading it as if it belonged here would show one result's history under another result's name. Ordering and a length bound are checked for the same reason, this being the one read surface whose size is not bounded by anything else.

An absent document means no active version, which is either an unknown identifier or one withdrawn entirely. Both were already answered further down, by the tombstone if there is one and by "not found" if there is not.

Needs https://github.com/PalomarRegistry/PalomarDatabase/pull/73 — "feat: publish the versions of one result at its own key" — deployed before this merges, or entry pages will 404 on the version index.

I could not run the Playwright suite locally: Chromium cannot load `libglib-2.0.so.0` on this host, so all 28 fail at browser launch and say nothing either way. The unit suite passes at 44. CI runs both.

🤖 Prepared with Claude Code