### PR TITLE
doc: describe the documents the site reads, not the index it no longer has

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,15 @@
   nix shell nixpkgs#chromium -c bash -lc \
     'export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=$(command -v chromium); npm run test:browser'
   ```
+
+- `npm test` reads `schema-v2.json` out of a PalomarDatabase checkout, from
+  `PALOMAR_DATABASE_CHECKOUT` or a sibling `../PalomarDatabase/`. An
+  unavailable schema is a failure rather than a skip, deliberately: the point of
+  the test is that this repository's validators agree with the schema the
+  records are written against, and a version of that test which quietly does
+  nothing agrees with everything. Without a checkout you get two hard failures
+  and no hint why, so this is the first thing to check.
+
+- The browser suite needs `python3` on `PATH`, for the fixture server. Two of
+  its tests want `PALOMAR_PREVIOUS_REF` and skip silently without it, which only
+  CI sets.

--- a/README.md
+++ b/README.md
@@ -2,21 +2,30 @@
 
 The read-only human view of Palomar's machine-readable public registry.
 
-The site is static and deployed with GitHub Pages. It fetches the filtered
-`index.json` and entry records from <https://data.palomar-registry.org/> at
-runtime, so publishing a database change does not require a coordinated website
-deployment.
-Each render also loads the current source-availability manifest. When an
-original pinned commit has been confirmed missing and the recorded archive is
-available, source links automatically switch to the `PalomarArchive` copy while
-still displaying the original location. Missing archives are shown as degraded,
-and a stale or unavailable manifest never makes an unverified claim that a
-source is missing.
+The site is static and deployed with GitHub Pages. It reads
+<https://data.palomar-registry.org/> at runtime, so publishing a database change
+does not require a coordinated website deployment. There is no whole-registry
+document there any more, and the pages are shaped by that: the landing page
+reads `recent.json`, an entry page reads `versions/<id>.json` and then the one
+record it wants, a search reads `search/stopwords.json` and a word's postings,
+and a withdrawn version reads its tombstone. Fetching the index and filtering it
+in a browser meant every visitor paid for the whole registry to see a couple of
+hundred rows, and paid more every time somebody else published anything.
+
+The landing page and entry pages also load the current source-availability
+manifest. When an original pinned commit has been confirmed missing and the
+recorded archive is not itself known to be missing, source links automatically
+switch to the `PalomarArchive` copy while still displaying the original
+location. Missing archives are shown as degraded, and a stale or unavailable
+manifest is discarded rather than believed.
 Registry cards display arXiv and MSC2020 classifications, and the toolbar can
-filter the current records by either taxonomy. The classification fields suggest
-codes represented by current entries but also accept any exact code, so a deep
-link such as `?arxiv=math.AG` produces a useful empty result even before that
-classification has an entry.
+filter the rows the landing page holds by either taxonomy. The classification
+fields suggest codes represented by those rows but also accept any exact code,
+so a deep link such as `?arxiv=math.AG` produces a useful empty result even
+before that classification has an entry. The filter is over `recent.json`, which
+is the newest 200 current versions and not the registry, so it narrows what is
+on the page rather than searching everything; the search box does the latter,
+a word at a time, over titles, abstracts and author names.
 
 Local preview:
 
@@ -24,9 +33,14 @@ Local preview:
 python -m http.server 8000
 ```
 
-Then open <http://localhost:8000>. Override the database endpoint for a fixture
-served from that development origin with `?database=/fixtures/index.json`. The
-matching render tree is resolved beside the fixture by default; use
+Then open <http://localhost:8000>. Note that a bare static server reads live
+production data: the overrides below are what point it somewhere else. The
+browser suite needs a different server, `python3 tests/fixture_server.py` on
+port 4173, which `playwright.config.js` starts for it.
+
+`?database=` overrides the endpoint, and it is an endpoint rather than a
+document: `?database=/fixtures/` names the directory every read surface is
+resolved against. The matching render tree is resolved beside it by default; use
 `&render-base=/fixtures/render-root/` to override it. These overrides are
 honored only when the site itself runs on localhost or another loopback address.
 Use `&availability=/fixtures/source-availability.json` to supply a local health
@@ -37,9 +51,16 @@ it never reads the private canonical database repository directly.
 Entry pages embed a rendered Challenge when the comparator names exactly one
 declaration and the recorded Challenge source is at most 100 lines and 32 KiB. Larger
 Challenges link to a dedicated rendered view. The pinned GitHub source link is
-always present. Rendered HTML is loaded in a fixed-height iframe with
+always present. Rendered HTML is loaded in an iframe with
 `sandbox="allow-scripts"` (deliberately without `allow-same-origin`) and no
-referrer.
+referrer. The frame sizes itself from a height the document posts back, clamped
+between 10rem and 42rem, so an untrusted render can ask for a sensible height
+without being able to take the page over.
+
+A record that arrives carrying review scores is refused rather than rendered.
+The scores are not published and are not in the record; a served record that had
+them would mean something upstream had gone wrong, and displaying it would be
+the worst moment to find out.
 
 The website is a presentation layer only. Public data and schemas live at the
 machine-readable data origin. A versioned ID
@@ -49,11 +70,13 @@ source, authors, or subject, so stable citations must include the version.
 
 ## RSS
 
-The filtered public-data deployment generates a main RSS feed and separate feeds for
-every arXiv and MSC2020 classification represented by a current entry. The web
-site advertises the main feed with RSS autodiscovery and links the relevant
-category feeds from each entry page. Static hosting is sufficient because feed
-XML is regenerated whenever the append-only database changes.
+The filtered public-data deployment generates a main RSS feed and separate feeds
+for every arXiv and MSC2020 classification represented by a current entry. The
+landing page and entry pages advertise the main feed with RSS autodiscovery. An
+entry page links its classifications to the filtered listing rather than to the
+category feed; the feed links were removed when they were all 404, and they have
+not been put back. Static hosting is sufficient because feed XML is regenerated
+whenever the append-only database changes.
 
 ## Version presentation
 
@@ -83,5 +106,8 @@ scheme is adopted later, it will require a new URL contract; existing integer
 snapshot URLs remain permanent.
 
 This remains a runtime-JSON site: JavaScript is required for registry and entry
-content. The static entry shell explains this and links to the immutable JSON
-records for no-JavaScript readers.
+content. The static shells explain this and point a no-JavaScript reader at the
+machine-readable data. Those links, and the footer's, still name the
+whole-registry `index.json` that the data service no longer serves, so they
+currently answer 404; they want to be `recent.json` on the landing page and
+`entries/<id>-v<n>.json` on an entry page.


### PR DESCRIPTION
This PR brings `README.md` and `AGENTS.md` back in line with the code. The README still said the site fetches a filtered `index.json`, which the data service stopped serving; it now names what each page actually reads and why one document per question replaced one document for everything. It corrects the archive-switch condition, which fires whenever the archive is not itself known to be missing rather than only when it is known to be available; drops the promise that a stale manifest never claims a source is missing, which `entryCard` does not currently keep; calls the render frame self-resizing rather than fixed-height; says the classification filter narrows the newest two hundred rows rather than the registry, and points at the search box for the rest; and stops describing per-classification feed links that were removed when every one of them was a 404. The `?database=` example is now an endpoint rather than a document that no longer exists. `AGENTS.md` gains the two prerequisites that make `npm test` and the browser suite fail confusingly without them.

The no-JavaScript and footer links to `index.json` are still in the HTML and still 404; the README says so rather than continuing to promise they work, since fixing them is a code change.

🤖 Prepared with Claude Code