### PR TITLE
refactor: remove the category feed base nothing reads

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -39,7 +39,6 @@ import {
 } from "./security.mjs";
 
 const CANONICAL_WEB_BASE = "https://palomar-registry.org/";
-const FEED_BASE = "https://data.palomar-registry.org/feeds/";
 
 const params = new URLSearchParams(window.location.search);
 const PALOMAR_ID = /^PALOMAR-\d{4}-\d{2}-\d{2}-\d{6}$/;
@@ -59,11 +58,6 @@ function dataSource() {
     databaseBase,
   );
   return { databaseBase, renderBase, availabilityUrl };
-}
-
-function categoryFeedBase() {
-  if (!params.has("database")) return FEED_BASE;
-  return new URL("feeds/", dataSource().databaseBase);
 }
 
 function el(tag, className, text) {

--- a/assets/style.css
+++ b/assets/style.css
@@ -273,18 +273,13 @@ button:focus-visible {
   font: .9rem var(--sans);
 }
 
-.category-tokens,
-.category-feed-list {
+.category-tokens {
   display: flex;
   flex-wrap: wrap;
   gap: .3rem .5rem;
 }
 
 .category-tokens code {
-  white-space: nowrap;
-}
-
-.category-feed-item {
   white-space: nowrap;
 }
 

--- a/tests/build-site.test.js
+++ b/tests/build-site.test.js
@@ -53,6 +53,25 @@ test("the MSC descriptions shown to readers are readable", async () => {
   assert.equal(codes["52C10"], "Erdős problems and related topics of discrete geometry");
 });
 
+test("app.js writes down no data origin the database override cannot redirect", async () => {
+  // `?database=` names the endpoint every read surface is resolved against, so
+  // a fixture directory can stand in for the live service. A data URL spelled
+  // out as a literal in app.js is outside that arrangement by construction.
+  // `FEED_BASE` and the `categoryFeedBase()` that read it were the last of
+  // those: they outlived the category feed links, which were removed when
+  // every one of them answered 404, and went on naming a `feeds/` directory
+  // that nothing fetched and no reader could reach. The canonical web origin
+  // is a different thing and stays, because an entry's canonical link has to
+  // point at the official URL even when the page is being read from a fixture.
+  const app = await readFile(new URL("../assets/app.js", import.meta.url), "utf8");
+  assert.equal(
+    app.includes("data.palomar-registry.org"),
+    false,
+    "app.js names the data origin directly instead of resolving against the chosen endpoint",
+  );
+  assert.match(app, /const CANONICAL_WEB_BASE = "https:\/\/palomar-registry\.org\/";/);
+});
+
 test("everything the pages fetch at runtime is actually shipped", async () => {
   // The MSC table was added under assets/data/ and never added to the build's
   // copy list, so it was absent from the deployed site while the hover that


### PR DESCRIPTION
This PR removes `FEED_BASE` and `categoryFeedBase()` from `assets/app.js`, along with the `.category-feed-list` and `.category-feed-item` rules that styled the list they used to build. Nothing in the repository referenced any of them. They are the remainder of the category feed links, which were removed when every one of them answered 404, and the README already records that those links have not been put back.

Removing rather than wiring up, for two reasons. The feeds the entry page would link to are the per-classification ones, and an entry page already links each classification to the filtered listing on the landing page, which is a page that exists and holds the neighbouring entries; `tests/site.spec.js` asserts there is no RSS link there. And the only feed the site does advertise, `feed.xml`, is named statically in `index.html` and `entry.html`, in the autodiscovery link and the footer. No JavaScript touches it.

That last point answers the question about the `database` override. `categoryFeedBase()` read `params.has("database")` so that a local fixture run would get `feeds/` under the fixture endpoint instead of the live origin, which is what `selectDatabaseUrl`, `selectRenderBase` and `selectAvailabilityUrl` do for every read surface the site actually has. But it was overriding the location of a feed the site never linked to, while `feed.xml`, the one it does link to, was and remains a hard-coded absolute URL in static HTML that the override has never reached. So removing this leaves the override no less complete for feeds than it already was: it was never applied to the feed a reader can click. Pointing the autodiscovery link at a fixture would be a separate change, and not obviously a desirable one, since a fixture directory has no feed XML in it.

The test states the property the removal establishes rather than restating the deletion. `app.js` resolves every data URL against the endpoint `?database=` chooses, so it should name no data origin of its own, and `FEED_BASE` was the only literal left. `CANONICAL_WEB_BASE` is the web origin and stays, because an entry's canonical link has to point at the official URL even when the page is read from a fixture. Reverting `assets/app.js` alone turns the new test red.

This PR depends on nothing else.

🤖 Prepared with Claude Code