### PR TITLE
fix: read the schemas from the front door, not the second one

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,7 +28,7 @@ jobs:
       # public snapshot rather than cloning the canonical repository.
       - name: Download the published schemas
         env:
-          PUBLIC_DATA_ORIGIN: https://palomar-data.palomar-server.workers.dev
+          PUBLIC_DATA_ORIGIN: https://data.palomar-registry.org
         run: |
           mkdir palomar-database
           curl --fail --silent --show-error --retry 3 \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       # public snapshot rather than cloning the canonical repository.
       - name: Download the published schemas
         env:
-          PUBLIC_DATA_ORIGIN: https://palomar-data.palomar-server.workers.dev
+          PUBLIC_DATA_ORIGIN: https://data.palomar-registry.org
         run: |
           mkdir palomar-database
           curl --fail --silent --show-error --retry 3 \


### PR DESCRIPTION
This PR points both CI workflows at `data.palomar-registry.org` for the published
schemas, instead of the workers.dev hostname.

That hostname is a second, independently deployed copy of the read surface, bound
to the production bucket. It sits outside anything scoped to the zone, it can lag
the Worker's path allowlist indefinitely, and nothing monitors it.
PalomarRegistry/PalomarDatabase#88 turns it off, and these are two of the three
workflows across two repositories that would break when it does. The third is
PalomarRegistry/PalomarReviewer#79.

The custom domain serves the same files; checked before changing anything, and
it is already what the site reads at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEeeSmhfMihzWxiWHwBmZF