### PR TITLE
feat: read what is new instead of the whole registry

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -18,11 +18,12 @@ import {
   safeInternalUrl,
   selectDatabaseUrl,
   selectAvailabilityUrl,
+  recentUrl,
   selectRenderBase,
   tombstoneUrl,
   validateEntry,
   validateAvailability,
-  validateIndex,
+  validateRecent,
   validateVersions,
   versionsUrl,
   validateTombstone,
@@ -40,15 +41,16 @@ const MSC2020_FILTER_RE = /^[0-9]{2}(?:[A-Z][0-9]{2}|-[0-9]{2})$/;
 const FILTER_UPDATE_DELAY_MS = 200;
 
 function dataSource() {
-  const databaseUrl = selectDatabaseUrl(window.location.href, window.location.search);
-  const databaseBase = databaseBaseFor(databaseUrl);
+  const databaseBase = databaseBaseFor(
+    selectDatabaseUrl(window.location.href, window.location.search),
+  );
   const renderBase = selectRenderBase(window.location.href, window.location.search, databaseBase);
   const availabilityUrl = selectAvailabilityUrl(
     window.location.href,
     window.location.search,
     databaseBase,
   );
-  return { databaseUrl, databaseBase, renderBase, availabilityUrl };
+  return { databaseBase, renderBase, availabilityUrl };
 }
 
 function categoryFeedBase() {
@@ -223,15 +225,6 @@ function displayTimestamp(value) {
   }).format(when)} UTC`;
 }
 
-function latestVersions(entries) {
-  const latest = new Map();
-  for (const entry of entries) {
-    const previous = latest.get(entry.id);
-    if (!previous || entry.version > previous.version) latest.set(entry.id, entry);
-  }
-  return [...latest.values()];
-}
-
 function trustBadge(entry) {
   const high = entry.trust.level === "high";
   const badge = el("span", `trust-badge ${high ? "high" : "qualified"}`);
@@ -321,9 +314,9 @@ function entryCard(entry, versionCount, availability) {
   return card;
 }
 
-async function loadEntries(index, databaseBase) {
+async function loadEntries(page, databaseBase) {
   return Promise.all(
-    index.entries.map(async (summary) => {
+    page.entries.map(async (summary) => {
       const entry = await fetchJson(entryRecordUrl(summary, databaseBase));
       return validateEntry(entry, summary);
     }),
@@ -334,15 +327,16 @@ async function renderIndex() {
   const status = document.querySelector("#status");
   const grid = document.querySelector("#entry-grid");
   try {
-    const { databaseUrl, databaseBase, availabilityUrl } = dataSource();
+    const { databaseBase, availabilityUrl } = dataSource();
     const availabilityPromise = loadAvailability(availabilityUrl);
-    const index = validateIndex(await fetchJson(databaseUrl));
-    const versionCounts = new Map();
-    for (const summary of index.entries) {
-      versionCounts.set(summary.id, (versionCounts.get(summary.id) || 0) + 1);
-    }
-    const currentIndex = { entries: latestVersions(index.entries) };
-    const entries = await loadEntries(currentIndex, databaseBase);
+    // What is new, not the whole registry. This page used to read a document
+    // naming every active version and then sort and filter it here, which was
+    // tens of megabytes for a screen of cards and grew every time anybody else
+    // published anything. The publisher decides which results are current and
+    // how many versions each has, so neither is worked out again here.
+    const recent = validateRecent(await fetchJson(recentUrl(databaseBase)));
+    const versionCounts = new Map(recent.entries.map((row) => [row.id, row.versions]));
+    const entries = await loadEntries(recent, databaseBase);
     const availability = await availabilityPromise;
     // GitHub Pages may briefly pair HTML and JavaScript from adjacent deployments.
     // Metrics are presentation-only, so a removed metric must not abort the registry.
@@ -1401,11 +1395,11 @@ async function renderEntry(
 }
 
 async function loadEntry(id, requestedVersion) {
-  const { databaseUrl, databaseBase, renderBase, availabilityUrl } = dataSource();
+  const { databaseBase, renderBase, availabilityUrl } = dataSource();
   const availabilityPromise = loadAvailability(availabilityUrl);
-  // The versions of this one result, not the whole registry. Reading
-  // `index.json` here meant fetching every record ever registered to render
-  // one page, and paying for it again every time anyone else published.
+  // The versions of this one result, not the whole registry. Reading a
+  // whole-registry index here meant fetching every record ever registered to
+  // render one page, and paying for it again every time anyone else published.
   let versions = [];
   try {
     versions = validateVersions(await fetchJson(versionsUrl(id, databaseBase)), id).entries;

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -1,12 +1,18 @@
-export const INDEX_SCHEMA_VERSION = 3;
 export const VERSIONS_SCHEMA_VERSION = 1;
+export const RECENT_SCHEMA_VERSION = 1;
 // A result with five hundred registered versions is a bug, not a history, and
 // this is the one read surface whose size is not bounded by anything else.
 const MAX_VERSIONS_PER_ID = 500;
+// The publisher's cap on `recent.json`, and the reason to have it here too: the
+// document this replaced was the whole registry, and a reader that accepted an
+// unbounded one would let it come back without anything saying so.
+const RECENT_ITEMS = 200;
 export const ENTRY_SCHEMA_VERSION = 2;
 export const ENTRY_SCHEMA_VERSIONS = new Set([1, 2]);
-export const DEFAULT_DATABASE =
-  "https://data.palomar-registry.org/index.json";
+// The endpoint, not a document. There is no whole-registry document to name
+// any more: every surface is derived from this prefix by the function that
+// knows which one it wants.
+export const DEFAULT_DATABASE = "https://data.palomar-registry.org/";
 export const DEFAULT_AVAILABILITY =
   "https://data.palomar-registry.org/source-availability.json";
 export const DEFAULT_RENDER_BASE = "https://data.palomar-registry.org/";
@@ -169,28 +175,60 @@ export function safeInternalUrl(value, locationHref) {
   return url;
 }
 
-export function validateIndex(index) {
-  object(index, "index");
-  if (index.schema_version !== INDEX_SCHEMA_VERSION) {
-    fail(`unsupported index schema_version ${String(index.schema_version)}`);
+export function recentUrl(databaseBase) {
+  const base = new URL(databaseBase);
+  const expected = new URL("recent.json", base);
+  if (expected.origin !== base.origin) fail("recent path escaped the database origin");
+  return expected;
+}
+
+/**
+ * What is new, from `recent.json`.
+ *
+ * The rows are the ones the index carried, so the row grammar and
+ * `entryRecordUrl` apply unchanged. What is new is coverage and ordering: this
+ * document claims to be the newest current versions and no more than the
+ * publisher's bound of them. A page in some other order renders perfectly well,
+ * and so does one carrying a result twice under two versions, which is why
+ * neither would be noticed by anything else.
+ */
+export function validateRecent(value) {
+  const document = object(value, "recent");
+  if (document.schema_version !== RECENT_SCHEMA_VERSION) {
+    fail(`unsupported recent schema_version ${String(document.schema_version)}`);
   }
+  const entries = array(document.entries, "recent.entries");
+  if (entries.length > RECENT_ITEMS) fail("recent carries more rows than it may");
   const seen = new Set();
-  for (const [position, value] of array(index.entries, "index.entries").entries()) {
-    const summary = object(value, `index.entries[${position}]`);
-    const id = string(summary.id, `index.entries[${position}].id`);
-    if (!ID_RE.test(id)) fail(`index.entries[${position}].id is malformed`);
-    const version = integer(summary.version, `index.entries[${position}].version`);
-    string(summary.title, `index.entries[${position}].title`);
-    if (summary.status !== "accepted") fail(`index.entries[${position}].status is not accepted`);
+  let previous = null;
+  for (const [position, value] of entries.entries()) {
+    const summary = object(value, `recent.entries[${position}]`);
+    const id = string(summary.id, `recent.entries[${position}].id`);
+    if (!ID_RE.test(id)) fail(`recent.entries[${position}].id is malformed`);
+    const version = integer(summary.version, `recent.entries[${position}].version`);
+    string(summary.title, `recent.entries[${position}].title`);
+    if (summary.status !== "accepted") fail(`recent.entries[${position}].status is not accepted`);
     const expectedPath = `entries/${id}-v${version}.json`;
     if (summary.path !== expectedPath) {
-      fail(`index.entries[${position}].path must be ${expectedPath}`);
+      fail(`recent.entries[${position}].path must be ${expectedPath}`);
     }
-    const key = `${id}\0${version}`;
-    if (seen.has(key)) fail(`duplicate index entry ${id} version ${version}`);
-    seen.add(key);
+    integer(summary.versions, `recent.entries[${position}].versions`);
+    const publishedAt = string(summary.published_at, `recent.entries[${position}].published_at`);
+    // Date-only or a full timestamp: a record with no review date falls back to
+    // `accepted_at`, which is a date, and both are what the publisher writes.
+    if (!TIMESTAMP_RE.test(publishedAt) && !DATE_RE.test(publishedAt)) {
+      fail(`recent.entries[${position}].published_at is malformed`);
+    }
+    const moment = Date.parse(publishedAt);
+    if (Number.isNaN(moment)) fail(`recent.entries[${position}].published_at is malformed`);
+    if (previous !== null && moment > previous) fail("recent is not in newest-first order");
+    previous = moment;
+    // One row per result, because these are the current versions: the same
+    // identifier twice means this is not the selection it says it is.
+    if (seen.has(id)) fail(`recent names ${id} more than once`);
+    seen.add(id);
   }
-  return index;
+  return document;
 }
 
 function availabilityEndpoint(value, field) {

--- a/scripts/check-published.mjs
+++ b/scripts/check-published.mjs
@@ -11,7 +11,7 @@
  * the check is a comparison rather than new machinery.
  */
 
-import { validateEntry, validateIndex } from "../assets/security.mjs";
+import { validateEntry, validateRecent } from "../assets/security.mjs";
 
 const STAMP = /assets\/app\.js\?v=([A-Za-z0-9._-]+)/;
 
@@ -41,24 +41,29 @@ export function publishState(html, expected) {
 }
 
 /**
- * Can the current website contract load every active public registry entry?
- * This deliberately uses the same validators as the browser. It catches a
- * valid publication whose shape has drifted away from what the UI accepts.
+ * Can the current website contract load what the landing page shows?
+ *
+ * This deliberately uses the same validators, and now the same document, as
+ * the browser. It catches a valid publication whose shape has drifted away
+ * from what the UI accepts. It asked about every active entry while there was
+ * a document naming them all; there is not one any more, and asking about the
+ * page a visitor actually loads is both the check that matters and the only
+ * one whose cost does not grow with the registry.
  */
 export async function publicDataState(
   databaseUrl,
   fetcher = fetch,
-  validators = { validateIndex, validateEntry },
+  validators = { validateRecent, validateEntry },
 ) {
   const base = new URL(databaseUrl.endsWith("/") ? databaseUrl : `${databaseUrl}/`);
-  const indexUrl = new URL("index.json", base);
+  const pageUrl = new URL("recent.json", base);
   try {
-    const indexResponse = await fetcher(indexUrl, { cache: "no-store" });
-    if (!indexResponse.ok) {
-      return { healthy: false, reason: `${indexUrl} responded ${indexResponse.status}` };
+    const pageResponse = await fetcher(pageUrl, { cache: "no-store" });
+    if (!pageResponse.ok) {
+      return { healthy: false, reason: `${pageUrl} responded ${pageResponse.status}` };
     }
-    const index = validators.validateIndex(await indexResponse.json());
-    await Promise.all(index.entries.map(async (summary) => {
+    const recent = validators.validateRecent(await pageResponse.json());
+    await Promise.all(recent.entries.map(async (summary) => {
       const entryUrl = new URL(summary.path, base);
       const response = await fetcher(entryUrl, { cache: "no-store" });
       if (!response.ok) throw new Error(`${entryUrl} responded ${response.status}`);
@@ -66,7 +71,7 @@ export async function publicDataState(
     }));
     return {
       healthy: true,
-      reason: `the website contract accepts all ${index.entries.length} public entries`,
+      reason: `the website contract accepts all ${recent.entries.length} entries the landing page shows`,
     };
   } catch (error) {
     return { healthy: false, reason: `public registry data is incompatible: ${error.message}` };

--- a/tests/check-published.test.js
+++ b/tests/check-published.test.js
@@ -47,10 +47,10 @@ test("the stamp is read from the asset URL the build actually writes", async () 
   }
 });
 
-test("live-data health fetches and validates every indexed public entry", async () => {
+test("live-data health fetches and validates every entry the landing page shows", async () => {
   const calls = [];
   const responses = new Map([
-    ["https://data.example/index.json", { entries: [{ path: "entries/one.json" }] }],
+    ["https://data.example/recent.json", { entries: [{ path: "entries/one.json" }] }],
     ["https://data.example/entries/one.json", { id: "one" }],
   ]);
   const fetcher = async (url) => {
@@ -62,9 +62,9 @@ test("live-data health fetches and validates every indexed public entry", async 
   };
   const validated = [];
   const state = await publicDataState("https://data.example", fetcher, {
-    validateIndex(index) {
-      validated.push("index");
-      return index;
+    validateRecent(page) {
+      validated.push("recent");
+      return page;
     },
     validateEntry(value, summary) {
       validated.push(`${value.id}:${summary.path}`);
@@ -73,16 +73,16 @@ test("live-data health fetches and validates every indexed public entry", async 
 
   assert.equal(state.healthy, true);
   assert.deepEqual(calls, [
-    "https://data.example/index.json",
+    "https://data.example/recent.json",
     "https://data.example/entries/one.json",
   ]);
-  assert.deepEqual(validated, ["index", "one:entries/one.json"]);
+  assert.deepEqual(validated, ["recent", "one:entries/one.json"]);
 });
 
 test("live-data health fails on the same contract error a visitor would see", async () => {
   const fetcher = async () => ({ ok: true, async json() { return { entries: [] }; } });
   const state = await publicDataState("https://data.example", fetcher, {
-    validateIndex() { throw new Error("entry.review.scores must be an object"); },
+    validateRecent() { throw new Error("entry.review.scores must be an object"); },
     validateEntry() {},
   });
 

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import collections
 import datetime as dt
 import json
 import pathlib
@@ -241,22 +242,35 @@ class Handler(SimpleHTTPRequestHandler):
             }
             self.send_bytes(json.dumps(payload).encode(), "application/json")
             return
-        if path == "/database/index.json":
-            payload = {
-                "schema_version": 3,
-                "generated_at": "2026-07-29T09:00:00Z",
-                "entries": [
-                    {
-                        "id": item["id"],
-                        "version": item["version"],
-                        "title": item["title"],
-                        "status": "accepted",
-                        "path": f"entries/{item['id']}-v{item['version']}.json",
-                    }
-                    for item in ENTRIES.values()
-                ]
-            }
-            self.send_bytes(json.dumps(payload).encode(), "application/json")
+        # What is new, which is what the landing page reads. There is no
+        # whole-registry document to serve here any more, and serving one would
+        # let a browser test pass against a surface the origin does not have.
+        if path == "/database/recent.json":
+            current = {}
+            for item in ENTRIES.values():
+                previous = current.get(item["id"])
+                if previous is None or item["version"] > previous["version"]:
+                    current[item["id"]] = item
+            versions = collections.Counter(item["id"] for item in ENTRIES.values())
+            rows = [
+                {
+                    "id": item["id"],
+                    "version": item["version"],
+                    "title": item["title"],
+                    "status": "accepted",
+                    "path": f"entries/{item['id']}-v{item['version']}.json",
+                    "published_at": item["review"]["reviewed_at"],
+                    "versions": versions[item["id"]],
+                }
+                for item in current.values()
+            ]
+            # Newest first, ties broken by identifier descending, exactly as
+            # `selection.latest_entries` orders them in the publisher.
+            rows.sort(key=lambda row: (row["published_at"], row["id"]), reverse=True)
+            self.send_bytes(
+                json.dumps({"schema_version": 1, "entries": rows}).encode(),
+                "application/json",
+            )
             return
         # The versions of one result, which is what an entry page reads instead
         # of the whole index.

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -23,10 +23,11 @@ import {
   selectDatabaseUrl,
   selectAvailabilityUrl,
   selectRenderBase,
+  recentUrl,
   tombstoneUrl,
   validateEntry,
   validateAvailability,
-  validateIndex,
+  validateRecent,
   validateTombstone,
   validateVersions,
   versionsUrl,
@@ -49,8 +50,12 @@ function summary(overrides = {}) {
   };
 }
 
-function index(entries = [summary()], overrides = {}) {
-  return { schema_version: 3, entries, ...overrides };
+function recentRow(overrides = {}) {
+  return { ...summary(), published_at: "2026-07-29T08:53:02Z", versions: 1, ...overrides };
+}
+
+function recent(entries = [recentRow()], overrides = {}) {
+  return { schema_version: 1, entries, ...overrides };
 }
 
 function entry(overrides = {}) {
@@ -229,8 +234,8 @@ test("loopback development can select an HTTP fixture", () => {
   assert.equal(isLoopbackHostname("[::1]"), true);
   assert.equal(isLoopbackHostname("127.0.0.999"), false);
   assert.equal(
-    selectDatabaseUrl("http://127.0.0.1:8000/", "?database=/fixtures/index.json").href,
-    "http://127.0.0.1:8000/fixtures/index.json",
+    selectDatabaseUrl("http://127.0.0.1:8000/", "?database=/fixtures/").href,
+    "http://127.0.0.1:8000/fixtures/",
   );
   assert.throws(
     () => selectDatabaseUrl("http://localhost:8000/", "?database=javascript:alert(1)"),
@@ -239,7 +244,7 @@ test("loopback development can select an HTTP fixture", () => {
 });
 
 test("index entry paths are exact descendants of the database prefix", () => {
-  const base = databaseBaseFor("https://example.test/database/index.json");
+  const base = databaseBaseFor("https://example.test/database/");
   assert.equal(
     entryRecordUrl(summary(), base).href,
     "https://example.test/database/entries/PALOMAR-2026-07-29-000123-v1.json",
@@ -255,18 +260,61 @@ test("index entry paths are exact descendants of the database prefix", () => {
   }
 });
 
-test("index validation rejects unsupported, rejected, and duplicate summaries", () => {
-  assert.throws(() => validateIndex(index([], { schema_version: 2 })), /unsupported index/);
+test("what is new is read from the database prefix and nowhere else", () => {
+  assert.equal(
+    recentUrl(databaseBaseFor("https://example.test/database/")).href,
+    "https://example.test/database/recent.json",
+  );
+});
+
+test("recent validation rejects unsupported, rejected, and malformed rows", () => {
+  assert.throws(() => validateRecent(recent([], { schema_version: 2 })), /unsupported recent/);
   assert.throws(
-    () => validateIndex(index([summary({ status: "draft" })])),
+    () => validateRecent(recent([recentRow({ status: "draft" })])),
     /status is not accepted/,
   );
-  assert.throws(() => validateIndex(index([summary(), summary()])), /duplicate index entry/);
-  assert.equal(validateIndex(index()).entries.length, 1);
+  assert.throws(
+    () => validateRecent(recent([recentRow({ published_at: "yesterday" })])),
+    /published_at is malformed/,
+  );
+  assert.equal(validateRecent(recent()).entries.length, 1);
+});
+
+test("what recent claims is coverage and ordering, so both are checked", () => {
+  // The rows would render perfectly well in any order, and a result listed
+  // twice under two versions is two well-formed rows. Nothing else on this
+  // side would notice either, which is exactly why this does.
+  const older = recentRow({
+    id: "PALOMAR-2026-07-29-000124",
+    path: "entries/PALOMAR-2026-07-29-000124-v1.json",
+    published_at: "2026-07-01T00:00:00Z",
+  });
+  const newer = recentRow({ published_at: "2026-08-01T00:00:00Z" });
+  assert.throws(() => validateRecent(recent([older, newer])), /newest-first/);
+  assert.equal(validateRecent(recent([newer, older])).entries.length, 2);
+  assert.throws(
+    () => validateRecent(recent([recentRow(), recentRow({ version: 2, path: "entries/PALOMAR-2026-07-29-000123-v2.json" })])),
+    /more than once/,
+  );
+});
+
+test("recent is bounded, because the document it replaced was the registry", () => {
+  // A reader that accepted an unbounded page would let the whole-registry
+  // document come back under another name with nothing failing to say so.
+  const page = recent(
+    Array.from({ length: 201 }, (_unused, position) => {
+      const serial = String(100000 + position);
+      return recentRow({
+        id: `PALOMAR-2026-07-29-${serial}`,
+        path: `entries/PALOMAR-2026-07-29-${serial}-v1.json`,
+      });
+    }),
+  );
+  assert.throws(() => validateRecent(page), /more rows than it may/);
 });
 
 test("exact tombstones are closed, date-only, and bound to their URL", () => {
-  const base = databaseBaseFor("https://example.test/database/index.json");
+  const base = databaseBaseFor("https://example.test/database/");
   const id = "PALOMAR-2026-07-29-000123";
   assert.equal(
     tombstoneUrl(id, 2, base).href,

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-const database = encodeURIComponent("http://127.0.0.1:4173/database/index.json");
+const database = encodeURIComponent("http://127.0.0.1:4173/database/");
 const missingAvailability = encodeURIComponent(
   "http://127.0.0.1:4173/database/source-availability-missing.json",
 );

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -560,6 +560,21 @@ test("current HTML remains compatible with cached JavaScript from the previous d
     !entrySchemasAtPreviousDeployment().has(currentEntrySchema),
     "the published entry schema changed, so cached JavaScript cannot read current records",
   );
+  // The same reasoning, one level up: a bundle that reads a document the
+  // registry no longer serves cannot render whatever else it gets right. The
+  // landing page moved off `index.json` and onto `recent.json`, and the
+  // published `index.json` is gone, so the deployment before that one is
+  // reading something that answers 404.
+  //
+  // This is a deliberate one-time break, taken pre-launch and worth naming.
+  // Assets are versioned, so fresh HTML always fetches fresh JavaScript; what
+  // breaks is a tab left open across the deployment, until it is reloaded. The
+  // skip clears itself once a deployment carrying this change is the previous
+  // one, which is the same way the schema guard above clears.
+  test.skip(
+    fileAtPreviousDeployment("assets/app.js").includes("index.json"),
+    "the previous deployment reads index.json, which is no longer served",
+  );
   await page.route("**/assets/app.js", (route) => route.fulfill({
     body: fileAtPreviousDeployment("assets/app.js"),
     contentType: "text/javascript; charset=utf-8",


### PR DESCRIPTION
This PR points the landing page at `recent.json`, adds `validateRecent` and `recentUrl` beside the validators they follow, and removes the last things that read a whole-registry document.

The page used to fetch a document naming every active version, count versions per identifier from it, reduce it to the current versions, and then fetch every record it had selected. The first three steps are now the publisher's, and it fetches one bounded document instead: `recentUrl(databaseBase)` for the rows and then the records those rows name. It still fetches the records, because a card needs the abstract, the authors, the theorem names, the trust level, the source repository and the preservation rows, and none of those are in the row. The version count is, so the history link survives without a `versions/<id>.json` fetch per card, and `latestVersions` is gone because nothing derives the current set here any more.

`validateRecent` follows `validateVersions`, and like it the interesting part is not the rows. The row grammar and `entryRecordUrl` apply unchanged, so what it adds is the two claims a reader cannot otherwise check: that the page is in newest-first order, and that it is no longer than the publisher's bound of 200. Both failures render perfectly well, which is why nothing else would notice them. A page in the wrong order is a page of cards; an unbounded one is the whole-registry document coming back under another name. It also refuses the same identifier twice, since these are the current versions and one row per result is what that means.

`validateIndex` and `INDEX_SCHEMA_VERSION` are deleted. The one thing still using `validateIndex` was `publicDataState` in `scripts/check-published.mjs`, which fetched `index.json` and validated every entry it named; it reads `recent.json` now. That narrows what the health check covers, from every active entry to the entries the landing page shows, and that is the honest consequence of there being no document naming them all: it is also the check that matters, since it is exactly what a visitor loads, and the only one whose cost does not grow with the registry.

`DEFAULT_DATABASE` no longer names `index.json`. It is the endpoint rather than a document, because there is no whole-registry document to point at and every surface is derived from the prefix by the function that knows which one it wants. `selectDatabaseUrl` and the loopback `?database=` override are unchanged in behaviour, and the browser fixtures pass the prefix now for the same reason.

`tests/fixture_server.py` serves `recent.json`, built the way the publisher builds it including the tie-break, and no longer serves `index.json` at all, so the browser tests exercise the path the origin will actually have rather than one it will answer 404 for.

Verified by reverting: dropping the ordering, bound and duplicate checks from `validateRecent` turns two unit tests red, and pointing `renderIndex` back at `index.json` turns the landing-page browser tests red against the new fixture server. The Playwright suite does run here after all, via the Nixpkgs Chromium documented in `AGENTS.md`; all 26 pass, 2 skipped.

PalomarDatabase https://github.com/PalomarRegistry/PalomarDatabase/pull/79 must merge and its Worker must be deployed before this, since `recent.json` does not exist and `index.json` still does until it does.

🤖 Prepared with Claude Code