### PR TITLE
Degrade gracefully when recent entry loads fail

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -48,7 +48,7 @@ const ARXIV_FILTER_RE = /^[a-z]+(?:-[a-z]+)*(?:\.[A-Za-z-]+)?$/;
 const MSC2020_FILTER_RE = /^[0-9]{2}(?:[A-Z][0-9]{2}|-[0-9]{2})$/;
 const FILTER_UPDATE_DELAY_MS = 200;
 const RECENT_ENTRY_CONCURRENCY = 8;
-const RECENT_ENTRY_TIMEOUT_MS = 8_000;
+const RECENT_ENTRY_TIMEOUT_MS = 30_000;
 
 function dataSource() {
   const databaseBase = databaseBaseFor(
@@ -388,7 +388,10 @@ async function renderIndex() {
     const availability = await availabilityPromise;
     // GitHub Pages may briefly pair HTML and JavaScript from adjacent deployments.
     // Metrics are presentation-only, so a removed metric must not abort the registry.
-    setOptionalText("#metric-results", String(entries.length));
+    // The validated summary still names every accepted result when an
+    // individual record is temporarily unavailable. Counting only rendered
+    // cards would make a transport failure look like a registry withdrawal.
+    setOptionalText("#metric-results", String(recentTotal));
     setOptionalText(
       "#metric-projects",
       new Set(entries.map((entry) => entry.source.repository)).size,
@@ -400,19 +403,20 @@ async function renderIndex() {
       return;
     }
     if (!entries.length) {
+      status.hidden = false;
       status.textContent =
         `No recent registry entries could be loaded (${loaded.failed} of ${recentTotal} failed). ` +
         "Try again later.";
-      status.classList.add("error");
+      status.className = "status error";
       return;
     }
     const degradedMessage = loaded.failed
-      ? `Showing ${entries.length} of ${recentTotal} recent registry entries; ` +
-        `${loaded.failed} could not be loaded.`
+      ? `The recent listing is incomplete: ${loaded.failed} of ${recentTotal} entries ` +
+        "could not be loaded."
       : "";
     status.hidden = !degradedMessage;
     status.textContent = degradedMessage;
-    status.classList.toggle("warning", Boolean(degradedMessage));
+    status.className = degradedMessage ? "status warning" : "status";
     // `loadEntries` keeps fulfilled values in recent.entries order even when
     // its bounded parallel fetches finish out of order, so render the
     // publisher's newest-first list.
@@ -491,7 +495,6 @@ async function renderIndex() {
           ? `No registry entries match the current filters. Classification query: ${classificationQuery.join(", ")}.`
           : "No registry entries match those filters.";
       if (!shown && degradedMessage) status.textContent += ` ${degradedMessage}`;
-      status.classList.toggle("warning", Boolean(degradedMessage));
     };
     let updateTimer;
     const scheduleUpdate = () => {
@@ -517,8 +520,9 @@ async function renderIndex() {
     });
     update();
   } catch (error) {
+    status.hidden = false;
     status.textContent = `The registry could not be loaded: ${error.message}`;
-    status.classList.add("error");
+    status.className = "status error";
   }
 }
 

--- a/assets/app.js
+++ b/assets/app.js
@@ -37,6 +37,7 @@ import {
   validateTombstone,
   workflowRunId,
 } from "./security.mjs";
+import { loadSettledBounded } from "./loading.mjs";
 
 const CANONICAL_WEB_BASE = "https://palomar-registry.org/";
 
@@ -46,6 +47,8 @@ const VERSION_PARAMETER = /^[1-9][0-9]*$/;
 const ARXIV_FILTER_RE = /^[a-z]+(?:-[a-z]+)*(?:\.[A-Za-z-]+)?$/;
 const MSC2020_FILTER_RE = /^[0-9]{2}(?:[A-Z][0-9]{2}|-[0-9]{2})$/;
 const FILTER_UPDATE_DELAY_MS = 200;
+const RECENT_ENTRY_CONCURRENCY = 8;
+const RECENT_ENTRY_TIMEOUT_MS = 8_000;
 
 function dataSource() {
   const databaseBase = databaseBaseFor(
@@ -90,8 +93,8 @@ function setOptionalText(selector, text) {
   if (node) node.textContent = text;
 }
 
-async function fetchJson(url) {
-  const response = await fetch(url, { cache: "no-cache" });
+async function fetchJson(url, { signal } = {}) {
+  const response = await fetch(url, { cache: "no-cache", signal });
   if (!response.ok) {
     const error = new Error(`${response.status} ${response.statusText}`);
     error.status = response.status;
@@ -337,12 +340,33 @@ function entryCard(entry, versionCount, availability) {
 }
 
 async function loadEntries(page, databaseBase) {
-  return Promise.all(
-    page.entries.map(async (summary) => {
-      const entry = await fetchJson(entryRecordUrl(summary, databaseBase));
+  const settled = await loadSettledBounded(
+    page.entries,
+    async (summary, signal) => {
+      const entry = await fetchJson(entryRecordUrl(summary, databaseBase), { signal });
+      // Every response is still untrusted independently. Degraded loading
+      // means a malformed record is omitted, never rendered provisionally.
       return validateEntry(entry, summary);
-    }),
+    },
+    {
+      concurrency: RECENT_ENTRY_CONCURRENCY,
+      timeoutMs: RECENT_ENTRY_TIMEOUT_MS,
+    },
   );
+  const entries = [];
+  let failed = 0;
+  for (const [position, result] of settled.entries()) {
+    if (result.status === "fulfilled") {
+      entries.push(result.value);
+    } else {
+      failed += 1;
+      console.warn(
+        `Recent entry ${page.entries[position].id} v${page.entries[position].version} ` +
+          `could not be loaded: ${result.reason?.message || String(result.reason)}`,
+      );
+    }
+  }
+  return { entries, failed };
 }
 
 async function renderIndex() {
@@ -358,7 +382,9 @@ async function renderIndex() {
     // how many versions each has, so neither is worked out again here.
     const recent = validateRecent(await fetchJson(recentUrl(databaseBase)));
     const versionCounts = new Map(recent.entries.map((row) => [row.id, row.versions]));
-    const entries = await loadEntries(recent, databaseBase);
+    const loaded = await loadEntries(recent, databaseBase);
+    const { entries } = loaded;
+    const recentTotal = recent.entries.length;
     const availability = await availabilityPromise;
     // GitHub Pages may briefly pair HTML and JavaScript from adjacent deployments.
     // Metrics are presentation-only, so a removed metric must not abort the registry.
@@ -367,15 +393,29 @@ async function renderIndex() {
       "#metric-projects",
       new Set(entries.map((entry) => entry.source.repository)).size,
     );
-    if (!entries.length) {
+    if (!entries.length && !recentTotal) {
       status.textContent =
         "The telescope is ready. No entries have been published yet; the first accepted database PR will appear here automatically.";
       status.classList.add("empty");
       return;
     }
-    status.hidden = true;
-    // `loadEntries` preserves recent.entries order even when its parallel
-    // fetches finish out of order, so render the publisher's newest-first list.
+    if (!entries.length) {
+      status.textContent =
+        `No recent registry entries could be loaded (${loaded.failed} of ${recentTotal} failed). ` +
+        "Try again later.";
+      status.classList.add("error");
+      return;
+    }
+    const degradedMessage = loaded.failed
+      ? `Showing ${entries.length} of ${recentTotal} recent registry entries; ` +
+        `${loaded.failed} could not be loaded.`
+      : "";
+    status.hidden = !degradedMessage;
+    status.textContent = degradedMessage;
+    status.classList.toggle("warning", Boolean(degradedMessage));
+    // `loadEntries` keeps fulfilled values in recent.entries order even when
+    // its bounded parallel fetches finish out of order, so render the
+    // publisher's newest-first list.
     for (const entry of entries) {
       grid.append(entryCard(entry, versionCounts.get(entry.id), availability));
     }
@@ -434,7 +474,7 @@ async function renderIndex() {
         card.hidden = !visible;
         if (visible) shown += 1;
       }
-      status.hidden = shown !== 0;
+      status.hidden = shown !== 0 && !degradedMessage;
       const classificationQuery = [
         arxivValue && `arXiv ${arxivValue}`,
         mscValue && `MSC2020 ${mscValue}`,
@@ -444,12 +484,14 @@ async function renderIndex() {
         mscInvalid && "MSC2020",
       ].filter(Boolean);
       status.textContent = shown
-        ? ""
+        ? degradedMessage
         : invalidClassifications.length
           ? `No registry entries match the current filters. Invalid classification code format: ${invalidClassifications.join(", ")}.`
           : classificationQuery.length
           ? `No registry entries match the current filters. Classification query: ${classificationQuery.join(", ")}.`
           : "No registry entries match those filters.";
+      if (!shown && degradedMessage) status.textContent += ` ${degradedMessage}`;
+      status.classList.toggle("warning", Boolean(degradedMessage));
     };
     let updateTimer;
     const scheduleUpdate = () => {

--- a/assets/loading.mjs
+++ b/assets/loading.mjs
@@ -1,0 +1,63 @@
+/**
+ * Run independent loads without allowing either their concurrency or their
+ * total wait to grow with the number of items.
+ *
+ * Results occupy their input positions, like Promise.allSettled. Each load
+ * receives a signal that aborts at the shared deadline. A shared deadline is
+ * important here: giving every queued request a fresh timeout would let a
+ * page of unavailable records wait for `items / concurrency` timeouts.
+ */
+export async function loadSettledBounded(
+  items,
+  load,
+  { concurrency, timeoutMs },
+) {
+  if (!Array.isArray(items)) throw new TypeError("items must be an array");
+  if (typeof load !== "function") throw new TypeError("load must be a function");
+  if (!Number.isSafeInteger(concurrency) || concurrency < 1) {
+    throw new RangeError("concurrency must be a positive integer");
+  }
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new RangeError("timeoutMs must be positive");
+  }
+
+  const results = new Array(items.length);
+  const controller = new AbortController();
+  const deadlineError = new Error(`load deadline of ${timeoutMs}ms expired`);
+  const timer = setTimeout(() => controller.abort(deadlineError), timeoutMs);
+  let next = 0;
+
+  async function worker() {
+    while (next < items.length) {
+      const position = next;
+      next += 1;
+      if (controller.signal.aborted) {
+        results[position] = {
+          status: "rejected",
+          reason: controller.signal.reason,
+        };
+        continue;
+      }
+
+      try {
+        results[position] = {
+          status: "fulfilled",
+          value: await load(items[position], controller.signal),
+        };
+      } catch (reason) {
+        results[position] = { status: "rejected", reason };
+      }
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    () => worker(),
+  );
+  try {
+    await Promise.all(workers);
+  } finally {
+    clearTimeout(timer);
+  }
+  return results;
+}

--- a/assets/loading.mjs
+++ b/assets/loading.mjs
@@ -27,6 +27,36 @@ export async function loadSettledBounded(
   const timer = setTimeout(() => controller.abort(deadlineError), timeoutMs);
   let next = 0;
 
+  /**
+   * Settle when the load settles or the one shared deadline expires.
+   *
+   * The load is not trusted to observe its signal. The abort listener is the
+   * loader's own enforcement, and is removed as soon as a load settles so a
+   * long but healthy page does not accumulate listeners. Both load outcomes
+   * are handled even after the deadline wins, preventing late rejections from
+   * becoming unhandled.
+   */
+  function beforeDeadline(loadPromise) {
+    return new Promise((resolve, reject) => {
+      if (controller.signal.aborted) {
+        reject(controller.signal.reason);
+        return;
+      }
+      const onAbort = () => reject(controller.signal.reason);
+      controller.signal.addEventListener("abort", onAbort, { once: true });
+      loadPromise.then(
+        (value) => {
+          controller.signal.removeEventListener("abort", onAbort);
+          resolve(value);
+        },
+        (reason) => {
+          controller.signal.removeEventListener("abort", onAbort);
+          reject(reason);
+        },
+      );
+    });
+  }
+
   async function worker() {
     while (next < items.length) {
       const position = next;
@@ -40,9 +70,12 @@ export async function loadSettledBounded(
       }
 
       try {
+        const loadPromise = Promise.resolve().then(
+          () => load(items[position], controller.signal),
+        );
         results[position] = {
           status: "fulfilled",
-          value: await load(items[position], controller.signal),
+          value: await beforeDeadline(loadPromise),
         };
       } catch (reason) {
         results[position] = { status: "rejected", reason };

--- a/assets/style.css
+++ b/assets/style.css
@@ -321,6 +321,11 @@ button:focus-visible {
   color: var(--warning);
 }
 
+.status.warning {
+  border-color: var(--caution);
+  color: var(--caution);
+}
+
 .status.empty {
   padding-block: 2rem;
 }

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -5,7 +5,14 @@ import { fileURLToPath } from "node:url";
 const root = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 export const htmlFiles = ["404.html", "about.html", "entry.html", "index.html", "render.html"];
 const publicFiles = [...htmlFiles, "site.webmanifest", "favicon.svg"];
-const assetFiles = ["about.js", "app.js", "rendering.js", "security.mjs", "style.css"];
+const assetFiles = [
+  "about.js",
+  "app.js",
+  "loading.mjs",
+  "rendering.js",
+  "security.mjs",
+  "style.css",
+];
 // Copied verbatim into assets/, keeping their subdirectory. Listed separately
 // because they are data rather than code: no version query, no rewriting.
 const assetDataFiles = ["data/msc2020-codes.json"];
@@ -80,9 +87,11 @@ export async function buildSite({ output, version }) {
   const appTarget = path.join(destination, "assets", "app.js");
   const app = await readFile(appTarget, "utf8");
   const versionedImport = app
+    .replace('from "./loading.mjs";', `from "./loading.mjs?v=${version}";`)
     .replace('from "./rendering.js";', `from "./rendering.js?v=${version}";`)
     .replace('from "./security.mjs";', `from "./security.mjs?v=${version}";`);
   if (
+    !versionedImport.includes(`from "./loading.mjs?v=${version}";`) ||
     !versionedImport.includes(`from "./rendering.js?v=${version}";`) ||
     !versionedImport.includes(`from "./security.mjs?v=${version}";`)
   ) {

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -5,12 +5,11 @@ import { fileURLToPath } from "node:url";
 const root = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 export const htmlFiles = ["404.html", "about.html", "entry.html", "index.html", "render.html"];
 const publicFiles = [...htmlFiles, "site.webmanifest", "favicon.svg"];
+const appModules = ["loading.mjs", "rendering.js", "security.mjs"];
 const assetFiles = [
   "about.js",
   "app.js",
-  "loading.mjs",
-  "rendering.js",
-  "security.mjs",
+  ...appModules,
   "style.css",
 ];
 // Copied verbatim into assets/, keeping their subdirectory. Listed separately
@@ -86,16 +85,16 @@ export async function buildSite({ output, version }) {
 
   const appTarget = path.join(destination, "assets", "app.js");
   const app = await readFile(appTarget, "utf8");
-  const versionedImport = app
-    .replace('from "./loading.mjs";', `from "./loading.mjs?v=${version}";`)
-    .replace('from "./rendering.js";', `from "./rendering.js?v=${version}";`)
-    .replace('from "./security.mjs";', `from "./security.mjs?v=${version}";`);
-  if (
-    !versionedImport.includes(`from "./loading.mjs?v=${version}";`) ||
-    !versionedImport.includes(`from "./rendering.js?v=${version}";`) ||
-    !versionedImport.includes(`from "./security.mjs?v=${version}";`)
-  ) {
-    throw new Error("could not version coupled browser imports");
+  let versionedImport = app;
+  for (const module of appModules) {
+    const source = `from "./${module}";`;
+    if (!versionedImport.includes(source)) {
+      throw new Error(`could not find coupled browser import ${module}`);
+    }
+    versionedImport = versionedImport.replace(
+      source,
+      `from "./${module}?v=${version}";`,
+    );
   }
   await writeFile(appTarget, versionedImport);
   await writeFile(path.join(destination, ".nojekyll"), "");

--- a/tests/build-site.test.js
+++ b/tests/build-site.test.js
@@ -23,6 +23,8 @@ test("deployment build versions coupled browser assets", async () => {
     await readFile(path.join(destination, "assets", "about.js"), "utf8");
     assert.match(app, /\.\/rendering\.js\?v=0123456789abcdef/);
     assert.match(app, /\.\/security\.mjs\?v=0123456789abcdef/);
+    assert.match(app, /\.\/loading\.mjs\?v=0123456789abcdef/);
+    await readFile(path.join(destination, "assets", "loading.mjs"), "utf8");
     await readFile(path.join(destination, "assets", "security.mjs"), "utf8");
   } finally {
     await rm(destination, { recursive: true, force: true });

--- a/tests/loading.test.js
+++ b/tests/loading.test.js
@@ -48,3 +48,16 @@ test("one shared deadline aborts hung requests and bounds queued work", async ()
   assert.deepEqual(results.map((result) => result.status), Array(4).fill("rejected"));
   for (const result of results) assert.match(result.reason.message, /deadline of 30ms expired/);
 });
+
+test("the deadline settles a load that ignores its abort signal", async () => {
+  const before = Date.now();
+  const results = await loadSettledBounded(
+    ["never"],
+    () => new Promise(() => {}),
+    { concurrency: 1, timeoutMs: 30 },
+  );
+
+  assert.ok(Date.now() - before < 500, "an abort-ignoring load hung the loader");
+  assert.equal(results[0].status, "rejected");
+  assert.match(results[0].reason.message, /deadline of 30ms expired/);
+});

--- a/tests/loading.test.js
+++ b/tests/loading.test.js
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { loadSettledBounded } from "../assets/loading.mjs";
+
+test("bounded loads settle independently and retain input order", async () => {
+  let active = 0;
+  let maximumActive = 0;
+  const results = await loadSettledBounded(
+    [30, 5, 15, 1],
+    async (delay) => {
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      active -= 1;
+      if (delay === 15) throw new Error("malformed record");
+      return delay;
+    },
+    { concurrency: 2, timeoutMs: 500 },
+  );
+
+  assert.equal(maximumActive, 2);
+  assert.deepEqual(
+    results.map((result) => result.status),
+    ["fulfilled", "fulfilled", "rejected", "fulfilled"],
+  );
+  assert.deepEqual(
+    results.filter((result) => result.status === "fulfilled").map((result) => result.value),
+    [30, 5, 1],
+  );
+  assert.match(results[2].reason.message, /malformed record/);
+});
+
+test("one shared deadline aborts hung requests and bounds queued work", async () => {
+  const started = [];
+  const before = Date.now();
+  const results = await loadSettledBounded(
+    [0, 1, 2, 3],
+    (item, signal) => new Promise((resolve, reject) => {
+      started.push(item);
+      signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+    }),
+    { concurrency: 2, timeoutMs: 30 },
+  );
+
+  assert.ok(Date.now() - before < 500, "the loader exceeded its shared deadline");
+  assert.deepEqual(started, [0, 1]);
+  assert.deepEqual(results.map((result) => result.status), Array(4).fill("rejected"));
+  for (const result of results) assert.match(result.reason.message, /deadline of 30ms expired/);
+});

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -166,9 +166,23 @@ test("one malformed recent entry does not hide valid cards", async ({ page }) =>
     "PALOMAR-2026-07-29-000124 v1 · current",
   ]);
   await expect(page.locator("#status")).toHaveText(
-    "Showing 1 of 2 recent registry entries; 1 could not be loaded.",
+    "The recent listing is incomplete: 1 of 2 entries could not be loaded.",
   );
   await expect(page.locator("#status")).toHaveClass(/warning/);
+  await expect(page.locator("#metric-results")).toHaveText("2");
+
+  await page.locator("#arxiv-query").fill("math.NT");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(1);
+  await expect(page.locator("#status")).toHaveText(
+    "The recent listing is incomplete: 1 of 2 entries could not be loaded.",
+  );
+
+  await page.locator("#arxiv-query").fill("math.CO");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(0);
+  await expect(page.locator("#status")).toHaveText(
+    "No registry entries match the current filters. Classification query: arXiv math.CO. " +
+      "The recent listing is incomplete: 1 of 2 entries could not be loaded.",
+  );
 });
 
 test("an entirely unavailable recent selection reports failure instead of emptiness", async ({ page }) => {
@@ -176,10 +190,10 @@ test("an entirely unavailable recent selection reports failure instead of emptin
 
   await page.goto(`/?database=${database}`);
 
-  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(0);
   await expect(page.locator("#status")).toHaveText(
     "No recent registry entries could be loaded (2 of 2 failed). Try again later.",
   );
+  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(0);
   await expect(page.locator("#status")).toHaveClass(/error/);
   await expect(page.locator("#status")).not.toContainText("No entries have been published");
 });

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -152,6 +152,38 @@ test("landing cards preserve the publisher's newest-first order", async ({ page 
   ]);
 });
 
+test("one malformed recent entry does not hide valid cards", async ({ page }) => {
+  await page.route("**/database/entries/PALOMAR-2026-07-29-000123-v2.json", async (route) => {
+    const response = await route.fetch();
+    const malformed = await response.json();
+    malformed.title = "";
+    await route.fulfill({ response, json: malformed });
+  });
+
+  await page.goto(`/?database=${database}`);
+
+  await expect(page.locator("#entry-grid .entry-card .entry-id")).toHaveText([
+    "PALOMAR-2026-07-29-000124 v1 · current",
+  ]);
+  await expect(page.locator("#status")).toHaveText(
+    "Showing 1 of 2 recent registry entries; 1 could not be loaded.",
+  );
+  await expect(page.locator("#status")).toHaveClass(/warning/);
+});
+
+test("an entirely unavailable recent selection reports failure instead of emptiness", async ({ page }) => {
+  await page.route("**/database/entries/*.json", (route) => route.abort());
+
+  await page.goto(`/?database=${database}`);
+
+  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(0);
+  await expect(page.locator("#status")).toHaveText(
+    "No recent registry entries could be loaded (2 of 2 failed). Try again later.",
+  );
+  await expect(page.locator("#status")).toHaveClass(/error/);
+  await expect(page.locator("#status")).not.toContainText("No entries have been published");
+});
+
 test("registry entries can be filtered by arXiv and MSC classifications", async ({ page }) => {
   await page.goto(`/?database=${database}`);
   await expect(page.locator('#arxiv-options option[value="math.NT"]')).toHaveCount(1);


### PR DESCRIPTION
## Root cause

The landing page loaded every record named by recent.json through one unbounded, fail-fast Promise.all. One unavailable or schema-invalid record therefore prevented every valid recent card from rendering, and a stalled request could keep the page waiting indefinitely.

## Behavior

- load at most eight recent records concurrently under one shared 30-second hard deadline
- enforce the deadline even when a loader ignores its AbortSignal
- settle and validate each record independently, omitting malformed responses instead of rendering untrusted data
- retain the publisher order among successfully loaded cards
- show an explicit degraded count alongside valid cards and filter results
- distinguish an unavailable selection from a genuinely empty registry when all records fail
- keep the accepted-result metric faithful to the validated recent summary during degradation
- ship and cache-version the small loading helper with the existing browser assets

The timeout deliberately covers only the bounded recent-entry fanout. Fetches for recent.json itself, source availability, and registry search are separate paths and are not changed here. Health-monitoring semantics are also unchanged.

## Checks

- `PALOMAR_DATABASE_CHECKOUT=/tmp/PalomarDatabase npm test` — 64 passed
- `PALOMAR_ASSET_VERSION=test npm run build` — passed
- Nixpkgs Chromium `npm run test:browser` — 37 passed, 2 CI-only skips
- `git diff --check` — passed