### PR TITLE
feat: read the registry a browse page at a time

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -5,6 +5,8 @@ import {
   isInlineChallenge,
 } from "./rendering.js";
 import {
+  browseDirectoryUrl,
+  browseShardUrl,
   databaseBaseFor,
   availabilityRecord,
   RESULT_ORIGIN_LABELS,
@@ -20,9 +22,10 @@ import {
   selectAvailabilityUrl,
   selectRenderBase,
   tombstoneUrl,
+  validateBrowseDirectory,
+  validateBrowseShard,
   validateEntry,
   validateAvailability,
-  validateIndex,
   validateVersions,
   versionsUrl,
   validateTombstone,
@@ -330,18 +333,49 @@ async function loadEntries(index, databaseBase) {
   );
 }
 
+/**
+ * Every registered version, a browse page at a time.
+ *
+ * `index.json` is one document naming all of them, rewritten in full on every
+ * publication, and it is retiring for exactly that reason. The shards carry
+ * the same rows and each one changes only when a result on it does.
+ *
+ * A shard the directory counts as empty is not fetched, which is what keeps a
+ * small registry at a handful of requests rather than a hundred. The directory
+ * is written after the shards it counts, so it is never newer than they are:
+ * the worst a reader who arrives during a publication can see is a page one
+ * publication behind, which is the tolerance the feeds already have and which
+ * the next load heals.
+ */
+async function loadBrowseRows(databaseBase) {
+  const directory = validateBrowseDirectory(
+    await fetchJson(browseDirectoryUrl(databaseBase)),
+  );
+  const pages = await Promise.all(
+    directory.shards
+      .filter((shard) => shard.count > 0)
+      .map(async (shard) =>
+        validateBrowseShard(
+          await fetchJson(browseShardUrl(shard.shard, databaseBase)),
+          shard.shard,
+        ).entries,
+      ),
+  );
+  return pages.flat();
+}
+
 async function renderIndex() {
   const status = document.querySelector("#status");
   const grid = document.querySelector("#entry-grid");
   try {
-    const { databaseUrl, databaseBase, availabilityUrl } = dataSource();
+    const { databaseBase, availabilityUrl } = dataSource();
     const availabilityPromise = loadAvailability(availabilityUrl);
-    const index = validateIndex(await fetchJson(databaseUrl));
+    const rows = await loadBrowseRows(databaseBase);
     const versionCounts = new Map();
-    for (const summary of index.entries) {
+    for (const summary of rows) {
       versionCounts.set(summary.id, (versionCounts.get(summary.id) || 0) + 1);
     }
-    const currentIndex = { entries: latestVersions(index.entries) };
+    const currentIndex = { entries: latestVersions(rows) };
     const entries = await loadEntries(currentIndex, databaseBase);
     const availability = await availabilityPromise;
     // GitHub Pages may briefly pair HTML and JavaScript from adjacent deployments.
@@ -1401,7 +1435,7 @@ async function renderEntry(
 }
 
 async function loadEntry(id, requestedVersion) {
-  const { databaseUrl, databaseBase, renderBase, availabilityUrl } = dataSource();
+  const { databaseBase, renderBase, availabilityUrl } = dataSource();
   const availabilityPromise = loadAvailability(availabilityUrl);
   // The versions of this one result, not the whole registry. Reading
   // `index.json` here meant fetching every record ever registered to render

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -1,8 +1,23 @@
 export const INDEX_SCHEMA_VERSION = 3;
 export const VERSIONS_SCHEMA_VERSION = 1;
+export const BROWSE_SCHEMA_VERSION = 1;
+export const SUBJECT_SCHEMA_VERSION = 1;
 // A result with five hundred registered versions is a bug, not a history, and
 // this is the one read surface whose size is not bounded by anything else.
 const MAX_VERSIONS_PER_ID = 500;
+// A fixed hundred, one per pair of trailing serial digits. Identifiers are
+// allocated at random, so this is uniform by construction and there is nothing
+// for the origin to renegotiate: a directory naming any other set of shards is
+// not the directory this reader understands.
+const BROWSE_SHARDS = 100;
+const BROWSE_SHARD_RE = /^[0-9]{2}$/;
+// What the publisher refuses to exceed. Mirrored rather than trusted: a page
+// this long is either a registry that outgrew its shard count or an origin
+// that is not the registry, and both are worth stopping for.
+const MAX_ROWS_PER_SHARD = 5000;
+export const SUBJECT_KINDS = Object.freeze(["arxiv", "msc"]);
+// The newest fifty, which is a documented truncation and not an accident.
+const MAX_SUBJECT_ITEMS = 50;
 export const ENTRY_SCHEMA_VERSION = 2;
 export const ENTRY_SCHEMA_VERSIONS = new Set([1, 2]);
 export const DEFAULT_DATABASE =
@@ -169,6 +184,26 @@ export function safeInternalUrl(value, locationHref) {
   return url;
 }
 
+/**
+ * One row, exactly as `index.json` writes it.
+ *
+ * Four documents now repeat these rows, and a row grammar living in four
+ * places is four chances for one of them to accept a path the other three
+ * refuse. What each document adds on top is its own claim about which rows
+ * belong in it, and that is what stays with each validator.
+ */
+function summaryRow(value, field) {
+  const summary = object(value, field);
+  const id = string(summary.id, `${field}.id`);
+  if (!ID_RE.test(id)) fail(`${field}.id is malformed`);
+  const version = integer(summary.version, `${field}.version`);
+  string(summary.title, `${field}.title`);
+  if (summary.status !== "accepted") fail(`${field}.status is not accepted`);
+  const expectedPath = `entries/${id}-v${version}.json`;
+  if (summary.path !== expectedPath) fail(`${field}.path must be ${expectedPath}`);
+  return { id, version };
+}
+
 export function validateIndex(index) {
   object(index, "index");
   if (index.schema_version !== INDEX_SCHEMA_VERSION) {
@@ -176,21 +211,153 @@ export function validateIndex(index) {
   }
   const seen = new Set();
   for (const [position, value] of array(index.entries, "index.entries").entries()) {
-    const summary = object(value, `index.entries[${position}]`);
-    const id = string(summary.id, `index.entries[${position}].id`);
-    if (!ID_RE.test(id)) fail(`index.entries[${position}].id is malformed`);
-    const version = integer(summary.version, `index.entries[${position}].version`);
-    string(summary.title, `index.entries[${position}].title`);
-    if (summary.status !== "accepted") fail(`index.entries[${position}].status is not accepted`);
-    const expectedPath = `entries/${id}-v${version}.json`;
-    if (summary.path !== expectedPath) {
-      fail(`index.entries[${position}].path must be ${expectedPath}`);
-    }
+    const { id, version } = summaryRow(value, `index.entries[${position}]`);
     const key = `${id}\0${version}`;
     if (seen.has(key)) fail(`duplicate index entry ${id} version ${version}`);
     seen.add(key);
   }
   return index;
+}
+
+/** Which of the hundred browse pages a result is listed on, for its whole life. */
+export function browseShardOf(id) {
+  const identifier = ID_RE.exec(typeof id === "string" ? id : "");
+  if (!identifier) fail("browse shard identifier is malformed");
+  return identifier[2].slice(-2);
+}
+
+export function browseDirectoryUrl(databaseBase) {
+  const base = new URL(databaseBase);
+  const expected = new URL("browse/index.json", base);
+  if (expected.origin !== base.origin) fail("browse directory escaped the database origin");
+  return expected;
+}
+
+export function browseShardUrl(shard, databaseBase) {
+  // The shard name comes out of a document the origin supplies, and is about
+  // to become a path. Two digits and nothing else, decided here rather than
+  // taken on trust from the directory that offered it.
+  if (typeof shard !== "string" || !BROWSE_SHARD_RE.test(shard)) {
+    fail("browse shard name is malformed");
+  }
+  const base = new URL(databaseBase);
+  const expected = new URL(`browse/${shard}.json`, base);
+  if (expected.origin !== base.origin) fail("browse shard escaped the database origin");
+  return expected;
+}
+
+/**
+ * The directory of browse shards, from `browse/index.json`.
+ *
+ * A manifest that supplies paths to fetch is an instruction, not data. The
+ * grammar of those paths is fixed here so that a hostile or broken directory
+ * can name only one of the hundred pages it is allowed to name, and the
+ * hundred are required in order: that is what makes "every registered result
+ * is on exactly one of these pages" checkable rather than merely claimed.
+ */
+export function validateBrowseDirectory(value) {
+  const directory = object(value, "browse directory");
+  if (directory.schema_version !== BROWSE_SCHEMA_VERSION) {
+    fail(`unsupported browse directory schema_version ${String(directory.schema_version)}`);
+  }
+  const shards = array(directory.shards, "browse directory shards");
+  if (shards.length !== BROWSE_SHARDS) {
+    fail(`browse directory names ${shards.length} shards, not ${BROWSE_SHARDS}`);
+  }
+  for (const [position, value] of shards.entries()) {
+    const field = `browse directory shards[${position}]`;
+    const row = object(value, field);
+    const shard = String(position).padStart(2, "0");
+    if (row.shard !== shard) fail("browse directory is not the hundred shards in order");
+    if (row.path !== `browse/${shard}.json`) fail(`${field}.path is not that shard's page`);
+    if (!Number.isSafeInteger(row.count) || row.count < 0 || row.count > MAX_ROWS_PER_SHARD) {
+      fail(`${field}.count is not a plausible number of results`);
+    }
+  }
+  return directory;
+}
+
+/**
+ * One browse page, from `browse/<shard>.json`.
+ *
+ * The rows are the ones `index.json` carries, so the row grammar and
+ * `entryRecordUrl` apply unchanged. What is new is the claim the document
+ * makes about itself: that it holds every active version whose identifier
+ * belongs to this shard, in identifier and version order. A row from another
+ * shard is a well-formed row, and a reader that accepted it would show the
+ * same result twice while some other page went on claiming it.
+ */
+export function validateBrowseShard(value, shard) {
+  const page = object(value, "browse shard");
+  if (page.schema_version !== BROWSE_SCHEMA_VERSION) {
+    fail(`unsupported browse shard schema_version ${String(page.schema_version)}`);
+  }
+  if (typeof shard !== "string" || !BROWSE_SHARD_RE.test(shard)) {
+    fail("browse shard name is malformed");
+  }
+  if (page.shard !== shard) fail("browse shard is not the one that was asked for");
+  const entries = array(page.entries, "browse shard entries");
+  if (entries.length > MAX_ROWS_PER_SHARD) fail("browse shard is implausibly long");
+  let previousId = "";
+  let previousVersion = 0;
+  for (const [position, row] of entries.entries()) {
+    const field = `browse shard entries[${position}]`;
+    const { id, version } = summaryRow(row, field);
+    if (browseShardOf(id) !== shard) fail(`${field} belongs to another shard`);
+    if (id < previousId || (id === previousId && version <= previousVersion)) {
+      fail("browse shard is not in identifier and version order");
+    }
+    previousId = id;
+    previousVersion = version;
+  }
+  return page;
+}
+
+export function subjectUrl(kind, code, databaseBase) {
+  if (!SUBJECT_KINDS.includes(kind)) fail("subject kind is not recognized");
+  const pattern = kind === "arxiv" ? ARXIV_RE : MSC2020_RE;
+  if (typeof code !== "string" || !pattern.test(code)) fail("subject code is malformed");
+  const base = new URL(databaseBase);
+  const expected = new URL(`subjects/${kind}/${code}.json`, base);
+  if (expected.origin !== base.origin) fail("subject page escaped the database origin");
+  return expected;
+}
+
+/**
+ * One subject page, from `subjects/<kind>/<code>.json`.
+ *
+ * The claim is "the newest results classified under this code", and both
+ * halves of it are checkable only because a row carries its classification and
+ * its publication date. A result that is not classified under the code is a
+ * well-formed row, and showing it here would put someone's work under a
+ * heading it has nothing to do with; a page in some other order is well formed
+ * too, and would quietly stop being the page of what is new.
+ */
+export function validateSubject(value, kind, code) {
+  const page = object(value, "subject page");
+  if (page.schema_version !== SUBJECT_SCHEMA_VERSION) {
+    fail(`unsupported subject page schema_version ${String(page.schema_version)}`);
+  }
+  if (!SUBJECT_KINDS.includes(kind)) fail("subject kind is not recognized");
+  if (page.kind !== kind || page.code !== code) fail("subject page is for a different subject");
+  const scheme = kind === "arxiv" ? "arxiv" : "msc2020";
+  const entries = array(page.entries, "subject page entries");
+  if (entries.length > MAX_SUBJECT_ITEMS) fail("subject page carries more than it may");
+  let previous = Infinity;
+  for (const [position, row] of entries.entries()) {
+    const field = `subject page entries[${position}]`;
+    summaryRow(row, field);
+    const classification = object(row.classification, `${field}.classification`);
+    const codes = stringArray(classification[scheme], `${field}.classification.${scheme}`);
+    if (!codes.includes(code)) fail(`${field} is not classified under ${code}`);
+    const published = Date.parse(string(row.published_at, `${field}.published_at`));
+    if (!Number.isFinite(published)) fail(`${field}.published_at is malformed`);
+    // Equal is allowed: two results reviewed in the same second are in no
+    // particular order and neither one is out of place.
+    if (published > previous) fail("subject page is not newest first");
+    previous = published;
+  }
+  return page;
 }
 
 function availabilityEndpoint(value, field) {
@@ -305,19 +472,11 @@ export function validateVersions(value, id) {
   if (entries.length > MAX_VERSIONS_PER_ID) fail("version index is implausibly long");
   let previous = 0;
   for (const [position, row] of entries.entries()) {
-    const summary = object(row, `version index entries[${position}]`);
-    if (summary.id !== id) fail(`version index entries[${position}] is a different result`);
-    const version = integer(summary.version, `version index entries[${position}].version`);
-    if (version <= previous) fail("version index is not in increasing version order");
-    previous = version;
-    string(summary.title, `version index entries[${position}].title`);
-    if (summary.status !== "accepted") {
-      fail(`version index entries[${position}].status is not accepted`);
-    }
-    const expectedPath = `entries/${id}-v${version}.json`;
-    if (summary.path !== expectedPath) {
-      fail(`version index entries[${position}].path must be ${expectedPath}`);
-    }
+    const field = `version index entries[${position}]`;
+    const summary = summaryRow(row, field);
+    if (summary.id !== id) fail(`${field} is a different result`);
+    if (summary.version <= previous) fail("version index is not in increasing version order");
+    previous = summary.version;
   }
   return document;
 }

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -191,6 +191,17 @@ ENTRIES[("PALOMAR-2026-07-29-000124", 1)]["trust"].update(
         "reasons": ["Challenge imports Tau Ceti"],
     }
 )
+def summary(item: dict) -> dict:
+    """One index row, which every derived surface repeats."""
+    return {
+        "id": item["id"],
+        "version": item["version"],
+        "title": item["title"],
+        "status": "accepted",
+        "path": f"entries/{item['id']}-v{item['version']}.json",
+    }
+
+
 class Handler(SimpleHTTPRequestHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=str(ROOT), **kwargs)
@@ -245,18 +256,47 @@ class Handler(SimpleHTTPRequestHandler):
             payload = {
                 "schema_version": 3,
                 "generated_at": "2026-07-29T09:00:00Z",
-                "entries": [
-                    {
-                        "id": item["id"],
-                        "version": item["version"],
-                        "title": item["title"],
-                        "status": "accepted",
-                        "path": f"entries/{item['id']}-v{item['version']}.json",
-                    }
-                    for item in ENTRIES.values()
-                ]
+                "entries": [summary(item) for item in ENTRIES.values()],
             }
             self.send_bytes(json.dumps(payload).encode(), "application/json")
+            return
+        # The registry a shard at a time, which is what the landing page reads
+        # instead of the index. Every shard exists, including the empty ones:
+        # a reader has to be able to tell "nothing here" from "not published".
+        if path == "/database/browse/index.json":
+            held = {}
+            for item in ENTRIES.values():
+                held[item["id"][-2:]] = held.get(item["id"][-2:], 0) + 1
+            self.send_bytes(
+                json.dumps({
+                    "schema_version": 1,
+                    "shards": [
+                        {
+                            "shard": f"{number:02d}",
+                            "path": f"browse/{number:02d}.json",
+                            "count": held.get(f"{number:02d}", 0),
+                        }
+                        for number in range(100)
+                    ],
+                }).encode(),
+                "application/json",
+            )
+            return
+        shard = re.fullmatch(r"/database/browse/([0-9]{2})\.json", path)
+        if shard:
+            rows = [
+                summary(item)
+                for item in ENTRIES.values()
+                if item["id"][-2:] == shard.group(1)
+            ]
+            self.send_bytes(
+                json.dumps({
+                    "schema_version": 1,
+                    "shard": shard.group(1),
+                    "entries": sorted(rows, key=lambda row: (row["id"], row["version"])),
+                }).encode(),
+                "application/json",
+            )
             return
         # The versions of one result, which is what an entry page reads instead
         # of the whole index.
@@ -266,17 +306,7 @@ class Handler(SimpleHTTPRequestHandler):
         )
         if versions:
             identifier = versions.group(1)
-            rows = [
-                {
-                    "id": item["id"],
-                    "version": item["version"],
-                    "title": item["title"],
-                    "status": "accepted",
-                    "path": f"entries/{item['id']}-v{item['version']}.json",
-                }
-                for item in ENTRIES.values()
-                if item["id"] == identifier
-            ]
+            rows = [summary(item) for item in ENTRIES.values() if item["id"] == identifier]
             if not rows:
                 self.send_error(404)
                 return

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -30,6 +30,13 @@ import {
   validateTombstone,
   validateVersions,
   versionsUrl,
+  browseDirectoryUrl,
+  browseShardOf,
+  browseShardUrl,
+  subjectUrl,
+  validateBrowseDirectory,
+  validateBrowseShard,
+  validateSubject,
 } from "../assets/security.mjs";
 
 // The website's own origin, for the cross-origin assertion below.
@@ -658,4 +665,176 @@ test("a version index URL cannot leave the database origin", () => {
     "https://data.example.org/versions/PALOMAR-2026-07-29-000123.json");
   assert.throws(() => versionsUrl("../../etc/passwd", base), /malformed/);
   assert.throws(() => versionsUrl("PALOMAR-2026-07-29-00012", base), /malformed/);
+});
+
+// The browse pages and the subject pages, whose new claim is not about the
+// rows -- those are the index's rows -- but about what each document asserts
+// it covers. A row in the wrong shard, or under the wrong code, passes the row
+// grammar, and reading it as if it belonged shows a reader something under the
+// wrong heading.
+
+function shardRow(serial, version = 1) {
+  const id = `PALOMAR-2026-07-29-${serial}`;
+  return { id, version, title: "A result", status: "accepted",
+    path: `entries/${id}-v${version}.json` };
+}
+
+function directory(overrides = new Map()) {
+  return {
+    schema_version: 1,
+    shards: Array.from({ length: 100 }, (_value, number) => {
+      const shard = String(number).padStart(2, "0");
+      return { shard, path: `browse/${shard}.json`, count: overrides.get(shard) ?? 0 };
+    }),
+  };
+}
+
+test("a browse directory is the hundred shards, in order, naming their own pages", () => {
+  const complete = directory(new Map([["23", 2]]));
+  assert.equal(validateBrowseDirectory(structuredClone(complete)).shards.length, 100);
+
+  assert.throws(
+    () => validateBrowseDirectory({ ...complete, shards: complete.shards.slice(0, 99) }),
+    /names 99 shards/,
+  );
+  assert.throws(
+    () => validateBrowseDirectory({ ...complete, shards: [...complete.shards].reverse() }),
+    /hundred shards in order/,
+  );
+  assert.throws(
+    () => validateBrowseDirectory({ ...complete, schema_version: 2 }),
+    /schema_version/,
+  );
+});
+
+test("a browse directory cannot point the reader anywhere but at its own shard", () => {
+  // The directory is an instruction, not data: its paths become the next
+  // fetch. A hostile one must be able to name only the page it is for.
+  for (const path of [
+    "browse/../index.json",
+    "https://attacker.invalid/23.json",
+    "browse/23.json?raw=1",
+    "browse/24.json",
+    "entries/PALOMAR-2026-07-29-000123-v1.json",
+  ]) {
+    const hostile = directory();
+    hostile.shards[23] = { shard: "23", path, count: 1 };
+    assert.throws(() => validateBrowseDirectory(hostile), /is not that shard's page/, path);
+  }
+});
+
+test("a browse directory count is a plausible number of results", () => {
+  for (const count of [-1, 1.5, 5001, "2", null]) {
+    const wrong = directory();
+    wrong.shards[23] = { shard: "23", path: "browse/23.json", count };
+    assert.throws(() => validateBrowseDirectory(wrong), /plausible number/, String(count));
+  }
+});
+
+test("a browse shard holds the identifiers that belong to it, in order", () => {
+  const page = { schema_version: 1, shard: "23",
+    entries: [shardRow("000123", 1), shardRow("000123", 2), shardRow("999923")] };
+  assert.equal(validateBrowseShard(structuredClone(page), "23").entries.length, 3);
+
+  assert.throws(() => validateBrowseShard(page, "24"), /not the one that was asked for/);
+  assert.throws(
+    () => validateBrowseShard({ ...page, entries: [shardRow("000124")] }, "23"),
+    /belongs to another shard/,
+  );
+  assert.throws(
+    () => validateBrowseShard({ ...page, entries: [shardRow("999923"), shardRow("000123")] }, "23"),
+    /identifier and version order/,
+  );
+  assert.throws(
+    () => validateBrowseShard({ ...page, entries: [shardRow("000123"), shardRow("000123")] }, "23"),
+    /identifier and version order/,
+  );
+  assert.throws(
+    () => validateBrowseShard({ ...page, entries: Array.from({ length: 5001 }, () => shardRow("000123")) }, "23"),
+    /implausibly long/,
+  );
+  assert.throws(() => validateBrowseShard(page, "2"), /shard name is malformed/);
+});
+
+test("a browse shard is read from the identifier and from nothing else", () => {
+  assert.equal(browseShardOf("PALOMAR-2026-07-29-735171"), "71");
+  assert.equal(browseShardOf("PALOMAR-2030-01-01-000000"), "00");
+  assert.throws(() => browseShardOf("PALOMAR-2026-07-29-73517"), /malformed/);
+  assert.throws(() => browseShardOf("PALOMAR-2026-07-29-735171-v1"), /malformed/);
+});
+
+test("a browse URL cannot leave the database origin", () => {
+  const base = "https://data.example.org/";
+  assert.equal(browseDirectoryUrl(base).href, "https://data.example.org/browse/index.json");
+  assert.equal(browseShardUrl("07", base).href, "https://data.example.org/browse/07.json");
+  for (const shard of ["7", "007", "..", "index", "0a"]) {
+    assert.throws(() => browseShardUrl(shard, base), /malformed/, shard);
+  }
+});
+
+test("a subject page is the newest results actually classified under its code", () => {
+  const row = (serial, when, codes = ["05C10"]) => ({
+    ...shardRow(serial),
+    published_at: when,
+    classification: { arxiv: ["math.CO"], msc2020: codes },
+  });
+  const page = {
+    schema_version: 1,
+    kind: "msc",
+    code: "05C10",
+    entries: [row("000123", "2026-08-02T00:00:00Z"), row("000124", "2026-08-01T00:00:00Z")],
+  };
+  assert.equal(validateSubject(structuredClone(page), "msc", "05C10").entries.length, 2);
+
+  assert.throws(() => validateSubject(page, "msc", "68R10"), /different subject/);
+  assert.throws(() => validateSubject(page, "arxiv", "05C10"), /different subject/);
+  assert.throws(() => validateSubject(page, "msc2020", "05C10"), /kind is not recognized/);
+  assert.throws(
+    () => validateSubject({ ...page, entries: [page.entries[1], page.entries[0]] }, "msc", "05C10"),
+    /not newest first/,
+  );
+  assert.throws(
+    () => validateSubject(
+      { ...page, entries: [row("000123", "2026-08-02T00:00:00Z", ["68R10"])] }, "msc", "05C10",
+    ),
+    /not classified under 05C10/,
+  );
+  assert.throws(
+    () => validateSubject(
+      { ...page, entries: [row("000123", "the day before yesterday")] }, "msc", "05C10",
+    ),
+    /published_at is malformed/,
+  );
+  assert.throws(
+    () => validateSubject(
+      { ...page, entries: Array.from({ length: 51 }, () => row("000123", "2026-08-02T00:00:00Z")) },
+      "msc", "05C10",
+    ),
+    /carries more than it may/,
+  );
+});
+
+test("two results published in the same second are in no wrong order", () => {
+  // A tie is not a violation, and refusing one would make a correct page fail
+  // whenever two results happened to be reviewed together.
+  const row = (serial) => ({
+    ...shardRow(serial),
+    published_at: "2026-08-02T00:00:00Z",
+    classification: { arxiv: ["math.CO"], msc2020: ["05C10"] },
+  });
+  const page = { schema_version: 1, kind: "msc", code: "05C10",
+    entries: [row("000123"), row("000124")] };
+  assert.equal(validateSubject(page, "msc", "05C10").entries.length, 2);
+});
+
+test("a subject URL cannot leave the database origin, or name a path", () => {
+  const base = "https://data.example.org/";
+  assert.equal(subjectUrl("msc", "05C10", base).href,
+    "https://data.example.org/subjects/msc/05C10.json");
+  assert.equal(subjectUrl("arxiv", "math.CO", base).href,
+    "https://data.example.org/subjects/arxiv/math.CO.json");
+  for (const code of ["../../etc/passwd", "05C10/../..", "", "05c10", "MATH.CO"]) {
+    assert.throws(() => subjectUrl("msc", code, base), /malformed/, code);
+  }
+  assert.throws(() => subjectUrl("msc2020", "05C10", base), /kind is not recognized/);
 });

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -116,6 +116,29 @@ test("landing cards show the acceptance date and dated identifier", async ({ pag
   await expect(page.getByRole("button", { name: "Additional libraries" })).toBeVisible();
 });
 
+test("the landing page reads the browse pages and not the whole index", async ({ page }) => {
+  // `index.json` names every version ever accepted and is rewritten in full on
+  // every publication. It is still served, and it is retiring; the landing
+  // page must stop being a reason to keep it. Only the shards the directory
+  // counts are fetched, so a registry of three costs three requests and not a
+  // hundred.
+  const asked = [];
+  await page.route("**/database/**", (route) => {
+    asked.push(new URL(route.request().url()).pathname);
+    return route.continue();
+  });
+
+  await page.goto(`/?database=${database}`);
+  await expect(page.locator(".entry-card")).toHaveCount(2);
+
+  expect(asked).not.toContain("/database/index.json");
+  expect(asked.filter((path) => path.startsWith("/database/browse/")).sort()).toEqual([
+    "/database/browse/23.json",
+    "/database/browse/24.json",
+    "/database/browse/index.json",
+  ]);
+});
+
 test("registry entries can be filtered by arXiv and MSC classifications", async ({ page }) => {
   await page.goto(`/?database=${database}`);
   await expect(page.locator('#arxiv-options option[value="math.NT"]')).toHaveCount(1);


### PR DESCRIPTION
This PR points the landing page at the browse shards instead of `index.json`, and adds the three validators the new surfaces need. `index.json` names every version ever accepted and is rewritten in full on every publication; it is retiring, and the landing page must stop being a reason to keep it. The shards carry the same rows, and each one changes only when a result on it does.

`validateBrowseDirectory`, `validateBrowseShard` and `validateSubject` follow `validateVersions`, which exists because the new claim is not about the rows but about what the document asserts it covers. A row from another shard, or one that is not classified under the code at the top of the page, is a well-formed row that the row grammar accepts, and reading it as if it belonged shows a reader someone's work under a heading it has nothing to do with. So the shard is recomputed from each identifier, the code is checked against the classification the row carries, and both the identifier-and-version order of a shard and the newest-first order of a subject page are checked rather than assumed.

The directory is an instruction and not data: its paths become the reader's next fetch. It has to be the hundred shards in order, each naming its own page under a fixed grammar, so a hostile or broken directory can point at nothing else and "every registered result is on exactly one of these pages" is checkable rather than merely claimed. The row grammar the four documents share is now one function, because a grammar living in four places is four chances for one of them to accept a path the other three refuse.

A shard the directory counts as empty is not fetched, which keeps a small registry at a handful of requests rather than a hundred. That is safe because the publisher writes the directory after the shards it counts, so it is never newer than they are; the worst a reader arriving during a publication sees is a page one publication behind, which is the tolerance the feeds already have and which the next load heals.

`validateSubject` and `subjectUrl` are unused by the site so far: this changes the landing page over, and nothing here yet renders a subject page. `tests/fixture_server.py` serves the browse directory and shards so the browser suite exercises the new path, and still serves `index.json`, which is what lets the cached-JavaScript compatibility test keep working.

This needs https://github.com/PalomarRegistry/PalomarDatabase/pull/75 (feat: browse the registry a shard at a time) merged and deployed first, and https://github.com/PalomarRegistry/PalomarDatabase/pull/76 (feat: publish the newest results under each classification code) before anything uses `validateSubject`. The Playwright suite could not be run locally, since Chromium cannot load libglib in this environment; the browse loading path was exercised against the fixture server directly instead.

🤖 Prepared with Claude Code