### PR TITLE
chore: pin setup-node once across the workflows

### DIFF
--- a/.github/workflows/publish-health.yml
+++ b/.github/workflows/publish-health.yml
@@ -29,9 +29,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22"
+          node-version: "24.4.1"
 
       - name: Is the served site the site this repository describes
         id: check


### PR DESCRIPTION
This PR moves `publish-health.yml` onto the same `actions/setup-node` pin the other two workflows already use, so all three name `820762786026740c76f36085b0efc47a31fe5020 # v7.0.0`. Both SHAs check out against the upstream tags: `repos/actions/setup-node/git/ref/tags/v6.0.0` is the lightweight tag at `2028fbc5c25fe9cf00d9f06a71cc4710d4507903` and `v7.0.0` is the lightweight tag at `820762786026740c76f36085b0efc47a31fe5020`, each pointing straight at the commit, with no annotated tag object in between.

It also moves that job from node 22 to 24.4.1, which is the version `pages.yml` and `test.yml` use. This is safe and worth doing rather than an incidental tidy-up. The job runs `scripts/check-published.mjs`, which imports `scripts/build-site.mjs` and `assets/security.mjs`; those are the same modules `npm test` loads under 24.4.1 in both other workflows, so they are already known to run there. The script has no dependencies of its own, using only `node:fs/promises` and global `fetch`, and 24 is the later runtime, so nothing it relies on has been withdrawn. The reason to change it rather than leave it is that the hourly health check was the only place those modules ran on a runtime nothing tests them against, which is the wrong property for the check whose job is to notice when the published site and this repository have drifted apart.

No `cache: npm` here, deliberately, unlike the other two. This job never runs `npm ci` or installs anything, so there is no install for a restored cache to make faster; it would save and restore an `~/.npm` that nothing reads.

This PR depends on nothing else.

🤖 Prepared with Claude Code