### PR TITLE
fix: link the documents the data service serves

### DIFF
--- a/.github/workflows/publish-health.yml
+++ b/.github/workflows/publish-health.yml
@@ -50,6 +50,13 @@ jobs:
         env:
           DATA: https://data.palomar-registry.org
 
+      # The other direction: not whether the records the site reads are
+      # readable, but whether the documents it sends readers to are there at
+      # all. Seven links to `index.json` outlived its removal from the service
+      # because nothing ever asked.
+      - name: Does the registry still serve every document the site links to
+        run: node scripts/check-published.mjs --links
+
       # One attempt, with the traps that cost a day written into the guards.
       # A deployment is identified by its commit, so a second one for a commit
       # already deploying is cancelled rather than queued; and re-running a

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,12 @@ jobs:
       - run: npm test
         env:
           PALOMAR_DATABASE_CHECKOUT: ${{ github.workspace }}/palomar-database
+      # Against the live service, because the grammar of what it serves lives
+      # in the canonical database and this repository cannot see it. A link to
+      # a document the service has removed answers 404 to a reader, which is
+      # how seven links to `index.json` survived its removal.
+      - name: Does the registry still serve every document the site links to
+        run: node scripts/check-published.mjs --links
       - run: npx playwright install --with-deps chromium
       - run: npm run test:browser
         env:

--- a/about.html
+++ b/about.html
@@ -570,7 +570,7 @@
 
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="https://data.palomar-registry.org/index.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="https://data.palomar-registry.org/browse/index.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/about.js"></script>
   </body>

--- a/entry.html
+++ b/entry.html
@@ -23,14 +23,14 @@
           <br>
           Entry pages require JavaScript because they read immutable records from
           the machine-readable registry at runtime. You can instead
-          <a href="https://data.palomar-registry.org/index.json">open the JSON index</a>.
+          <a href="https://data.palomar-registry.org/browse/index.json">browse the registry as JSON</a>.
         </noscript>
       </div>
       <article id="entry-content" hidden></article>
     </main>
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="https://data.palomar-registry.org/index.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="https://data.palomar-registry.org/browse/index.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/app.js"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
       <section class="registry-section" id="registry" aria-labelledby="registry-heading">
         <div class="section-heading">
           <h2 id="registry-heading">Accepted results</h2>
-          <a class="data-link" href="https://data.palomar-registry.org/index.json">
+          <a class="data-link" href="https://data.palomar-registry.org/browse/index.json">
             Machine-readable index
           </a>
         </div>
@@ -82,7 +82,7 @@
             <br>
             The registry requires JavaScript because it reads the machine-readable
             registry at runtime. You can instead
-            <a href="https://data.palomar-registry.org/index.json">open the JSON index</a>.
+            <a href="https://data.palomar-registry.org/recent.json">open the newest results as JSON</a>.
           </noscript>
         </div>
         <div id="entry-grid" class="entry-grid" aria-live="polite"></div>
@@ -97,7 +97,7 @@
       <div class="footer-links">
         <a href="https://data.palomar-registry.org/feed.xml">RSS</a>
         <a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a>
-        <a href="https://data.palomar-registry.org/index.json">Data</a>
+        <a href="https://data.palomar-registry.org/browse/index.json">Data</a>
         <a href="https://github.com/leanprover/comparator">Comparator</a>
         <a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a>
       </div>

--- a/render.html
+++ b/render.html
@@ -21,7 +21,7 @@
     </main>
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="https://data.palomar-registry.org/index.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="https://data.palomar-registry.org/browse/index.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/app.js"></script>
   </body>

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -9,6 +9,19 @@ const assetFiles = ["about.js", "app.js", "rendering.js", "security.mjs", "style
 // Copied verbatim into assets/, keeping their subdirectory. Listed separately
 // because they are data rather than code: no version query, no rewriting.
 const assetDataFiles = ["data/msc2020-codes.json"];
+/**
+ * Every file the deployment carries, as paths from the repository root.
+ *
+ * Exported because "what is shipped" is a question something other than the
+ * build asks: `check-published.mjs` reads these to find the registry documents
+ * the site sends readers to, and a file absent from this list is absent from
+ * the deployment however correct its markup is.
+ */
+export const shippedFiles = [
+  ...publicFiles,
+  ...assetFiles.map((name) => `assets/${name}`),
+  ...assetDataFiles.map((name) => `assets/${name}`),
+];
 
 function options(args) {
   const result = {

--- a/scripts/check-published.mjs
+++ b/scripts/check-published.mjs
@@ -11,6 +11,9 @@
  * the check is a comparison rather than new machinery.
  */
 
+import { readFile } from "node:fs/promises";
+
+import { shippedFiles } from "./build-site.mjs";
 import { validateEntry, validateRecent } from "../assets/security.mjs";
 
 const STAMP = /assets\/app\.js\?v=([A-Za-z0-9._-]+)/;
@@ -78,6 +81,64 @@ export async function publicDataState(
   }
 }
 
+// Stops at the delimiters a URL is written between: quotes and angle brackets
+// in markup, a semicolon in the CSP's source list, a bracket in CSS.
+const DATA_URL = /https:\/\/data\.palomar-registry\.org[^\s"'`<>();,]*/g;
+
+/**
+ * Every registry document the shipped site sends a reader to.
+ *
+ * A URL ending in `/` names a prefix the code builds a document out of rather
+ * than a document, and the bare origin appears in each page's content policy;
+ * neither is something to request.
+ */
+export function linkedDataDocuments(sources) {
+  const found = new Map();
+  for (const [name, text] of sources) {
+    for (const [href] of String(text).matchAll(DATA_URL)) {
+      const { pathname } = new URL(href);
+      if (pathname === "/" || pathname.endsWith("/")) continue;
+      if (!found.has(href)) found.set(href, name);
+    }
+  }
+  return found;
+}
+
+/** The shipped files, as `check-published.mjs` and the build both see them. */
+export async function shippedSources(root = new URL("..", import.meta.url)) {
+  return Promise.all(
+    shippedFiles.map(async (name) => [name, await readFile(new URL(name, root), "utf8")]),
+  );
+}
+
+/**
+ * Does the registry still serve every document the site links to?
+ *
+ * `index.json` was removed from the public data service, and seven links to it
+ * survived the removal: the landing page's machine-readable index, both
+ * noscript fallbacks and four footers, each answering 404 to whoever followed
+ * it. Nothing noticed, because nothing had ever asked the service whether the
+ * documents this site names are documents it will answer for. Asking it is the
+ * only check that cannot drift from it.
+ */
+export async function linkedDataState(sources, fetcher = fetch) {
+  const documents = linkedDataDocuments(sources);
+  const dead = [];
+  await Promise.all([...documents].map(async ([href, name]) => {
+    try {
+      const response = await fetcher(href, { method: "HEAD", cache: "no-store" });
+      if (!response.ok) dead.push(`${name} links ${href}, which responded ${response.status}`);
+    } catch (error) {
+      dead.push(`${name} links ${href}, which could not be fetched: ${error.message}`);
+    }
+  }));
+  if (dead.length) return { healthy: false, reason: dead.sort().join("; ") };
+  return {
+    healthy: true,
+    reason: `the registry serves all ${documents.size} documents the site links to`,
+  };
+}
+
 async function main(argv) {
   const options = new Map();
   for (let index = 0; index < argv.length; index += 2) {
@@ -91,9 +152,15 @@ async function main(argv) {
     console.log(`${data}: ${state.reason}`);
     return state.healthy ? 0 : 1;
   }
+  if (options.has("links") && !url && !expected) {
+    const state = await linkedDataState(await shippedSources());
+    console.log(state.reason);
+    return state.healthy ? 0 : 1;
+  }
   if (!url || !expected) {
     console.error(
-      "usage: check-published.mjs --url <site> --expect <commit> | --data <registry-data>",
+      "usage: check-published.mjs --url <site> --expect <commit> | --data <registry-data>"
+        + " | --links",
     );
     return 2;
   }

--- a/tests/check-published.test.js
+++ b/tests/check-published.test.js
@@ -89,3 +89,49 @@ test("live-data health fails on the same contract error a visitor would see", as
   assert.equal(state.healthy, false);
   assert.match(state.reason, /entry\.review\.scores must be an object/);
 });
+
+test("every registry document the site links to is one the registry still serves", async () => {
+  // Seven links pointed at `index.json` for weeks after it stopped being
+  // served: the landing page's machine-readable index, both noscript
+  // fallbacks, and four footers. Each answered 404 to whoever followed it, and
+  // nothing noticed, because nothing had ever asked the registry whether the
+  // documents this site names are ones it will answer for.
+  //
+  // Offline, that question is answered by the one document whose removal is
+  // already history. Against the live registry it is answered in full, by
+  // `check-published.mjs --links` in the published-site health workflow.
+  const { shippedSources, linkedDataState } = await import("../scripts/check-published.mjs");
+  const asked = [];
+  const registry = async (url, options) => {
+    asked.push([String(url), options.method]);
+    return { ok: new URL(url).pathname !== "/index.json", status: 404 };
+  };
+
+  const state = await linkedDataState(await shippedSources(), registry);
+  assert.equal(state.healthy, true, state.reason);
+  assert.ok(asked.length, "the shipped site names no registry documents at all");
+  assert.deepEqual([...new Set(asked.map(([, method]) => method))], ["HEAD"]);
+});
+
+test("a link to a document the registry has removed is reported with the file that carries it", async () => {
+  const { linkedDataState } = await import("../scripts/check-published.mjs");
+  const state = await linkedDataState(
+    [["index.html", '<a href="https://data.palomar-registry.org/index.json">Data</a>']],
+    async () => ({ ok: false, status: 404 }),
+  );
+  assert.equal(state.healthy, false);
+  assert.match(state.reason, /index\.html links .*\/index\.json, which responded 404/);
+});
+
+test("a prefix the site builds documents out of is not itself requested", async () => {
+  const { linkedDataDocuments } = await import("../scripts/check-published.mjs");
+  // `connect-src https://data.palomar-registry.org` in every page's content
+  // policy, and the render base the entry page resolves an artifact against.
+  // Neither names a document, and requesting either would report a 404 that
+  // means nothing.
+  const documents = linkedDataDocuments([
+    ["index.html", "connect-src 'self' https://data.palomar-registry.org; frame-src 'self'"],
+    ["assets/security.mjs", 'const base = "https://data.palomar-registry.org/";'],
+  ]);
+  assert.deepEqual([...documents], []);
+});


### PR DESCRIPTION
This PR points every live link to the removed `index.json` at a document the public data service actually answers for, and adds the check whose absence let seven of them rot. The landing page's machine-readable index and the four footers now name `browse/index.json`, the entry point for everything, and the landing page's `noscript` fallback names `recent.json`, which is what that page itself reads. `index.json` stopped being served when the landing page moved off it, so each of those links had been answering 404 to whoever followed it.

`check-published.mjs --links` collects every registry document the shipped files name and asks the registry for each one. It asks the service rather than a copy of its rules: the grammar of what is served lives in the canonical database, which is private and which this repository cannot see, and a copy of that grammar here would drift from it in exactly the way that let these links rot. It runs on every pull request and hourly beside the other published-site health checks, which is the same reasoning `check-published.mjs` already exists for.

Offline, `npm test` puts the shipped files in front of a registry that answers 404 for `index.json` and nothing else, which is a fact about history rather than a restatement of the grammar; that test is red without the four HTML changes here.

🤖 Prepared with Claude Code