### PR TITLE
feat: date a card by the version's own registration

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -189,12 +189,24 @@ function categoryTokens(entry) {
   return tokens;
 }
 
-function acceptanceDate(entry) {
-  const value = entry.accepted_at || entry.review?.reviewed_at?.slice(0, 10);
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value || "")) {
-    throw new Error("entry is missing a valid acceptance date");
+/**
+ * The day this version was registered.
+ *
+ * Not `accepted_at`, which is the *result's* date: the identifier carries it,
+ * every later version inherits it, and it is already on the card beside this.
+ * So a v2 labelled by it named a day years before that version existed, and on
+ * a page ordered by registration the visible dates ran out of order.
+ *
+ * There is no fallback to the review's date any more. A review's verdict and
+ * the registration it leads to are different moments, and the record carries
+ * `registered_at` for exactly this.
+ */
+function registrationDate(entry) {
+  const value = entry.registered_at;
+  if (!/^\d{4}-\d{2}-\d{2}T/.test(value || "")) {
+    throw new Error("entry is missing a valid registration date");
   }
-  return value;
+  return value.slice(0, 10);
 }
 
 function displayDate(value) {
@@ -258,7 +270,7 @@ function entryCard(entry, versionCount, availability) {
   const identity = el("div", "card-identity");
   identity.append(
     el("span", "entry-id", `${entry.id} v${entry.version} · current`),
-    el("span", "entry-date", `Accepted ${displayDate(acceptanceDate(entry))}`),
+    el("span", "entry-date", `Registered ${displayDate(registrationDate(entry))}`),
   );
   top.append(identity, trustBadge(entry));
   const title = el("h3");
@@ -1106,7 +1118,7 @@ function acceptanceCallout(entry, databaseBase) {
     );
   }
   copy.append(
-    el("strong", "", `Accepted on ${displayDate(acceptanceDate(entry))}`),
+    el("strong", "", `Registered on ${displayDate(registrationDate(entry))}`),
     assurance(
       "Mechanical assurance",
       "Comparator checked that the recorded Solution proves the recorded formal Challenge under the listed axiom and dependency rules, and both Lean's kernel and NanoDa accepted the exported proof.",

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -214,9 +214,12 @@ export function validateRecent(value) {
     }
     integer(summary.versions, `recent.entries[${position}].versions`);
     const publishedAt = string(summary.published_at, `recent.entries[${position}].published_at`);
-    // Date-only or a full timestamp: a record with no review date falls back to
-    // `accepted_at`, which is a date, and both are what the publisher writes.
-    if (!TIMESTAMP_RE.test(publishedAt) && !DATE_RE.test(publishedAt)) {
+    // An instant, and only an instant. This is the record's `registered_at`,
+    // which the schema requires of every version. A date was tolerated while a
+    // row could fall back to `accepted_at`, and a date read as an instant is
+    // midnight, so such a row would sort ahead of everything registered that
+    // day with nothing to say why.
+    if (!TIMESTAMP_RE.test(publishedAt)) {
       fail(`recent.entries[${position}].published_at is malformed`);
     }
     const moment = Date.parse(publishedAt);
@@ -607,6 +610,20 @@ function validateCanonicalRecordLinks(entry) {
   const identifier = ID_RE.exec(entry.id);
   if (identifier[1] !== entry.accepted_at) fail("entry ID date does not match accepted_at");
 
+  // `accepted_at` is the result's date, inherited by every later version, and
+  // `registered_at` is the version's own instant. They meet at version 1, and
+  // there they must: one is in the identifier and decides which browse page
+  // the result is on, the other decides where it appears among what is new. A
+  // record where they have come apart renders perfectly well while being
+  // browsed under one day and ordered under another.
+  const registeredOn = entry.registered_at.slice(0, 10);
+  if (entry.version === 1 && registeredOn !== entry.accepted_at) {
+    fail("entry.accepted_at is not the day version 1 was registered");
+  }
+  if (registeredOn < entry.accepted_at) {
+    fail("entry.registered_at is before the result entered the registry");
+  }
+
   const submission = entry.submission;
   if (!SUBMISSION_ID_RE.test(submission.submission_id)) {
     fail("entry.submission.submission_id is malformed");
@@ -661,6 +678,14 @@ export function validateEntry(entry, summary) {
   string(entry.abstract, "entry.abstract");
   const acceptedAt = string(entry.accepted_at, "entry.accepted_at");
   if (!DATE_RE.test(acceptedAt)) fail("entry.accepted_at is malformed");
+  // The version's own registration instant, which is what every ordering
+  // surface reads and what the card is dated by. How it has to agree with
+  // `accepted_at` is in `validateCanonicalRecordLinks`, beside the rest of what
+  // a record derives from itself.
+  const registeredAt = string(entry.registered_at, "entry.registered_at");
+  if (!TIMESTAMP_RE.test(registeredAt) || Number.isNaN(Date.parse(registeredAt))) {
+    fail("entry.registered_at is malformed");
+  }
 
   for (const [position, value] of array(entry.authors, "entry.authors").entries()) {
     string(object(value, `entry.authors[${position}]`).name, `entry.authors[${position}].name`);

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -37,6 +37,12 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
         "schema_version": 2,
         "id": identifier,
         "accepted_at": "2026-07-29",
+        # The result's date is the day its version 1 was registered, and a
+        # later version brings its own instant: a v2 is a new registration and
+        # is news, where the result's date would file it beside its v1.
+        "registered_at": (
+            "2026-07-29T09:14:07Z" if version == 1 else f"2026-08-{version:02d}T09:14:07Z"
+        ),
         "version": version,
         "status": "accepted",
         "title": f"Fixture {identifier} version {version}",
@@ -308,7 +314,7 @@ class Handler(SimpleHTTPRequestHandler):
                     "title": item["title"],
                     "status": "accepted",
                     "path": f"entries/{item['id']}-v{item['version']}.json",
-                    "published_at": item["review"]["reviewed_at"],
+                    "published_at": item["registered_at"],
                     "versions": versions[item["id"]],
                 }
                 for item in current.values()

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -58,6 +58,17 @@ function summary(overrides = {}) {
   };
 }
 
+/** The same record as a second version, with every path that names the version moved. */
+function secondVersion(overrides = {}) {
+  const value = entry({ version: 2, ...overrides });
+  value.challenge_render.artifact_path = `renders/${value.id}-v2/${DIGEST}/`;
+  value.verification.evidence_path = `evidence/${value.id}-v2/${"c".repeat(64)}/`;
+  for (const repository of value.preservation.repositories) {
+    repository.ref = `refs/tags/palomar/${value.id}-v2/${repository.commit}`;
+  }
+  return value;
+}
+
 function recentRow(overrides = {}) {
   return { ...summary(), published_at: "2026-07-29T08:53:02Z", versions: 1, ...overrides };
 }
@@ -72,6 +83,7 @@ function entry(overrides = {}) {
     schema_version: 2,
     id: "PALOMAR-2026-07-29-000123",
     accepted_at: "2026-07-29",
+    registered_at: "2026-07-29T09:14:07Z",
     version: 1,
     status: "accepted",
     title: "Fixture theorem",
@@ -285,7 +297,56 @@ test("recent validation rejects unsupported, rejected, and malformed rows", () =
     () => validateRecent(recent([recentRow({ published_at: "yesterday" })])),
     /published_at is malformed/,
   );
+  // A date, not an instant. Every row carries the record's `registered_at`,
+  // which the schema requires of every version, and a date read as an instant
+  // is midnight: such a row would sort ahead of everything registered that day
+  // and no reader could tell why.
+  assert.throws(
+    () => validateRecent(recent([recentRow({ published_at: "2026-07-29" })])),
+    /published_at is malformed/,
+  );
   assert.equal(validateRecent(recent()).entries.length, 1);
+});
+
+test("a record must say when the version was registered, and agree with its result date", () => {
+  // The two are one fact written twice, in two repositories. `accepted_at` is
+  // the result's date: the identifier carries it, browsing pages by it, and
+  // every later version inherits it. `registered_at` is the version's own
+  // instant and is what the landing page, the feeds and the subject pages
+  // order by. A record where they have come apart is well formed and renders,
+  // and is browsed under one day while being ordered under another.
+  const missing = entry();
+  delete missing.registered_at;
+  assert.throws(() => validateEntry(missing, summary()), /entry\.registered_at/);
+
+  assert.throws(
+    () => validateEntry(entry({ registered_at: "2026-07-29" }), summary()),
+    /entry\.registered_at is malformed/,
+  );
+  assert.throws(
+    () => validateEntry(entry({ registered_at: "2026-07-30T09:14:07Z" }), summary()),
+    /accepted_at is not the day version 1 was registered/,
+  );
+  assert.throws(
+    () => validateEntry(entry({ registered_at: "2026-07-28T09:14:07Z" }), summary()),
+    /accepted_at is not the day version 1 was registered/,
+  );
+
+  // A later version brings its own instant and inherits its result's date,
+  // which is what keeps it on its v1's browse page while sorting it as news.
+  const secondSummary = summary({
+    version: 2,
+    path: "entries/PALOMAR-2026-07-29-000123-v2.json",
+  });
+  const second = secondVersion({ registered_at: "2027-04-01T09:00:00Z" });
+  assert.equal(validateEntry(second, secondSummary), second);
+
+  // And it cannot be older than the result it supersedes. That row would sort
+  // behind rows for versions it replaced, on every page that carries it.
+  assert.throws(
+    () => validateEntry(secondVersion({ registered_at: "2026-07-28T09:00:00Z" }), secondSummary),
+    /registered_at is before the result entered the registry/,
+  );
 });
 
 test("what recent claims is coverage and ordering, so both are checked", () => {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -91,13 +91,16 @@ test("every formalization.yaml mention on the About page links to its standard",
   expect(result.unlinked).toEqual([]);
 });
 
-test("landing cards show the acceptance date and dated identifier", async ({ page }) => {
+test("landing cards show the registration date and dated identifier", async ({ page }) => {
   await page.route("**/entries/PALOMAR-2026-07-29-000123-v1.json", (route) => route.abort());
   await page.goto(`/?database=${database}`);
   const first = page.locator(".entry-card").first();
   await expect(first.locator(".entry-id")).toContainText("PALOMAR-2026-07-29-");
   await expect(first.locator(".entry-id")).toContainText("v2 · current");
-  await expect(first.locator(".entry-date")).toHaveText("Accepted 29 July 2026");
+  // The card is dated by the version it shows, so the current version of this
+  // result is dated by its own registration and not by its v1's day. The page
+  // is ordered by the same instant, so the visible dates run in page order.
+  await expect(first.locator(".entry-date")).toHaveText("Registered 2 August 2026");
   await expect(first.locator(".trust-badge")).toHaveText("Statement dependencies: Mathlib only");
   await expect(first.getByRole("link", { name: "2 versions" })).toHaveAttribute(
     "href",
@@ -521,7 +524,7 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   await expect(iframe).toHaveAttribute("data-height-adjusted", "true");
   const box = await iframe.boundingBox();
   expect(box.height).toBe(672);
-  await expect(page.locator(".acceptance-callout")).toContainText("Accepted");
+  await expect(page.locator(".acceptance-callout")).toContainText("Registered on");
   await expect(page.locator(".acceptance-callout")).toContainText("29 July 2026");
   await expect(page.locator(".acceptance-callout")).toContainText("Mechanical assurance");
   await expect(page.locator(".acceptance-callout")).toContainText(


### PR DESCRIPTION
This PR labels a record with `registered_at`, the instant the version was registered, and stops labelling it "Accepted on" with `accepted_at`. The label was no longer right: `accepted_at` is the *result's* date, carried by the identifier and inherited by every later version, so on a v2 it named a day years before that version existed, and on a landing page ordered by registration the visible dates ran out of order. The identifier beside it already shows the result's date, so nothing is lost. A card now reads "Registered 2 August 2026" and the entry callout "Registered on ...".

The validator learns the field with it. `entry.registered_at` must be an instant; a version 1's must fall on the day its `accepted_at` names, since one of the two decides which browse page the result is on and the other decides where it appears among what is new; and no version's may precede its result's date. A record where these have come apart renders perfectly well and nothing else on this side would notice. `recent.entries[].published_at` is tightened to an instant for the same reason: it is now always a record's `registered_at`, and a date read as an instant is midnight, so such a row would sort ahead of everything registered that day with nothing to say why.

The review's own timestamp is still validated and still shown where the review is described. Nothing orders by it any more.

Merge https://github.com/PalomarRegistry/PalomarDatabase/pull/86 first: it is where `registered_at` becomes part of the schema this repository's validators are checked against, and until it lands no served record carries the field.

🤖 Prepared with Claude Code