### PR TITLE
doc: say what registration actually publishes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ explicit snapshot URL.
 
 Entry pages list all active versions. Older pages display a prominent link
 to the current version. Each page renders the selected version's own authorship,
-statement, proof, trust information, review, and warnings; information is never
+statement, proof, trust information, and review comments; information is never
 borrowed from a newer record. The site provides links, not computed diffs.
 The registry does not define change summaries or major/minor versions, so the
 website does not infer them. If a richer version

--- a/about.html
+++ b/about.html
@@ -119,9 +119,20 @@
           Palomar asserts nothing beyond these three checks.
         </p>
         <p>
-          For a registered result, the source, warnings, and full review are
-          publicly visible to help readers reach their own judgment on the work
-          and perform independent verification.
+          For a registered result, the source and the review's comments are
+          publicly visible, so that a reader can reach their own judgment on the
+          work and verify it independently. The published review is redacted: it
+          carries the accepted outcome and every comment, but not the scores
+          behind them or how severe the review considered each one.
+          <a href="https://github.com/PalomarRegistry/PalomarPolicy/blob/main/docs/specification.md#editorial-review">The
+          protocol specification</a> defines what is published.
+        </p>
+        <p>
+          The scores behind that outcome are withheld deliberately. The same
+          repository at the same commit has scored 5 and then 4 on one axis
+          across two runs of the same policy, with the same verdict both times,
+          and a number that moves like that reads as a judgement it cannot
+          carry. The verdict is what a reader is shown instead.
         </p>
       </section>
 
@@ -449,9 +460,25 @@
         <ol>
           <li>Push the final snapshot to a public GitHub repository and copy its full 40-character commit SHA.</li>
           <li><a href="https://submit.palomar-registry.org/">Open the submission form</a>. Enter the repository and commit SHA. Leave the optional project, Comparator-config, and metadata paths blank for the normal root layout; fill them only for a nested or non-default layout. Record whether you maintain the substantive formalization or have approval from someone who does, and, for a correction to an existing entry, enter its Palomar ID.</li>
-          <li>Sign in with GitHub so Palomar can confirm you have write access to the repository you are submitting. The sign-in is used once and is not stored.</li>
+          <li>Prove that you can write to the repository you are submitting. In a browser this is a GitHub sign-in: Palomar reads whether that account can push and then discards the token, keeping the account name in its private submission state.</li>
           <li>Keep the status page you are given. Its link is the only way back to your submission: Palomar does not email, and there is no account to sign in to.</li>
         </ol>
+        <p>
+          There are two ways to prove that write access, and they do not
+          establish the same thing. A sign-in answers for one account: GitHub
+          reports that this account can push, and the same account identified
+          itself to Palomar. An agent has no browser, so it instead pushes a tag
+          at the submitted commit and posts a gist carrying the same challenge.
+          That establishes that someone who can write to the repository submitted
+          it, and that an account named itself, which are not provably the same
+          account. It is deliberately the weaker of the two, and Palomar's
+          private submission record says which route a submission used; the
+          public registry entry does not carry it.
+          <a href="https://github.com/PalomarRegistry/PalomarPolicy/blob/main/docs/specification.md#submission-lifecycle-and-privacy">The
+          protocol specification</a> states the difference. Neither is proof of
+          authorship, which is why you are asked about your relationship to the
+          formalization separately.
+        </p>
         <h3 id="what-is-public">What is public, and what is not</h3>
         <p>
           Public from the moment you submit: your repository, commit, declared
@@ -461,11 +488,21 @@
           registry.
         </p>
         <p>
-          Not public unless you register: the editorial review, the decision, and
-          your identity as submitter. If a review goes badly, or you simply
-          change your mind, withdrawing leaves no public trace of the review,
-          decision, or submitter identity. The already-public verification run
+          Not public unless you register: the editorial review and the decision.
+          If a review goes badly, or you simply change your mind, withdrawing
+          leaves no public trace of either. The already-public verification run
           remains.
+        </p>
+        <p>
+          Not published whichever you choose: your identity as submitter.
+          Palomar does not publish the GitHub account that proved push access,
+          and the registry record has no field for the person who sent a
+          submission. What a record carries about you is the authorization
+          relationship you declared and, if you wrote one, the approval evidence
+          you supplied, which is free text and is public. Your repository is
+          public too, so the account that owns it stays as visible as it was
+          before you submitted. What Palomar does not do is put your name in the
+          record.
         </p>
         <p>
           “Private” here means not public, not confidential. Reviews are
@@ -489,7 +526,7 @@
         </p>
         <p>
           The review then appears on your status page, and nowhere else. It
-          gives the reasons, warnings, and any requested changes, not just a
+          gives the reasons, its comments, and any requested changes, not just a
           decision. A request for changes means the work may be reconsidered
           after specific correctable problems are addressed; a rejection means
           the submission failed a fundamental semantic, provenance, or editorial

--- a/assets/app.js
+++ b/assets/app.js
@@ -856,7 +856,7 @@ function versionHistory(entry, versions, currentVersion) {
     el(
       "p",
       "version-history-intro",
-      "Every version is an immutable accepted snapshot. The authorship, statement, proof, review, warnings, and dependency information on this page belong to the selected version only.",
+      "Every version is an immutable accepted snapshot. The authorship, statement, proof, review comments, and dependency information on this page belong to the selected version only.",
     ),
   );
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
         <p class="hero-copy">
           Palomar records mathematical claims from fixed versions of their
           source files, checks their proofs with Lean, and publishes the exact
-          statement, the libraries it uses, and any review warnings.
+          statement, the libraries it uses, and the review's comments.
         </p>
         <div class="metric-row" aria-live="polite">
           <span><strong id="metric-results">—</strong> accepted results</span>

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -679,6 +679,34 @@ test("About describes the current review and version contracts", async () => {
   assert.match(about, /operational fault, not a decision/);
 });
 
+test("About says what registration publishes, and what it does not", async () => {
+  // About said the submitter's identity becomes public on registration. It
+  // does not, the schema has no field for it, and that is the direction of
+  // error nobody reports. It also promised the "full review", which is not
+  // what is published either.
+  const about = await readFile(new URL("../about.html", import.meta.url), "utf8");
+  assert.match(about, /the registry record has no field for the person who sent a\s+submission/);
+  assert.doesNotMatch(about, /full review are\s+publicly visible/);
+  assert.match(about, /The published review is redacted/);
+  assert.match(about, /scored 5 and then 4 on one axis/);
+  for (const anchor of ["#editorial-review", "#submission-lifecycle-and-privacy"]) {
+    assert.match(
+      about,
+      new RegExp(`PalomarPolicy/blob/main/docs/specification\\.md${anchor}`),
+      `About should link the specification at ${anchor} rather than restate it`,
+    );
+  }
+});
+
+test("About describes both ways push access is proved", async () => {
+  // A sign-in and the agent's tag-and-gist do not establish the same thing,
+  // and step 3 used to name only the first.
+  const about = await readFile(new URL("../about.html", import.meta.url), "utf8");
+  assert.match(about, /There are two ways to prove that write access/);
+  assert.match(about, /not provably the same\s+account/);
+  assert.match(about, /Neither is proof of\s+authorship/);
+});
+
 test("About states the repository licence boundary", async () => {
   const about = await readFile(new URL("../about.html", import.meta.url), "utf8");
   assert.match(about, /root licence file, SPDX identifier, and checksum/);


### PR DESCRIPTION
This PR corrects what about.html says registration makes public, describes both ways push access is proved, and finishes migrating "warnings" to "comments" in prose.

about.html told a reader that registering makes their identity as submitter public. It does not. `submission` in schema-v2.json is `additionalProperties: false` over `submission_id` and `authorization`, and llms.txt has been saying so correctly the whole time. That is the direction of error nobody reports, so it is the one worth fixing first. The paragraph is honest about the rest: the authorization evidence you write is free text and is public, and your repository was public before you submitted.

It also promised "the source, warnings, and full review". What is published is the source and the review's comments, in a redacted archive without scores or per-finding severity, so about.html says that and links docs/specification.md rather than restating it a fourth time. The withheld scores get the reason already in app.js: the same commit scored 5 and then 4 on one axis across two runs with the same verdict both times.

Step 3 said "Sign in with GitHub", which stopped being the whole story when the agent path shipped on 7 August. The two routes do not prove the same thing, and a reader should be told which one a record does not carry.

Remaining prose uses of "warnings" in the AI-review sense are now "comments", matching what an entry page has called them since #48 in PalomarPolicy. The schema field `review.warnings` and the CSS classes are untouched.

Codex caught three overstatements in the first draft: "used once and not stored" was false about the account name, "the record says which was used" named the wrong record, and "the verdict does not move" claimed a stability the same-commit rerolling note contradicts. All three are fixed here.

Cross-links: https://github.com/PalomarRegistry/PalomarSubmission/pull/46 , https://github.com/PalomarRegistry/PalomarPolicy/pull/53 and https://github.com/PalomarRegistry/PalomarTemplate/pull/11 are the rest of the same documentation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEeeSmhfMihzWxiWHwBmZF
