### PR TITLE
feat: search the registry from the landing page

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -13,14 +13,22 @@ import {
   isLoopbackHostname,
   pinnedRepositoryDirectoryUrl,
   pinnedRepositoryFileUrl,
+  postingRecordUrl,
   safeDataUrl,
   safeExternalUrl,
   safeInternalUrl,
+  searchHeadUrl,
+  searchPageUrl,
+  searchTerms,
+  stopwordsUrl,
   selectDatabaseUrl,
   selectAvailabilityUrl,
   recentUrl,
   selectRenderBase,
   tombstoneUrl,
+  validateSearchHead,
+  validateSearchPage,
+  validateStopwords,
   validateEntry,
   validateAvailability,
   validateRecent,
@@ -454,6 +462,269 @@ async function renderIndex() {
     status.textContent = `The registry could not be loaded: ${error.message}`;
     status.classList.add("error");
   }
+}
+
+// How much of a word's postings one query is allowed to pull. A common word
+// runs to hundreds of pages at a hundred thousand results, and a reader wants
+// the newest matches rather than all of them; the record check below is what
+// makes stopping early safe rather than merely cheap.
+const SEARCH_PAGE_BUDGET = 16;
+const SEARCH_RESULT_LIMIT = 20;
+const SEARCH_CANDIDATE_LIMIT = 60;
+const POSTING_RE = /^(PALOMAR-\d{4}-\d{2}-\d{2}-\d{6})-v([1-9]\d*)$/;
+
+// One editorial constant, fetched once per page rather than copied into this
+// repository, where it would drift from the indexer's across two deployments.
+let stopwords = null;
+
+/**
+ * The words the indexer drops, so that a query can drop them too.
+ *
+ * Inferring them instead, from the fact that a dropped word has no head, was
+ * wrong in a way a reader could not diagnose: a missing head is also what a
+ * word nothing carries looks like, so "the ring" was answered against a record
+ * whose text happens not to contain "the" by reporting that "the" is
+ * unfindable. The list is published because it is a fixed choice of a few
+ * hundred function words, which is nothing like the document naming every
+ * known word that this index exists without.
+ *
+ * A list that cannot be fetched leaves every word in the query, which is the
+ * behaviour this replaced: it narrows a search that should have been wider,
+ * and never shows a result that does not match.
+ */
+async function searchStopwords(databaseBase) {
+  if (stopwords) return stopwords;
+  try {
+    stopwords = validateStopwords(await fetchJson(stopwordsUrl(databaseBase)));
+  } catch (error) {
+    if (error.status !== 404) throw error;
+    stopwords = new Set();
+  }
+  return stopwords;
+}
+
+async function searchHead(term, databaseBase) {
+  try {
+    return validateSearchHead(await fetchJson(searchHeadUrl(term, databaseBase)), term);
+  } catch (error) {
+    // A 404 is the only answer there is for a word nothing carries. There is
+    // no document to consult first: one that named every known word would grow
+    // with the registry and be rewritten on every publication, which is the
+    // whole reason this index is shaped the way it is.
+    if (error.status !== 404) throw error;
+    return null;
+  }
+}
+
+/**
+ * One word's postings, newest first, for as many pages as the budget allows.
+ *
+ * The pages are in registration order, so the last page is the newest batch,
+ * and within a page an identifier begins with its registration date. A page
+ * the head says exists and that is not there is an error rather than an empty
+ * answer: the head is the only account of which pages there are.
+ */
+async function searchPostings(term, head, databaseBase, wanted) {
+  const postings = [];
+  const first = Math.max(0, head.pages - wanted);
+  for (let number = head.pages - 1; number >= first; number -= 1) {
+    const page = validateSearchPage(
+      await fetchJson(searchPageUrl(term, number, databaseBase)),
+      term,
+      number,
+      head,
+    );
+    postings.push(...[...page.postings].reverse());
+  }
+  return { postings, whole: first === 0 };
+}
+
+/**
+ * Which results might match, in the order they would be shown.
+ *
+ * The rarest word drives, because its sequence is the shortest and every match
+ * is somewhere in it. Another word joins the intersection only if the whole of
+ * it fits in what is left of the budget: intersecting against half a word's
+ * postings would drop genuine matches while looking like a narrower search.
+ * Everything else is settled per record by `carriesEveryTerm`, which is exact
+ * and costs nothing, since the record has to be fetched to be shown anyway.
+ *
+ * A word with no head is a word nothing carries, and it is that rather than a
+ * word the indexer drops because the dropped ones have already left the query
+ * by the time this runs. It leaves the intersection and stays in the
+ * per-record check, which rejects every candidate, and it is named in what the
+ * reader is told rather than guessed about.
+ */
+async function searchCandidates(terms, databaseBase) {
+  const heads = [];
+  const missing = [];
+  for (const term of terms) {
+    const head = await searchHead(term, databaseBase);
+    if (head && head.results > 0) heads.push([term, head]);
+    else missing.push(term);
+  }
+  heads.sort((left, right) => left[1].results - right[1].results);
+  if (!heads.length) return { postings: [], whole: true, missing };
+
+  let budget = SEARCH_PAGE_BUDGET;
+  let found = null;
+  let whole = true;
+  for (const [term, head] of heads) {
+    if (found !== null && head.pages > budget) break;
+    const wanted = Math.min(head.pages, budget);
+    if (wanted === 0) break;
+    const pulled = await searchPostings(term, head, databaseBase, wanted);
+    budget -= wanted;
+    whole = whole && pulled.whole;
+    if (found === null) {
+      found = pulled.postings;
+    } else {
+      const carried = new Set(pulled.postings);
+      found = found.filter((posting) => carried.has(posting));
+    }
+    if (budget <= 0) break;
+  }
+  return { postings: found ?? [], whole, missing };
+}
+
+/**
+ * Whether a record really carries every word of the query.
+ *
+ * This is the check the postings are an index *of*, made against the record
+ * itself, so a posting that claims a result it should not is caught here
+ * rather than shown. It is also what lets the intersection above stop early
+ * and what lets a word with no head still be answered exactly.
+ */
+function carriesEveryTerm(entry, terms) {
+  const words = new Set([
+    ...searchTerms(entry.title),
+    ...searchTerms(entry.abstract),
+    ...entry.authors.flatMap((author) => searchTerms(author.name)),
+  ]);
+  return terms.every((term) => words.has(term));
+}
+
+/**
+ * The summary a fetched record is checked against.
+ *
+ * `index.json` is an independent claim about a record's title, which is why
+ * `validateEntry` compares the two. A posting claims something else: that this
+ * record carries these words. So the identity is checked here and the claim
+ * itself is checked by `carriesEveryTerm`, against the record's own text.
+ */
+function postingSummary(posting, entry) {
+  const match = POSTING_RE.exec(posting);
+  return {
+    id: match[1],
+    version: Number(match[2]),
+    title: entry.title,
+    status: entry.status,
+    path: `entries/${posting}.json`,
+  };
+}
+
+async function searchRegistry(query, databaseBase) {
+  const asked = [...new Set(searchTerms(query))];
+  const dropping = await searchStopwords(databaseBase);
+  const dropped = asked.filter((term) => dropping.has(term));
+  const terms = asked.filter((term) => !dropping.has(term));
+  if (!terms.length) {
+    return { terms, dropped, entries: [], whole: true, examined: 0, missing: [] };
+  }
+  const { postings, whole, missing } = await searchCandidates(terms, databaseBase);
+  const entries = [];
+  let examined = 0;
+  for (const posting of postings) {
+    if (entries.length >= SEARCH_RESULT_LIMIT || examined >= SEARCH_CANDIDATE_LIMIT) break;
+    examined += 1;
+    const record = await fetchJson(postingRecordUrl(posting, databaseBase));
+    const entry = validateEntry(record, postingSummary(posting, record));
+    if (carriesEveryTerm(entry, terms)) entries.push(entry);
+  }
+  return {
+    terms,
+    dropped,
+    entries,
+    missing,
+    whole: whole && examined === postings.length,
+    examined,
+  };
+}
+
+function searchPageUrlFor(query) {
+  const target = new URL("index.html", window.location.href);
+  target.search = "";
+  for (const [name, value] of params.entries()) {
+    if (name !== "q") target.searchParams.set(name, value);
+  }
+  if (query) target.searchParams.set("q", query);
+  return safeInternalUrl(target, window.location.href);
+}
+
+async function renderSearch(query) {
+  const status = document.querySelector("#search-status");
+  const results = document.querySelector("#search-results");
+  const grid = document.querySelector("#entry-grid");
+  const toolbar = document.querySelector(".toolbar");
+  if (!status || !results) return;
+  results.replaceChildren();
+  status.className = "status";
+  const searching = Boolean(searchTerms(query).length);
+  if (grid) grid.hidden = searching;
+  if (toolbar) toolbar.hidden = searching;
+  if (!searching) {
+    status.hidden = true;
+    return;
+  }
+  status.hidden = false;
+  status.textContent = "Searching the registry…";
+  try {
+    const { databaseBase } = dataSource();
+    const found = await searchRegistry(query, databaseBase);
+    for (const entry of found.entries) results.append(entryCard(entry, 1, null));
+    if (!found.terms.length) {
+      // Every word of the query is one the indexer drops, so there is nothing
+      // to ask for. Saying which words those were is the difference between an
+      // answer and an apparently empty registry.
+      status.textContent =
+        `Every word of that search is too common to be indexed: ${found.dropped.join(", ")}.`;
+      return;
+    }
+    if (!found.entries.length) {
+      // Naming the words nothing carries is what turns "no results" into
+      // something a reader can act on. The words the indexer drops are not
+      // among them: they left the query before it was asked.
+      status.textContent = found.missing.length
+        ? `No result carries all of: ${found.terms.join(", ")}. Nothing is indexed under `
+          + `${found.missing.join(", ")}.`
+        : `No result carries all of: ${found.terms.join(", ")}.`;
+      return;
+    }
+    status.hidden = found.whole;
+    status.textContent = found.whole
+      ? ""
+      : `Showing the newest ${found.entries.length} results; narrow the search for older ones.`;
+  } catch (error) {
+    status.textContent = `The search could not be run: ${error.message}`;
+    status.classList.add("error");
+  }
+}
+
+function wireSearch() {
+  const form = document.querySelector("#registry-search");
+  const input = document.querySelector("#query");
+  if (!form || !input) return;
+  const initial = params.get("q") || "";
+  input.value = initial;
+  form.addEventListener("submit", (event) => {
+    // The page's own content security policy forbids form submission, which is
+    // right: nothing here posts anywhere. The query is a link to this page.
+    event.preventDefault();
+    const query = input.value.trim();
+    window.history.replaceState(null, "", searchPageUrlFor(query));
+    renderSearch(query);
+  });
+  if (initial) renderSearch(initial);
 }
 
 function detailRow(label, value) {
@@ -1562,6 +1833,11 @@ async function renderChallengePage() {
   }
 }
 
-if (document.body.dataset.page === "index") renderIndex();
+if (document.body.dataset.page === "index") {
+  // Wired first and run independently of the listing, so that arriving at a
+  // search link does not wait for every record on the landing page to load.
+  wireSearch();
+  renderIndex();
+}
 if (document.body.dataset.page === "entry") renderEntryPage();
 if (document.body.dataset.page === "render") renderChallengePage();

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -360,6 +360,187 @@ export function validateVersions(value, id) {
   return document;
 }
 
+export const SEARCH_SCHEMA_VERSION = 1;
+// A word is lowercase, alphanumeric and short, and anything a word cannot be
+// was dropped by the indexer rather than escaped. That is what lets this
+// request be built straight from what somebody typed: there is no term
+// dictionary to check the word against first, because a document naming every
+// known word grows with the registry and would be rewritten on every
+// publication. See `docs/publication.md` in PalomarDatabase.
+const SEARCH_TERM_RE = /^[a-z0-9]{2,32}$/;
+const POSTING_RE = /^PALOMAR-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6}-v[1-9][0-9]*$/;
+// Two hundred and sixty thousand results under one word at the published page
+// size. The publisher refuses to go past this, so a head that claims to is
+// describing an index this reader has never been able to read.
+const MAX_SEARCH_PAGES = 2048;
+const MAX_SEARCH_PAGE_SIZE = 1024;
+// The published list is a few hundred function words and is meant to stay
+// that way. A list an order of magnitude longer is not a stopword list any
+// more, and reading one would let the served data decide which queries this
+// page is willing to run.
+const MAX_STOPWORDS = 2000;
+
+function count(value, field) {
+  if (!Number.isSafeInteger(value) || value < 0) fail(`${field} must be a count`);
+  return value;
+}
+
+/**
+ * The words of a text, by exactly the rule the indexer used.
+ *
+ * Three steps, in this order: decompose, drop combining marks, lowercase. The
+ * marks are dropped rather than split on, so Erdős is `erdos` and not `erd`
+ * and `s`; a registry of mathematics is full of names nobody types with their
+ * accents. `toLowerCase` rather than a fuller case fold, because Python's
+ * `str.casefold` maps ß to ss and this does not, and the two sides have to
+ * agree exactly: a query folded differently is a request for a word the
+ * indexer never wrote, which looks from here exactly like no results.
+ *
+ * Used on the query and on each record this page is about to show, which is
+ * what lets a word with no postings still be decided correctly. See
+ * `searchCandidates` in `app.js`.
+ */
+export function searchTerms(text) {
+  const folded = String(text ?? "")
+    .normalize("NFKD")
+    .replace(/\p{Mn}/gu, "")
+    .toLowerCase();
+  return folded.split(/[^a-z0-9]+/).filter((word) => SEARCH_TERM_RE.test(word));
+}
+
+function searchUrl(term, leaf, databaseBase) {
+  if (typeof term !== "string" || !SEARCH_TERM_RE.test(term)) {
+    fail("search term is not a word this index can name");
+  }
+  const base = new URL(databaseBase);
+  const expected = new URL(`search/t/${term}/${leaf}.json`, base);
+  if (expected.origin !== base.origin || !expected.pathname.endsWith(`/${term}/${leaf}.json`)) {
+    fail("search path escaped the database origin");
+  }
+  return expected;
+}
+
+export function searchHeadUrl(term, databaseBase) {
+  return searchUrl(term, "head", databaseBase);
+}
+
+export function searchPageUrl(term, page, databaseBase) {
+  if (!Number.isSafeInteger(page) || page < 0 || page >= MAX_SEARCH_PAGES) {
+    fail("search page number is out of range");
+  }
+  return searchUrl(term, String(page), databaseBase);
+}
+
+/**
+ * How long one word's postings are, from `search/t/<term>/head.json`.
+ *
+ * The head is the only thing that tells a reader which pages exist, so it is
+ * an instruction and not data: its numbers become the next requests. A head
+ * claiming more pages than its sequence has sends a reader after pages that
+ * are not there; one claiming fewer hides results while looking perfectly
+ * well-formed. So the arithmetic is checked rather than trusted, and the
+ * bounds are checked too, because the alternative to a bound here is a page
+ * count somebody can make as large as they like.
+ *
+ * One count, not two. There were two while a withdrawal emptied its slot
+ * instead of closing the sequence up, and the difference between them said how
+ * many withdrawn results carried the word, which is what a takedown is meant
+ * to take away.
+ */
+export function validateSearchHead(value, term) {
+  const head = object(value, "search head");
+  if (head.schema_version !== SEARCH_SCHEMA_VERSION) {
+    fail(`unsupported search head schema_version ${String(head.schema_version)}`);
+  }
+  if (head.term !== term) fail("search head is for a different word");
+  const pageSize = integer(head.page_size, "search head page_size");
+  if (pageSize > MAX_SEARCH_PAGE_SIZE) fail("search head page_size is implausibly large");
+  const pages = count(head.pages, "search head pages");
+  if (pages > MAX_SEARCH_PAGES) fail("search head claims more pages than this index can have");
+  const results = count(head.results, "search head results");
+  if (pages !== Math.ceil(results / pageSize)) {
+    fail("search head page count does not cover the postings it claims");
+  }
+  return head;
+}
+
+/**
+ * One page of a word's postings, from `search/t/<term>/<page>.json`.
+ *
+ * The rows are versioned identifiers, so a posting resolves straight to a
+ * record with nothing in between. What is checked beyond their shape is what
+ * the page claims about itself: that it is this page of this word, that it
+ * holds no more than the page size the head published, and that its postings
+ * strictly increase. The last of those is the one worth having. An identifier
+ * begins with its registration date, so increasing order is date order within
+ * the page, and a page that repeated a posting or padded itself with the same
+ * result over and over would be a well-formed page that showed a reader the
+ * same work several times under a search it may not match at all.
+ */
+export function validateSearchPage(value, term, number, head) {
+  const page = object(value, "search page");
+  if (page.schema_version !== SEARCH_SCHEMA_VERSION) {
+    fail(`unsupported search page schema_version ${String(page.schema_version)}`);
+  }
+  if (page.term !== term) fail("search page is for a different word");
+  if (page.page !== number) fail("search page is not the page that was requested");
+  if (number >= head.pages) fail("search page is past the end of the sequence");
+  const postings = array(page.postings, "search page postings");
+  if (postings.length > head.page_size) fail("search page is longer than the head allows");
+  let previous = "";
+  for (const [position, posting] of postings.entries()) {
+    string(posting, `search page postings[${position}]`);
+    if (!POSTING_RE.test(posting)) fail(`search page postings[${position}] is malformed`);
+    if (posting <= previous) fail("search page postings are not in increasing order");
+    previous = posting;
+  }
+  return page;
+}
+
+export function stopwordsUrl(databaseBase) {
+  const base = new URL(databaseBase);
+  const expected = new URL("search/stopwords.json", base);
+  if (expected.origin !== base.origin) fail("stopwords path escaped the database origin");
+  return expected;
+}
+
+/**
+ * The words the indexer drops, from `search/stopwords.json`.
+ *
+ * This is the one document in the search surface that names words, and it is
+ * not the term dictionary the design refuses: it is a fixed editorial choice of
+ * function words, so it is the same size at a hundred thousand results as it is
+ * now, where a dictionary of every known word grows with the vocabulary and is
+ * rewritten on every publication. So the bound is checked here, and a list that
+ * had grown into a dictionary is refused rather than read.
+ *
+ * Fetched rather than copied. A copy in this repository would drift from the
+ * indexer's across two deployments, and a reader whose copy disagreed would ask
+ * for a word that was never written and be told, in a way they cannot diagnose,
+ * that nothing carries it.
+ */
+export function validateStopwords(value) {
+  const document = object(value, "stopwords");
+  if (document.schema_version !== SEARCH_SCHEMA_VERSION) {
+    fail(`unsupported stopwords schema_version ${String(document.schema_version)}`);
+  }
+  const words = array(document.stopwords, "stopwords list");
+  if (words.length > MAX_STOPWORDS) fail("stopword list has grown into a term dictionary");
+  for (const [position, word] of words.entries()) {
+    string(word, `stopwords list[${position}]`);
+    if (!SEARCH_TERM_RE.test(word)) fail(`stopwords list[${position}] is not a word`);
+  }
+  return new Set(words);
+}
+
+export function postingRecordUrl(posting, databaseBase) {
+  if (typeof posting !== "string" || !POSTING_RE.test(posting)) fail("posting is malformed");
+  const base = new URL(databaseBase);
+  const expected = new URL(`entries/${posting}.json`, base);
+  if (expected.origin !== base.origin) fail("posting path escaped the database origin");
+  return expected;
+}
+
 export function tombstoneUrl(id, version, databaseBase) {
   if (typeof id !== "string" || !ID_RE.test(id)) fail("tombstone ID is malformed");
   integer(version, "tombstone version");

--- a/assets/style.css
+++ b/assets/style.css
@@ -172,6 +172,40 @@ h3 {
   font-size: .9rem;
 }
 
+/* The registry-wide search, which asks the published index a question, above
+   the toolbar, which filters what is already on the page. Two controls that
+   both take words need to be told apart by where they are and what they say. */
+.registry-search {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  flex-wrap: wrap;
+  margin-block: 1rem .75rem;
+  font: .9rem/1.3 var(--sans);
+}
+
+.registry-search input {
+  flex: 1;
+  min-width: 14rem;
+  max-width: 34rem;
+  min-height: 2.1rem;
+  padding: .3rem .45rem;
+  border: 1px solid #777;
+  border-radius: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font: .95rem var(--sans);
+}
+
+.registry-search input:focus-visible {
+  outline: 2px solid var(--link);
+  outline-offset: 2px;
+}
+
+#search-results:empty {
+  display: none;
+}
+
 .toolbar {
   display: flex;
   align-items: center;

--- a/index.html
+++ b/index.html
@@ -45,9 +45,17 @@
           </a>
         </div>
 
+        <form id="registry-search" class="registry-search" role="search">
+          <label for="query">Search the registry:</label>
+          <input id="query" name="q" type="search" placeholder="words from a title, abstract, or author" autocomplete="off" spellcheck="false" maxlength="200">
+          <button type="submit">Search</button>
+        </form>
+        <div id="search-status" class="status" role="status" hidden></div>
+        <div id="search-results" class="entry-grid" aria-live="polite"></div>
+
         <div class="toolbar">
           <label class="search">
-            <span>Search:</span>
+            <span>Filter:</span>
             <input id="search" type="search" placeholder="title, author, theorem, or repository" autocomplete="off">
           </label>
           <div class="category-filters" role="group" aria-label="Subject filters">

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -8,12 +8,21 @@ import datetime as dt
 import json
 import pathlib
 import re
+import unicodedata
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 HOST = "127.0.0.1"
 PORT = 4173
 HASH = "a" * 64
+# Small enough that the fixture has several pages per word, because a single
+# page would exercise none of the walking the browser does.
+SEARCH_PAGE_SIZE = 2
+# The same three steps, in the same order, as `tools/build_search.py` in
+# PalomarDatabase and `searchTerms` in assets/security.mjs. A fixture that
+# tokenized differently would test the browser against an index nothing
+# publishes.
+SEARCH_STOPWORDS = {"an", "and", "for", "in", "of", "on", "the", "to", "with"}
 
 
 def entry(identifier: str, lines: int, version: int = 1) -> dict:
@@ -31,7 +40,7 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
         "version": version,
         "status": "accepted",
         "title": f"Fixture {identifier} version {version}",
-        "abstract": "A browser confinement fixture.",
+        "abstract": "A browser confinement fixture for the registry, about the quasicoherent behaviour of a synthetic result.",
         "authors": [{"name": "Example"}],
         "classification": classification,
         "provenance": {
@@ -176,6 +185,37 @@ ENTRIES = {
         "PALOMAR-2026-07-29-000124", 101, 1
     ),
 }
+def search_terms(text: str) -> list[str]:
+    decomposed = unicodedata.normalize("NFKD", text)
+    folded = "".join(
+        character for character in decomposed if unicodedata.category(character) != "Mn"
+    ).lower()
+    return [word for word in re.split(r"[^a-z0-9]+", folded) if 2 <= len(word) <= 32]
+
+
+def search_index(entries: dict) -> dict[str, list[str]]:
+    """One postings sequence per word, in registration order.
+
+    Built here rather than copied from a published snapshot so that the browser
+    suite exercises the walking and the validators against an index it can
+    reason about, including a word that is on every result and a word that is
+    on one.
+    """
+    postings: dict[str, list[str]] = {}
+    for (identifier, version), record in sorted(entries.items()):
+        texts = [record["title"], record["abstract"]]
+        texts.extend(author["name"] for author in record["authors"])
+        words = {
+            word
+            for text in texts
+            for word in search_terms(text)
+            if word not in SEARCH_STOPWORDS
+        }
+        for word in sorted(words):
+            postings.setdefault(word, []).append(f"{identifier}-v{version}")
+    return postings
+
+
 ENTRIES[("PALOMAR-2026-07-29-000124", 1)]["trust"].update(
     {
         "level": "qualified",
@@ -192,6 +232,15 @@ ENTRIES[("PALOMAR-2026-07-29-000124", 1)]["trust"].update(
         "reasons": ["Challenge imports Tau Ceti"],
     }
 )
+# One record whose text carries no function word at all, which is exactly the
+# case the published stopword list exists for: a query containing "the" has to
+# find it anyway, and inferring stopwords from a missing head could not.
+ENTRIES[("PALOMAR-2026-07-29-000124", 1)]["abstract"] = (
+    "Quasicoherent sheaves, synthetically."
+)
+SEARCH_INDEX = search_index(ENTRIES)
+
+
 class Handler(SimpleHTTPRequestHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=str(ROOT), **kwargs)
@@ -302,6 +351,51 @@ class Handler(SimpleHTTPRequestHandler):
                 }).encode(),
                 "application/json",
             )
+            return
+        # The words the indexer drops, which is the one list there is: a fixed
+        # editorial choice, so it is constant in size and is nothing like the
+        # document naming every known word that this index exists without.
+        if path == "/database/search/stopwords.json":
+            self.send_bytes(
+                json.dumps(
+                    {"schema_version": 1, "stopwords": sorted(SEARCH_STOPWORDS)}
+                ).encode(),
+                "application/json",
+            )
+            return
+        # One word's postings. There is no document naming the words, by
+        # design, so an unknown word is a 404 and the browser has to be able to
+        # tell that apart from a broken index.
+        search = re.fullmatch(r"/database/search/t/([a-z0-9]{2,32})/(head|[0-9]{1,4})\.json", path)
+        if search:
+            term, leaf = search.group(1), search.group(2)
+            rows = SEARCH_INDEX.get(term)
+            if rows is None:
+                self.send_error(404)
+                return
+            pages = [
+                sorted(rows[start : start + SEARCH_PAGE_SIZE])
+                for start in range(0, len(rows), SEARCH_PAGE_SIZE)
+            ]
+            if leaf == "head":
+                payload = {
+                    "schema_version": 1,
+                    "term": term,
+                    "page_size": SEARCH_PAGE_SIZE,
+                    "pages": len(pages),
+                    "results": len(rows),
+                }
+            elif int(leaf) < len(pages):
+                payload = {
+                    "schema_version": 1,
+                    "term": term,
+                    "page": int(leaf),
+                    "postings": pages[int(leaf)],
+                }
+            else:
+                self.send_error(404)
+                return
+            self.send_bytes(json.dumps(payload).encode(), "application/json")
             return
         tombstone = re.fullmatch(
             r"/database/tombstones/(PALOMAR-2026-07-29-000125)-v(1)\.json",

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -31,6 +31,14 @@ import {
   validateTombstone,
   validateVersions,
   versionsUrl,
+  postingRecordUrl,
+  searchHeadUrl,
+  searchPageUrl,
+  searchTerms,
+  stopwordsUrl,
+  validateSearchHead,
+  validateSearchPage,
+  validateStopwords,
 } from "../assets/security.mjs";
 
 // The website's own origin, for the cross-origin assertion below.
@@ -706,4 +714,155 @@ test("a version index URL cannot leave the database origin", () => {
     "https://data.example.org/versions/PALOMAR-2026-07-29-000123.json");
   assert.throws(() => versionsUrl("../../etc/passwd", base), /malformed/);
   assert.throws(() => versionsUrl("PALOMAR-2026-07-29-00012", base), /malformed/);
+});
+
+const SEARCH_BASE = "https://data.example.test/";
+
+function searchHead(overrides = {}) {
+  return {
+    schema_version: 1,
+    term: "ring",
+    page_size: 128,
+    pages: 2,
+    results: 130,
+    ...overrides,
+  };
+}
+
+test("a query becomes a path only when every word could be one", () => {
+  // There is no dictionary to check a word against before asking for it: a
+  // document naming every known word would grow with the registry and be
+  // rewritten on every publication. So the grammar is the whole defence, and
+  // it has to refuse everything a word cannot be.
+  assert.equal(
+    searchHeadUrl("ring", SEARCH_BASE).href,
+    "https://data.example.test/search/t/ring/head.json",
+  );
+  assert.equal(
+    searchPageUrl("ring", 17, SEARCH_BASE).href,
+    "https://data.example.test/search/t/ring/17.json",
+  );
+  for (const hostile of ["", "a", "Ring", "ring!", "../entries/x", "ring/0", "r".repeat(33), 7]) {
+    assert.throws(() => searchHeadUrl(hostile, SEARCH_BASE), /search term/, String(hostile));
+  }
+  for (const page of [-1, 1.5, 2048, Number.MAX_SAFE_INTEGER, "0"]) {
+    assert.throws(() => searchPageUrl("ring", page, SEARCH_BASE), /page number/, String(page));
+  }
+});
+
+test("the words of a query are folded exactly as the indexer folded them", () => {
+  // Three steps in one order: decompose, drop the combining marks, lowercase.
+  // A query folded any other way asks for a word that was never written, which
+  // from here is indistinguishable from no results.
+  assert.deepEqual(searchTerms("Erdős–Kähler rings"), ["erdos", "kahler", "rings"]);
+  assert.deepEqual(searchTerms("../../etc/passwd %2e%2e"), ["etc", "passwd", "2e", "2e"]);
+  // Nothing is stemmed: `ring` and `rings` are different questions in a
+  // registry of mathematics.
+  assert.deepEqual(searchTerms("ring rings"), ["ring", "rings"]);
+  // Dropped rather than escaped, so nothing outside the grammar can reach a path.
+  assert.deepEqual(searchTerms("a \u{1f600} <script>"), ["script"]);
+  assert.deepEqual(searchTerms("x".repeat(33)), []);
+});
+
+test("a postings head must account for the pages it sends a reader after", () => {
+  // The head is an instruction, not data: its numbers become the next requests.
+  // One claiming more pages than its sequence has sends a reader after pages
+  // that are not there; one claiming fewer hides results while staying a
+  // perfectly well-formed document.
+  assert.equal(validateSearchHead(searchHead(), "ring").results, 130);
+  assert.equal(validateSearchHead(searchHead({ pages: 0, results: 0 }), "ring").pages, 0);
+
+  assert.throws(() => validateSearchHead(searchHead(), "field"), /different word/);
+  assert.throws(() => validateSearchHead(searchHead({ pages: 3 }), "ring"), /does not cover/);
+  assert.throws(() => validateSearchHead(searchHead({ pages: 1 }), "ring"), /does not cover/);
+  assert.throws(
+    () => validateSearchHead(searchHead({ page_size: 1, pages: 2049, results: 2049 }), "ring"),
+    /more pages/,
+  );
+  assert.throws(() => validateSearchHead(searchHead({ page_size: 1025 }), "ring"), /page_size/);
+  assert.throws(() => validateSearchHead(searchHead({ schema_version: 2 }), "ring"), /schema_version/);
+});
+
+test("a postings page must be the page it was asked for, in order, and no longer", () => {
+  const head = searchHead({ page_size: 4, pages: 2, results: 8 });
+  const page = (postings, overrides = {}) => ({
+    schema_version: 1,
+    term: "ring",
+    page: 1,
+    postings,
+    ...overrides,
+  });
+  const rows = [
+    "PALOMAR-2026-07-29-000001-v1",
+    "PALOMAR-2026-07-29-000002-v1",
+  ];
+  assert.equal(validateSearchPage(page(rows), "ring", 1, head).postings.length, 2);
+
+  assert.throws(() => validateSearchPage(page(rows), "field", 1, head), /different word/);
+  assert.throws(() => validateSearchPage(page(rows), "ring", 0, head), /not the page/);
+  assert.throws(() => validateSearchPage(page(rows, { page: 2 }), "ring", 2, head), /past the end/);
+  // A page that repeated a posting, or padded itself with the same result over
+  // and over, would be a well-formed page that showed one reader the same work
+  // several times under a search it may not match at all.
+  assert.throws(
+    () => validateSearchPage(page([rows[1], rows[0]]), "ring", 1, head),
+    /increasing order/,
+  );
+  assert.throws(() => validateSearchPage(page([rows[0], rows[0]]), "ring", 1, head), /increasing order/);
+  assert.throws(
+    () => validateSearchPage(page([...rows, ...rows.map((row) => row.replace("-v1", "-v2"))
+      .concat("PALOMAR-2026-07-29-000003-v1")]), "ring", 1, head),
+    /longer than the head allows/,
+  );
+  assert.throws(() => validateSearchPage(page(["PALOMAR-2026-07-29-000001"]), "ring", 1, head),
+    /malformed/);
+  assert.throws(() => validateSearchPage(page(rows, { schema_version: 2 }), "ring", 1, head),
+    /schema_version/);
+});
+
+test("a posting resolves straight to the record it names", () => {
+  // The whole reason postings carry the identifier rather than a position:
+  // there is no second surface between a hit and the record.
+  assert.equal(
+    postingRecordUrl("PALOMAR-2026-07-29-000123-v2", SEARCH_BASE).href,
+    "https://data.example.test/entries/PALOMAR-2026-07-29-000123-v2.json",
+  );
+  for (const hostile of ["PALOMAR-2026-07-29-000123", "../index", "PALOMAR-2026-07-29-000123-v0", 1]) {
+    assert.throws(() => postingRecordUrl(hostile, SEARCH_BASE), /posting is malformed/);
+  }
+});
+
+test("the published stopword list is read, and refused if it becomes a dictionary", () => {
+  // The one document in this surface that names words. It is not the term
+  // dictionary the index exists without: a fixed editorial choice of function
+  // words is the same size at a hundred thousand results, where a document
+  // naming every known word grows with the vocabulary and is rewritten on
+  // every publication. So the bound is what keeps the two apart, and it is
+  // checked here rather than assumed.
+  assert.equal(
+    stopwordsUrl(SEARCH_BASE).href,
+    "https://data.example.test/search/stopwords.json",
+  );
+  const dropped = validateStopwords({ schema_version: 1, stopwords: ["the", "of"] });
+  assert.ok(dropped.has("the") && !dropped.has("ring"));
+
+  assert.throws(
+    () => validateStopwords({ schema_version: 1, stopwords: ["The"] }),
+    /not a word/,
+  );
+  assert.throws(
+    () => validateStopwords({ schema_version: 1, stopwords: [7] }),
+    /must be a non-empty string/,
+  );
+  assert.throws(
+    () => validateStopwords({
+      schema_version: 1,
+      stopwords: Array.from({ length: 2001 }, (_unused, index) => `w${index}`),
+    }),
+    /term dictionary/,
+  );
+  assert.throws(
+    () => validateStopwords({ schema_version: 2, stopwords: [] }),
+    /schema_version/,
+  );
 });

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -709,3 +709,114 @@ test("what was checked is compressed without losing what it said", async ({ page
   expect(rootOnly).toBe(0);
   expect(project.length).toBeLessThanOrEqual(1);
 });
+
+test("a search reads one postings sequence per word and confirms every hit", async ({ page }) => {
+  const asked = [];
+  page.on("request", (request) => {
+    const path = new URL(request.url()).pathname;
+    if (path.startsWith("/database/")) asked.push(path);
+  });
+  await page.goto(`/?database=${database}`);
+  await expect(page.locator(".entry-card")).toHaveCount(2);
+
+  asked.length = 0;
+  await page.locator("#query").fill("quasicoherent 000124");
+  await page.getByRole("button", { name: "Search" }).click();
+
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
+  await expect(page.locator("#search-results .entry-card")).toContainText("000124");
+  // The listing is a different question, and answering both at once would show
+  // one reader two sets of results with nothing saying which was which.
+  await expect(page.locator("#entry-grid")).toBeHidden();
+  // Two words, two heads, and the pages of each; the rarer word drives, and
+  // the pages are walked newest first.
+  expect(asked).toContain("/database/search/t/quasicoherent/head.json");
+  expect(asked.filter((path) => path.startsWith("/database/search/t/000124/")))
+    .toEqual(["/database/search/t/000124/head.json", "/database/search/t/000124/0.json"]);
+  expect(asked.filter((path) => /quasicoherent\/[0-9]/.test(path)))
+    .toEqual([
+      "/database/search/t/quasicoherent/1.json",
+      "/database/search/t/quasicoherent/0.json",
+    ]);
+  // One record, because the intersection settled the rest. The record is
+  // fetched to be shown, and checking that it really carries every word costs
+  // nothing on top of that.
+  expect(asked.filter((path) => path.startsWith("/database/entries/")))
+    .toEqual(["/database/entries/PALOMAR-2026-07-29-000124-v1.json"]);
+});
+
+test("a search runs from a link, and says so when nothing carries the words", async ({ page }) => {
+  await page.goto(`/?database=${database}&q=quasicoherent`);
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(3);
+
+  await page.locator("#query").fill("quasicoherent unobtainium");
+  await page.getByRole("button", { name: "Search" }).click();
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(0);
+  // The words with no postings are named rather than guessed about. They are
+  // words nothing carries and not words the indexer drops, because the dropped
+  // ones left the query before it was asked.
+  await expect(page.locator("#search-status")).toContainText("Nothing is indexed under unobtainium");
+  await expect(page).toHaveURL(/q=quasicoherent\+unobtainium/);
+});
+
+test("a hostile query cannot construct a path outside the postings grammar", async ({ page }) => {
+  const asked = [];
+  page.on("request", (request) => asked.push(new URL(request.url()).pathname));
+  await page.goto(`/?database=${database}`);
+
+  asked.length = 0;
+  await page.locator("#query").fill("../../etc/passwd?x=1 <script>");
+  await page.getByRole("button", { name: "Search" }).click();
+  await expect(page.locator("#search-status")).toContainText("No result carries all of");
+
+  // The stopword list is at a fixed path and is the only request under
+  // `/search/` that the query has no part in building. Every other one is
+  // constructed from what somebody typed, with no dictionary to check it
+  // against first, which is why the grammar is the whole defence.
+  const searched = asked.filter(
+    (path) => path.includes("/search/") && path !== "/database/search/stopwords.json",
+  );
+  expect(searched.length).toBeGreaterThan(0);
+  for (const path of searched) {
+    expect(path).toMatch(/^\/database\/search\/t\/[a-z0-9]{2,32}\/(?:head|[0-9]{1,4})\.json$/);
+  }
+});
+
+test("a query with no word in it leaves the listing alone", async ({ page }) => {
+  await page.goto(`/?database=${database}`);
+  await page.locator("#query").fill("a !");
+  await page.getByRole("button", { name: "Search" }).click();
+  await expect(page.locator("#entry-grid")).toBeVisible();
+  await expect(page.locator("#search-status")).toBeHidden();
+});
+
+test("a word the indexer drops leaves the query instead of failing it", async ({ page }) => {
+  // The hole the published list closes. "the" has no head, which from a
+  // browser is indistinguishable from a word nothing carries, so a query
+  // containing it used to be answered against each record's own text -- and
+  // this record's text does not contain "the". Fetching the list is what turns
+  // that from a wrong answer nobody could diagnose into no question at all.
+  const asked = [];
+  page.on("request", (request) => asked.push(new URL(request.url()).pathname));
+  await page.goto(`/?database=${database}`);
+
+  asked.length = 0;
+  await page.locator("#query").fill("the quasicoherent sheaves");
+  await page.getByRole("button", { name: "Search" }).click();
+
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
+  await expect(page.locator("#search-results .entry-card")).toContainText("000124");
+  expect(asked).toContain("/database/search/stopwords.json");
+  expect(asked.filter((path) => path.startsWith("/database/search/t/the/"))).toEqual([]);
+});
+
+test("a search made only of words the indexer drops says which they were", async ({ page }) => {
+  // Otherwise this is a registry that appears to hold nothing.
+  await page.goto(`/?database=${database}`);
+  await page.locator("#query").fill("the of and");
+  await page.getByRole("button", { name: "Search" }).click();
+
+  await expect(page.locator("#search-status")).toContainText("too common to be indexed");
+  await expect(page.locator("#search-status")).toContainText("the");
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(0);
+});


### PR DESCRIPTION
This PR puts a search box on the landing page and answers it from the published postings sequences, one word at a time, with no document in between that knows what the words are. `searchTerms` folds a query by exactly the three steps the indexer uses, in the same order: decompose, drop the combining marks, lowercase. A query folded any other way asks for a word that was never written, which from a browser is indistinguishable from no results, so the two sides have to agree exactly and the reason they do is written down where each of them does it.

`searchHeadUrl` and `searchPageUrl` are the whole defence between a hostile query and a key in the bucket, because there is nothing to check a word against before asking for it: a document naming every known word would grow with the registry and be rewritten on every publication. So they refuse everything a word cannot be, and a word that is not `[a-z0-9]{2,32}` never becomes a path at all. `validateSearchHead` and `validateSearchPage` follow `validateVersions`, which exists because the interesting claim is not about the rows but about what the document asserts it covers. A head is an instruction rather than data, since its numbers become the reader's next requests: one claiming more pages than its sequence has sends a reader after pages that are not there, and one claiming fewer hides results while staying a perfectly well-formed document, so the arithmetic between `pages`, `page_size` and `results` is checked and both are bounded. The head carries one count rather than two: there were two while a withdrawal in PalomarDatabase emptied its slot instead of closing the sequence up, and the difference between them said how many withdrawn results carried the word, which is what a takedown is meant to take away. A page has to be the page that was asked for, of the word that was asked for, no longer than the head's own page size, and in strictly increasing order. That last one is the one worth having: an identifier begins with its registration date, so increasing order is date order, and a page that repeated a posting or padded itself with the same result over and over would be well formed and would show one reader the same work several times under a search it may not match at all.

The words the indexer drops are fetched from `search/stopwords.json` and dropped from the query, which is the change since the last review. There is exactly one list and it is published, so nothing here keeps a copy that could drift from the indexer's across two independently deployed repositories. Inferring the list instead, from the fact that a dropped word has no head, was wrong in a way a reader could not diagnose: a missing head is also what a word nothing carries looks like, so "the ring" was answered against each candidate's own text, and a record whose text happens not to contain "the" was rejected with nothing saying why. `validateStopwords` bounds the list, because a list an order of magnitude longer is not a stopword list any more and reading one would let the served data decide which queries this page is willing to run. A list that cannot be fetched leaves every word in the query, which is the behaviour this replaces: it narrows a search that should have been wider and never shows a result that does not match. A query made only of dropped words says which they were, rather than reporting a registry that appears to hold nothing.

The rarest word drives the query, because its sequence is the shortest and every match is somewhere in it, and its pages are walked newest first. Another word joins the intersection only if the whole of it fits in what is left of a page budget, since intersecting against half a word's postings would drop genuine matches while looking like a narrower search. Everything else is settled per record by `carriesEveryTerm`, which re-derives the record's own words and checks the query against them. That is exact, it is the check the postings are an index of, and it costs nothing, because the record has to be fetched to be shown anyway. It is also what makes stopping early safe rather than merely cheap. A word with no head is now a word nothing carries rather than either that or a word the indexer drops, because the dropped ones have left the query before it is asked, so when nothing matches those words are named rather than guessed about.

A posting resolves straight to `entries/<id>-vN.json` with no second lookup. `validateEntry` normally compares a record against `index.json`, which is an independent claim about its title; a posting claims something else, that this record carries these words, so `postingSummary` checks the identity and `carriesEveryTerm` checks the claim itself against the record's text, which is the stronger of the two.

The toolbar's existing box is relabelled from "Search" to "Filter", because that is what it does: it hides cards that are already on the page, and two controls that both take words need to be told apart by where they are and what they say. A search hides the listing while it is showing results, since answering both questions at once would show one reader two sets with nothing saying which was which. A query is a link, so `?q=` runs on load and the form updates the URL rather than submitting, which the page's own content security policy forbids anyway.

`tests/fixture_server.py` builds a small postings index from the fixture records by the same three steps, with pages of two so that the browser suite exercises walking a sequence rather than reading a single page, and serves the stopword list beside it. One fixture record's abstract carries no function word at all, which is the case the published list exists for: a query containing "the" has to find it anyway, and inferring stopwords from a missing head could not. The browser tests check that a two-word query fetches two heads and the pages of each, walks them newest first, fetches exactly one record because the intersection settled the rest, that a query runs from a link, that a query nothing carries names the word it could not find, that a query containing a dropped word finds the record whose text lacks it and never asks for that word's head, that a query made only of dropped words says so, and that a query made of path fragments and angle brackets produces only requests matching the postings grammar, the fixed stopword path apart.

Each behaviour was checked by reverting the source and watching the test go red: dropping the increasing-order and length checks on a page, dropping the head's page-count arithmetic, letting any string be a term, showing every candidate without checking it against its record, keeping the dropped words in the query, saying nothing when every word of a query is dropped, and both bounds on the published list.

The head's `appended` field is gone, which is the second change since the last review and follows the one in https://github.com/PalomarRegistry/PalomarDatabase/pull/80 (feat: search the registry a word at a time).

The Playwright suite does run here, through the Nixpkgs Chromium that `AGENTS.md` documents: thirty-two pass and two are skipped, both of them the pre-existing checks that need `PALOMAR_PREVIOUS_REF`, which only deployment and pull-request CI set.

This needs https://github.com/PalomarRegistry/PalomarDatabase/pull/80 (feat: search the registry a word at a time) merged and deployed first; until then every head is a 404 and a search reports that nothing is indexed. It sits on current `main` and needed no rebase.

🤖 Prepared with Claude Code
