### PR TITLE
fix: preserve newest-first landing-page order

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -374,7 +374,9 @@ async function renderIndex() {
       return;
     }
     status.hidden = true;
-    for (const entry of entries.sort((a, b) => a.id.localeCompare(b.id))) {
+    // `loadEntries` preserves recent.entries order even when its parallel
+    // fetches finish out of order, so render the publisher's newest-first list.
+    for (const entry of entries) {
       grid.append(entryCard(entry, versionCounts.get(entry.id), availability));
     }
     let trust = "all";

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -686,6 +686,9 @@ export function validateEntry(entry, summary) {
   if (!TIMESTAMP_RE.test(registeredAt) || Number.isNaN(Date.parse(registeredAt))) {
     fail("entry.registered_at is malformed");
   }
+  if (summary.published_at !== undefined && summary.published_at !== registeredAt) {
+    fail("entry.registered_at does not match summary.published_at");
+  }
 
   for (const [position, value] of array(entry.authors, "entry.authors").entries()) {
     string(object(value, `entry.authors[${position}]`).name, `entry.authors[${position}].name`);

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -70,7 +70,7 @@ function secondVersion(overrides = {}) {
 }
 
 function recentRow(overrides = {}) {
-  return { ...summary(), published_at: "2026-07-29T08:53:02Z", versions: 1, ...overrides };
+  return { ...summary(), published_at: "2026-07-29T09:14:07Z", versions: 1, ...overrides };
 }
 
 function recent(entries = [recentRow()], overrides = {}) {
@@ -347,6 +347,19 @@ test("a record must say when the version was registered, and agree with its resu
     () => validateEntry(secondVersion({ registered_at: "2026-07-28T09:00:00Z" }), secondSummary),
     /registered_at is before the result entered the registry/,
   );
+});
+
+test("a recent summary's publication instant matches the entry it orders", () => {
+  const record = entry();
+  assert.equal(validateEntry(record, recentRow()), record);
+  assert.throws(
+    () => validateEntry(record, recentRow({ published_at: "2026-07-29T09:14:08Z" })),
+    /registered_at does not match summary\.published_at/,
+  );
+
+  // Version indexes and search postings do not order cards by publication
+  // time, so their summaries deliberately do not carry this field.
+  assert.equal(validateEntry(record, summary()), record);
 });
 
 test("what recent claims is coverage and ordering, so both are checked", () => {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -119,6 +119,38 @@ test("landing cards show the registration date and dated identifier", async ({ p
   await expect(page.getByRole("button", { name: "Additional libraries" })).toBeVisible();
 });
 
+test("landing cards preserve the publisher's newest-first order", async ({ page }) => {
+  const registeredAt = new Map([
+    ["PALOMAR-2026-07-29-000124", "2026-07-29T23:00:00Z"],
+    ["PALOMAR-2026-07-29-000123", "2026-07-29T22:00:00Z"],
+  ]);
+  await page.route("**/database/recent.json", async (route) => {
+    const response = await route.fetch();
+    const recent = await response.json();
+    const rows = new Map(recent.entries.map((row) => [row.id, row]));
+    recent.entries = [...registeredAt].map(([id, publishedAt]) => ({
+      ...rows.get(id),
+      published_at: publishedAt,
+    }));
+    await route.fulfill({ response, json: recent });
+  });
+  await page.route("**/database/entries/*.json", async (route) => {
+    const response = await route.fetch();
+    const entry = await response.json();
+    entry.registered_at = registeredAt.get(entry.id);
+    await route.fulfill({ response, json: entry });
+  });
+
+  await page.goto(`/?database=${database}`);
+
+  // Recency and identifier order deliberately disagree. The DOM must follow
+  // recent.json, whose order has already been validated as newest-first.
+  await expect(page.locator(".entry-card .entry-id")).toHaveText([
+    "PALOMAR-2026-07-29-000124 v1 · current",
+    "PALOMAR-2026-07-29-000123 v2 · current",
+  ]);
+});
+
 test("registry entries can be filtered by arXiv and MSC classifications", async ({ page }) => {
   await page.goto(`/?database=${database}`);
   await expect(page.locator('#arxiv-options option[value="math.NT"]')).toHaveCount(1);

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -127,6 +127,7 @@ test("landing cards preserve the publisher's newest-first order", async ({ page 
   await page.route("**/database/recent.json", async (route) => {
     const response = await route.fetch();
     const recent = await response.json();
+    expect(recent.entries).toHaveLength(registeredAt.size);
     const rows = new Map(recent.entries.map((row) => [row.id, row]));
     recent.entries = [...registeredAt].map(([id, publishedAt]) => ({
       ...rows.get(id),
@@ -145,7 +146,7 @@ test("landing cards preserve the publisher's newest-first order", async ({ page 
 
   // Recency and identifier order deliberately disagree. The DOM must follow
   // recent.json, whose order has already been validated as newest-first.
-  await expect(page.locator(".entry-card .entry-id")).toHaveText([
+  await expect(page.locator("#entry-grid .entry-card .entry-id")).toHaveText([
     "PALOMAR-2026-07-29-000124 v1 · current",
     "PALOMAR-2026-07-29-000123 v2 · current",
   ]);


### PR DESCRIPTION
## Summary

- render landing-page cards in the order supplied by the validated `recent.json` document
- retain parallel entry fetching while relying on `Promise.all` to preserve input order
- reject a recent summary whose ordering timestamp disagrees with the fetched entry's registration timestamp
- add a browser regression whose recency order deliberately conflicts with identifier order

## Root cause

`validateRecent` already rejects documents that are not newest-first, and `loadEntries` preserves that validated order. Immediately before rendering, however, `renderIndex` sorted the loaded entries by identifier. Because Palomar identifiers carry acceptance dates, that commonly changed the landing page to oldest-first and always discarded the publisher's ordering decision. Entry validation also did not confirm that a recent row's `published_at` was the fetched record's `registered_at`, allowing the ordering timestamp and displayed date to disagree.

## Behavior

Before this change, two valid recent rows ordered as `000124`, then `000123` rendered as `000123`, then `000124`. The landing page now preserves the publisher's newest-first sequence even though entry records are still fetched concurrently.

## Validation

- `PALOMAR_DATABASE_CHECKOUT=/home/kim/palomar/PalomarDatabase npm test` — 61 passed
- `npm run build -- --version test` — passed
- `nix shell nixpkgs#chromium -c bash -lc 'export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=$(command -v chromium); npm run test:browser'` — 35 passed, 2 expected deployment-compatibility skips
- the new focused browser regression failed against the old identifier sort and passes with this change
