### PR TITLE
Pipeline bounded registry search I/O

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ before that classification has an entry. The filter is over `recent.json`, which
 is the newest 200 current versions and not the registry, so it narrows what is
 on the page rather than searching everything; the search box does the latter,
 a word at a time, over titles, abstracts and author names.
+Search heads, posting pages and records load with bounded concurrency under one
+30-second deadline. A failed page or record leaves already validated results
+visible with an incomplete-search warning. Posting rows currently carry only a
+versioned identifier, so search cards do not call that version current or show
+a version-history count they cannot verify; landing cards get both facts from
+`recent.json`.
 
 Local preview:
 

--- a/README.md
+++ b/README.md
@@ -30,14 +30,15 @@ Search heads, posting pages and records load with bounded concurrency under one
 30-second deadline. A failed page or record leaves already validated results
 visible with an incomplete-search warning. The record loader advances as a
 bounded sliding window, keeps publisher order however requests finish, and
-stops at the result limit with at most seven speculative record reads. Multiple
+stops at the result limit with at most seven speculative result groups. Multiple
 matching versions of one Palomar ID collapse to the newest matching version in
 the bounded candidate set, so a result is not repeated. A posting still says
 neither that a version is current nor how many active versions exist, so search
 cards make neither claim; landing cards get both facts from `recent.json`.
-Verified search cards render before the source-availability manifest and are
-decorated if it arrives. A linked `?q=` search does not also load the hidden
-recent listing; clearing the search starts that landing load once.
+Landing and verified search cards render before the source-availability
+manifest; if it arrives, their existing source controls are decorated in place.
+A linked `?q=` search does not also load the hidden recent listing; clearing the
+search starts one landing attempt, and a failed attempt can be retried.
 
 Local preview:
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,16 @@ on the page rather than searching everything; the search box does the latter,
 a word at a time, over titles, abstracts and author names.
 Search heads, posting pages and records load with bounded concurrency under one
 30-second deadline. A failed page or record leaves already validated results
-visible with an incomplete-search warning. Posting rows currently carry only a
-versioned identifier, so search cards do not call that version current or show
-a version-history count they cannot verify; landing cards get both facts from
-`recent.json`.
+visible with an incomplete-search warning. The record loader advances as a
+bounded sliding window, keeps publisher order however requests finish, and
+stops at the result limit with at most seven speculative record reads. Multiple
+matching versions of one Palomar ID collapse to the newest matching version in
+the bounded candidate set, so a result is not repeated. A posting still says
+neither that a version is current nor how many active versions exist, so search
+cards make neither claim; landing cards get both facts from `recent.json`.
+Verified search cards render before the source-availability manifest and are
+decorated if it arrives. A linked `?q=` search does not also load the hidden
+recent listing; clearing the search starts that landing load once.
 
 Local preview:
 

--- a/assets/app.js
+++ b/assets/app.js
@@ -100,9 +100,13 @@ async function fetchJson(url, { signal } = {}) {
 
 const searchRegistry = createRegistrySearch(fetchJson);
 
+async function fetchAvailability(url, { signal } = {}) {
+  return validateAvailability(await fetchJson(url, { signal }));
+}
+
 async function loadAvailability(url, { signal } = {}) {
   try {
-    return validateAvailability(await fetchJson(url, { signal }));
+    return await fetchAvailability(url, { signal });
   } catch (error) {
     console.warn(`Source availability is unavailable: ${error.message}`);
     return null;
@@ -118,12 +122,21 @@ function loadAvailabilityBounded(url) {
   if (!availabilityLoads.has(key)) {
     const loading = loadSettledBounded(
       [url],
-      (selected, signal) => loadAvailability(selected, { signal }),
+      (selected, signal) => fetchAvailability(selected, { signal }),
       { concurrency: 1, timeoutMs: AVAILABILITY_TIMEOUT_MS },
     ).then(([loaded]) => {
-      const availability = loaded.status === "fulfilled" ? loaded.value : null;
-      if (availability === null) availabilityLoads.delete(key);
-      return availability;
+      if (loaded.status === "fulfilled") return loaded.value;
+      // A missing manifest is a stable legacy answer for this page load. A
+      // timeout, transport error, or invalid document may recover, so only
+      // those outcomes are evicted and retried by the next consumer.
+      if (loaded.reason?.status !== 404) {
+        availabilityLoads.delete(key);
+        console.warn(
+          `Source availability is unavailable: ` +
+            `${loaded.reason?.message || String(loaded.reason)}`,
+        );
+      }
+      return null;
     });
     availabilityLoads.set(key, loading);
   }
@@ -269,9 +282,53 @@ function trustBadge(entry) {
   return badge;
 }
 
+function decorateCardAvailability(card, entry, availability) {
+  const location = topSourceLocation(entry, availability);
+  const repositoryLink = card.querySelector(".repo-link");
+  if (!repositoryLink) throw new Error("card has no repository link");
+  repositoryLink.textContent = location.useArchive
+    ? "Palomar preserved copy"
+    : entry.source.repository;
+  repositoryLink.href = pinnedRepositoryDirectoryUrl(
+    location.repository,
+    entry.source.commit,
+  ).href;
+
+  const archiveLink = card.querySelector(".archive-link");
+  if (archiveLink) {
+    const archiveWasFocused = document.activeElement === archiveLink;
+    archiveLink.href = pinnedRepositoryDirectoryUrl(
+      location.archiveRepository,
+      entry.source.commit,
+    ).href;
+    archiveLink.hidden = location.useArchive;
+    let missing = card.querySelector(".source-status.missing");
+    if (location.useArchive && !missing) {
+      missing = el("span", "source-status missing", "Original unavailable");
+      archiveLink.insertAdjacentElement("afterend", missing);
+    }
+    if (!location.useArchive) missing?.remove();
+    if (archiveWasFocused && location.useArchive) repositoryLink.focus();
+  }
+}
+
+function decorateCardSet(cards, entries, availability, context) {
+  if (availability === null) return;
+  for (const [position, card] of cards.entries()) {
+    try {
+      decorateCardAvailability(card, entries[position], availability);
+    } catch (error) {
+      console.warn(
+        `${context} source availability could not be applied to ` +
+          `${entries[position].id} v${entries[position].version}: ${error.message}`,
+      );
+    }
+  }
+}
+
 function entryCard(
   entry,
-  { versionCount = null, availability = null, current = false } = {},
+  { versionCount = null, current = false } = {},
 ) {
   const categories = classification(entry);
   const card = el("article", "entry-card");
@@ -317,18 +374,18 @@ function entryCard(
     meta.append(project);
   }
   const footer = el("div", "card-footer");
-  const location = topSourceLocation(entry, availability);
+  const location = topSourceLocation(entry, null);
   const historyUrl = new URL(localPageUrl("entry.html", entry));
   historyUrl.hash = "version-history";
   footer.append(
     externalLink(
-      location.useArchive ? "Palomar preserved copy" : entry.source.repository,
-      pinnedRepositoryDirectoryUrl(location.repository, entry.source.commit),
+      entry.source.repository,
+      pinnedRepositoryDirectoryUrl(entry.source.repository, entry.source.commit),
       "repo-link",
     ),
     internalLink("View record", localPageUrl("entry.html", entry)),
   );
-  if (!location.useArchive && location.archiveRepository) {
+  if (location.archiveRepository) {
     footer.append(
       externalLink(
         "Palomar preserved copy",
@@ -336,16 +393,6 @@ function entryCard(
         "archive-link",
       ),
     );
-  } else if (location.useArchive) {
-    // Reached only when the availability manifest says the original is
-    // missing, which is why the link above has switched to the preserved
-    // copy. A record with no preservation block predates archiving, so
-    // nothing has ever been checked about its repository at all; it used to
-    // fall through to here and be told, in public, that it is gone.
-    // `sourceAvailabilityNotice` says the accurate thing for that case on the
-    // entry page, which is that Palomar has no preserved copy. A card has no
-    // room to explain it, so it says nothing.
-    footer.append(el("span", "source-status missing", "Original unavailable"));
   }
   if (versionCount > 1) {
     const historyLink = internalLink(
@@ -390,10 +437,34 @@ async function loadEntries(page, databaseBase) {
   return { entries, failed };
 }
 
+let landingSuppressed = false;
+let landingStatusHidden = document.querySelector("#status")?.hidden ?? true;
+
+function setLandingStatusHidden(hidden) {
+  landingStatusHidden = hidden;
+  const status = document.querySelector("#status");
+  if (status) status.hidden = landingSuppressed || hidden;
+}
+
+function setLandingSuppressed(suppressed) {
+  landingSuppressed = suppressed;
+  document.body.classList.toggle("registry-searching", suppressed);
+  const toolbar = document.querySelector(".toolbar");
+  const status = document.querySelector("#status");
+  const grid = document.querySelector("#entry-grid");
+  if (toolbar) toolbar.hidden = suppressed;
+  if (grid) grid.hidden = suppressed;
+  if (status) status.hidden = suppressed || landingStatusHidden;
+}
+
 async function renderIndex() {
   const status = document.querySelector("#status");
   const grid = document.querySelector("#entry-grid");
   try {
+    status.className = "status";
+    status.textContent = "Reading the Palomar database…";
+    setLandingStatusHidden(false);
+    grid.replaceChildren();
     const { databaseBase, availabilityUrl } = dataSource();
     const availabilityPromise = loadAvailabilityBounded(availabilityUrl);
     // What is new, not the whole registry. This page used to read a document
@@ -406,7 +477,6 @@ async function renderIndex() {
     const loaded = await loadEntries(recent, databaseBase);
     const { entries } = loaded;
     const recentTotal = recent.entries.length;
-    const availability = await availabilityPromise;
     // GitHub Pages may briefly pair HTML and JavaScript from adjacent deployments.
     // Metrics are presentation-only, so a removed metric must not abort the registry.
     // The validated summary still names every accepted result when an
@@ -418,36 +488,41 @@ async function renderIndex() {
       new Set(entries.map((entry) => entry.source.repository)).size,
     );
     if (!entries.length && !recentTotal) {
+      setLandingStatusHidden(false);
       status.textContent =
         "The telescope is ready. No entries have been published yet; the first accepted database PR will appear here automatically.";
       status.classList.add("empty");
-      return;
+      return true;
     }
     if (!entries.length) {
-      status.hidden = false;
+      setLandingStatusHidden(false);
       status.textContent =
         `No recent registry entries could be loaded (${loaded.failed} of ${recentTotal} failed). ` +
         "Try again later.";
       status.className = "status error";
-      return;
+      return false;
     }
     const degradedMessage = loaded.failed
       ? `The recent listing is incomplete: ${loaded.failed} of ${recentTotal} entries ` +
         "could not be loaded."
       : "";
-    status.hidden = !degradedMessage;
+    setLandingStatusHidden(!degradedMessage);
     status.textContent = degradedMessage;
     status.className = degradedMessage ? "status warning" : "status";
     // `loadEntries` keeps fulfilled values in recent.entries order even when
     // its bounded parallel fetches finish out of order, so render the
     // publisher's newest-first list.
-    for (const entry of entries) {
-      grid.append(entryCard(entry, {
+    const cards = entries.map((entry) =>
+      entryCard(entry, {
         versionCount: versionCounts.get(entry.id),
-        availability,
         current: true,
       }));
-    }
+    grid.append(...cards);
+    void availabilityPromise.then((availability) => {
+      decorateCardSet(cards, entries, availability, "Landing card");
+    }).catch((error) => {
+      console.warn(`Landing card source availability could not be applied: ${error.message}`);
+    });
     let trust = "all";
     const search = document.querySelector("#search");
     // The fallback selectors keep new JavaScript compatible with cached HTML
@@ -503,7 +578,7 @@ async function renderIndex() {
         card.hidden = !visible;
         if (visible) shown += 1;
       }
-      status.hidden = shown !== 0 && !degradedMessage;
+      setLandingStatusHidden(shown !== 0 && !degradedMessage);
       const classificationQuery = [
         arxivValue && `arXiv ${arxivValue}`,
         mscValue && `MSC2020 ${mscValue}`,
@@ -544,16 +619,24 @@ async function renderIndex() {
       });
     });
     update();
+    return true;
   } catch (error) {
-    status.hidden = false;
+    setLandingStatusHidden(false);
     status.textContent = `The registry could not be loaded: ${error.message}`;
     status.className = "status error";
+    return false;
   }
 }
 
 let landingLoad = null;
 function ensureLanding() {
-  if (!landingLoad) landingLoad = renderIndex();
+  if (!landingLoad) {
+    const active = renderIndex();
+    landingLoad = active;
+    void active.then((loaded) => {
+      if (!loaded && landingLoad === active) landingLoad = null;
+    });
+  }
   return landingLoad;
 }
 
@@ -570,8 +653,10 @@ function searchPageUrlFor(query) {
 let searchGeneration = 0;
 let activeSearchController = null;
 
-function renderSearchCards(results, entries, availability = null) {
-  results.replaceChildren(...entries.map((entry) => entryCard(entry, { availability })));
+function renderSearchCards(results, entries) {
+  const cards = entries.map((entry) => entryCard(entry));
+  results.replaceChildren(...cards);
+  return cards;
 }
 
 async function renderSearch(query) {
@@ -585,7 +670,7 @@ async function renderSearch(query) {
   results.replaceChildren();
   status.className = "status";
   const searching = Boolean(searchTerms(query).length);
-  document.body.classList.toggle("registry-searching", searching);
+  setLandingSuppressed(searching);
   if (!searching) {
     status.hidden = true;
     ensureLanding();
@@ -607,11 +692,15 @@ async function renderSearch(query) {
     }
     // Availability changes only where a source link points. It must never hold
     // verified registry results behind its own long timeout.
-    renderSearchCards(results, found.entries);
+    const cards = renderSearchCards(results, found.entries);
     if (found.entries.length) {
       void loadAvailabilityBounded(availabilityUrl).then((availability) => {
         if (availability !== null && generation === searchGeneration) {
-          renderSearchCards(results, found.entries, availability);
+          decorateCardSet(cards, found.entries, availability, "Search card");
+        }
+      }).catch((error) => {
+        if (generation === searchGeneration) {
+          console.warn(`Search card source availability could not be applied: ${error.message}`);
         }
       });
     }

--- a/assets/app.js
+++ b/assets/app.js
@@ -13,22 +13,15 @@ import {
   isLoopbackHostname,
   pinnedRepositoryDirectoryUrl,
   pinnedRepositoryFileUrl,
-  postingRecordUrl,
   safeDataUrl,
   safeExternalUrl,
   safeInternalUrl,
-  searchHeadUrl,
-  searchPageUrl,
   searchTerms,
-  stopwordsUrl,
   selectDatabaseUrl,
   selectAvailabilityUrl,
   recentUrl,
   selectRenderBase,
   tombstoneUrl,
-  validateSearchHead,
-  validateSearchPage,
-  validateStopwords,
   validateEntry,
   validateAvailability,
   validateRecent,
@@ -38,6 +31,7 @@ import {
   workflowRunId,
 } from "./security.mjs";
 import { loadSettledBounded } from "./loading.mjs";
+import { createRegistrySearch } from "./searching.mjs";
 
 const CANONICAL_WEB_BASE = "https://palomar-registry.org/";
 
@@ -49,6 +43,7 @@ const MSC2020_FILTER_RE = /^[0-9]{2}(?:[A-Z][0-9]{2}|-[0-9]{2})$/;
 const FILTER_UPDATE_DELAY_MS = 200;
 const RECENT_ENTRY_CONCURRENCY = 8;
 const RECENT_ENTRY_TIMEOUT_MS = 30_000;
+const AVAILABILITY_TIMEOUT_MS = 30_000;
 
 function dataSource() {
   const databaseBase = databaseBaseFor(
@@ -103,13 +98,34 @@ async function fetchJson(url, { signal } = {}) {
   return response.json();
 }
 
-async function loadAvailability(url) {
+const searchRegistry = createRegistrySearch(fetchJson);
+
+async function loadAvailability(url, { signal } = {}) {
   try {
-    return validateAvailability(await fetchJson(url));
+    return validateAvailability(await fetchJson(url, { signal }));
   } catch (error) {
     console.warn(`Source availability is unavailable: ${error.message}`);
     return null;
   }
+}
+
+// The landing and search controllers run independently, but they need the same
+// manifest. Share one bounded read rather than doubling a large request when a
+// reader arrives at a search URL.
+const availabilityLoads = new Map();
+function loadAvailabilityBounded(url) {
+  const key = url.href;
+  if (!availabilityLoads.has(key)) {
+    availabilityLoads.set(
+      key,
+      loadSettledBounded(
+        [url],
+        (selected, signal) => loadAvailability(selected, { signal }),
+        { concurrency: 1, timeoutMs: AVAILABILITY_TIMEOUT_MS },
+      ).then(([loaded]) => loaded.status === "fulfilled" ? loaded.value : null),
+    );
+  }
+  return availabilityLoads.get(key);
 }
 
 function sourceLocation(entry, availability, repository, commit) {
@@ -251,7 +267,10 @@ function trustBadge(entry) {
   return badge;
 }
 
-function entryCard(entry, versionCount, availability) {
+function entryCard(
+  entry,
+  { versionCount = null, availability = null, current = false } = {},
+) {
   const categories = classification(entry);
   const card = el("article", "entry-card");
   card.dataset.trust = entry.trust.level;
@@ -272,7 +291,7 @@ function entryCard(entry, versionCount, availability) {
   const top = el("div", "card-top");
   const identity = el("div", "card-identity");
   identity.append(
-    el("span", "entry-id", `${entry.id} v${entry.version} · current`),
+    el("span", "entry-id", `${entry.id} v${entry.version}${current ? " · current" : ""}`),
     el("span", "entry-date", `Registered ${displayDate(registrationDate(entry))}`),
   );
   top.append(identity, trustBadge(entry));
@@ -374,7 +393,7 @@ async function renderIndex() {
   const grid = document.querySelector("#entry-grid");
   try {
     const { databaseBase, availabilityUrl } = dataSource();
-    const availabilityPromise = loadAvailability(availabilityUrl);
+    const availabilityPromise = loadAvailabilityBounded(availabilityUrl);
     // What is new, not the whole registry. This page used to read a document
     // naming every active version and then sort and filter it here, which was
     // tens of megabytes for a screen of cards and grew every time anybody else
@@ -421,7 +440,11 @@ async function renderIndex() {
     // its bounded parallel fetches finish out of order, so render the
     // publisher's newest-first list.
     for (const entry of entries) {
-      grid.append(entryCard(entry, versionCounts.get(entry.id), availability));
+      grid.append(entryCard(entry, {
+        versionCount: versionCounts.get(entry.id),
+        availability,
+        current: true,
+      }));
     }
     let trust = "all";
     const search = document.querySelector("#search");
@@ -526,193 +549,6 @@ async function renderIndex() {
   }
 }
 
-// How much of a word's postings one query is allowed to pull. A common word
-// runs to hundreds of pages at a hundred thousand results, and a reader wants
-// the newest matches rather than all of them; the record check below is what
-// makes stopping early safe rather than merely cheap.
-const SEARCH_PAGE_BUDGET = 16;
-const SEARCH_RESULT_LIMIT = 20;
-const SEARCH_CANDIDATE_LIMIT = 60;
-const POSTING_RE = /^(PALOMAR-\d{4}-\d{2}-\d{2}-\d{6})-v([1-9]\d*)$/;
-
-// One editorial constant, fetched once per page rather than copied into this
-// repository, where it would drift from the indexer's across two deployments.
-let stopwords = null;
-
-/**
- * The words the indexer drops, so that a query can drop them too.
- *
- * Inferring them instead, from the fact that a dropped word has no head, was
- * wrong in a way a reader could not diagnose: a missing head is also what a
- * word nothing carries looks like, so "the ring" was answered against a record
- * whose text happens not to contain "the" by reporting that "the" is
- * unfindable. The list is published because it is a fixed choice of a few
- * hundred function words, which is nothing like the document naming every
- * known word that this index exists without.
- *
- * A list that cannot be fetched leaves every word in the query, which is the
- * behaviour this replaced: it narrows a search that should have been wider,
- * and never shows a result that does not match.
- */
-async function searchStopwords(databaseBase) {
-  if (stopwords) return stopwords;
-  try {
-    stopwords = validateStopwords(await fetchJson(stopwordsUrl(databaseBase)));
-  } catch (error) {
-    if (error.status !== 404) throw error;
-    stopwords = new Set();
-  }
-  return stopwords;
-}
-
-async function searchHead(term, databaseBase) {
-  try {
-    return validateSearchHead(await fetchJson(searchHeadUrl(term, databaseBase)), term);
-  } catch (error) {
-    // A 404 is the only answer there is for a word nothing carries. There is
-    // no document to consult first: one that named every known word would grow
-    // with the registry and be rewritten on every publication, which is the
-    // whole reason this index is shaped the way it is.
-    if (error.status !== 404) throw error;
-    return null;
-  }
-}
-
-/**
- * One word's postings, newest first, for as many pages as the budget allows.
- *
- * The pages are in registration order, so the last page is the newest batch,
- * and within a page an identifier begins with its registration date. A page
- * the head says exists and that is not there is an error rather than an empty
- * answer: the head is the only account of which pages there are.
- */
-async function searchPostings(term, head, databaseBase, wanted) {
-  const postings = [];
-  const first = Math.max(0, head.pages - wanted);
-  for (let number = head.pages - 1; number >= first; number -= 1) {
-    const page = validateSearchPage(
-      await fetchJson(searchPageUrl(term, number, databaseBase)),
-      term,
-      number,
-      head,
-    );
-    postings.push(...[...page.postings].reverse());
-  }
-  return { postings, whole: first === 0 };
-}
-
-/**
- * Which results might match, in the order they would be shown.
- *
- * The rarest word drives, because its sequence is the shortest and every match
- * is somewhere in it. Another word joins the intersection only if the whole of
- * it fits in what is left of the budget: intersecting against half a word's
- * postings would drop genuine matches while looking like a narrower search.
- * Everything else is settled per record by `carriesEveryTerm`, which is exact
- * and costs nothing, since the record has to be fetched to be shown anyway.
- *
- * A word with no head is a word nothing carries, and it is that rather than a
- * word the indexer drops because the dropped ones have already left the query
- * by the time this runs. It leaves the intersection and stays in the
- * per-record check, which rejects every candidate, and it is named in what the
- * reader is told rather than guessed about.
- */
-async function searchCandidates(terms, databaseBase) {
-  const heads = [];
-  const missing = [];
-  for (const term of terms) {
-    const head = await searchHead(term, databaseBase);
-    if (head && head.results > 0) heads.push([term, head]);
-    else missing.push(term);
-  }
-  heads.sort((left, right) => left[1].results - right[1].results);
-  if (!heads.length) return { postings: [], whole: true, missing };
-
-  let budget = SEARCH_PAGE_BUDGET;
-  let found = null;
-  let whole = true;
-  for (const [term, head] of heads) {
-    if (found !== null && head.pages > budget) break;
-    const wanted = Math.min(head.pages, budget);
-    if (wanted === 0) break;
-    const pulled = await searchPostings(term, head, databaseBase, wanted);
-    budget -= wanted;
-    whole = whole && pulled.whole;
-    if (found === null) {
-      found = pulled.postings;
-    } else {
-      const carried = new Set(pulled.postings);
-      found = found.filter((posting) => carried.has(posting));
-    }
-    if (budget <= 0) break;
-  }
-  return { postings: found ?? [], whole, missing };
-}
-
-/**
- * Whether a record really carries every word of the query.
- *
- * This is the check the postings are an index *of*, made against the record
- * itself, so a posting that claims a result it should not is caught here
- * rather than shown. It is also what lets the intersection above stop early
- * and what lets a word with no head still be answered exactly.
- */
-function carriesEveryTerm(entry, terms) {
-  const words = new Set([
-    ...searchTerms(entry.title),
-    ...searchTerms(entry.abstract),
-    ...entry.authors.flatMap((author) => searchTerms(author.name)),
-  ]);
-  return terms.every((term) => words.has(term));
-}
-
-/**
- * The summary a fetched record is checked against.
- *
- * `index.json` is an independent claim about a record's title, which is why
- * `validateEntry` compares the two. A posting claims something else: that this
- * record carries these words. So the identity is checked here and the claim
- * itself is checked by `carriesEveryTerm`, against the record's own text.
- */
-function postingSummary(posting, entry) {
-  const match = POSTING_RE.exec(posting);
-  return {
-    id: match[1],
-    version: Number(match[2]),
-    title: entry.title,
-    status: entry.status,
-    path: `entries/${posting}.json`,
-  };
-}
-
-async function searchRegistry(query, databaseBase) {
-  const asked = [...new Set(searchTerms(query))];
-  const dropping = await searchStopwords(databaseBase);
-  const dropped = asked.filter((term) => dropping.has(term));
-  const terms = asked.filter((term) => !dropping.has(term));
-  if (!terms.length) {
-    return { terms, dropped, entries: [], whole: true, examined: 0, missing: [] };
-  }
-  const { postings, whole, missing } = await searchCandidates(terms, databaseBase);
-  const entries = [];
-  let examined = 0;
-  for (const posting of postings) {
-    if (entries.length >= SEARCH_RESULT_LIMIT || examined >= SEARCH_CANDIDATE_LIMIT) break;
-    examined += 1;
-    const record = await fetchJson(postingRecordUrl(posting, databaseBase));
-    const entry = validateEntry(record, postingSummary(posting, record));
-    if (carriesEveryTerm(entry, terms)) entries.push(entry);
-  }
-  return {
-    terms,
-    dropped,
-    entries,
-    missing,
-    whole: whole && examined === postings.length,
-    examined,
-  };
-}
-
 function searchPageUrlFor(query) {
   const target = new URL("index.html", window.location.href);
   target.search = "";
@@ -741,9 +577,17 @@ async function renderSearch(query) {
   status.hidden = false;
   status.textContent = "Searching the registry…";
   try {
-    const { databaseBase } = dataSource();
+    const { databaseBase, availabilityUrl } = dataSource();
+    const availabilityPromise = loadAvailabilityBounded(availabilityUrl);
     const found = await searchRegistry(query, databaseBase);
-    for (const entry of found.entries) results.append(entryCard(entry, 1, null));
+    const availability = await availabilityPromise;
+    for (const problem of found.problems) {
+      console.warn(
+        `Search ${problem.stage} ${problem.item} could not be loaded: ` +
+          `${problem.reason?.message || String(problem.reason)}`,
+      );
+    }
+    for (const entry of found.entries) results.append(entryCard(entry, { availability }));
     if (!found.terms.length) {
       // Every word of the query is one the indexer drops, so there is nothing
       // to ask for. Saying which words those were is the difference between an
@@ -752,20 +596,32 @@ async function renderSearch(query) {
         `Every word of that search is too common to be indexed: ${found.dropped.join(", ")}.`;
       return;
     }
+    const degraded = found.problems.length
+      ? found.timedOut
+        ? "the search deadline expired before every request completed"
+        : `${found.problems.length} data request${found.problems.length === 1 ? "" : "s"} failed`
+      : "";
     if (!found.entries.length) {
       // Naming the words nothing carries is what turns "no results" into
       // something a reader can act on. The words the indexer drops are not
       // among them: they left the query before it was asked.
-      status.textContent = found.missing.length
+      status.textContent = degraded
+        ? `No verified results could be shown. The search is incomplete because ${degraded}. Try again.`
+        : found.missing.length
         ? `No result carries all of: ${found.terms.join(", ")}. Nothing is indexed under `
           + `${found.missing.join(", ")}.`
         : `No result carries all of: ${found.terms.join(", ")}.`;
+      status.classList.toggle("warning", Boolean(degraded));
       return;
     }
-    status.hidden = found.whole;
-    status.textContent = found.whole
+    status.hidden = found.whole && !degraded;
+    status.textContent = degraded
+      ? `Showing ${found.entries.length} verified result${found.entries.length === 1 ? "" : "s"}. `
+        + `The search is incomplete because ${degraded}.`
+      : found.whole
       ? ""
       : `Showing the newest ${found.entries.length} results; narrow the search for older ones.`;
+    status.classList.toggle("warning", Boolean(degraded));
   } catch (error) {
     status.textContent = `The search could not be run: ${error.message}`;
     status.classList.add("error");

--- a/assets/app.js
+++ b/assets/app.js
@@ -109,21 +109,23 @@ async function loadAvailability(url, { signal } = {}) {
   }
 }
 
-// The landing and search controllers run independently, but they need the same
-// manifest. Share one bounded read rather than doubling a large request when a
-// reader arrives at a search URL.
+// The landing and search controllers can need the same manifest. Share a
+// successful bounded read, but never make one temporary failure or timeout the
+// page's answer for the rest of its lifetime.
 const availabilityLoads = new Map();
 function loadAvailabilityBounded(url) {
   const key = url.href;
   if (!availabilityLoads.has(key)) {
-    availabilityLoads.set(
-      key,
-      loadSettledBounded(
-        [url],
-        (selected, signal) => loadAvailability(selected, { signal }),
-        { concurrency: 1, timeoutMs: AVAILABILITY_TIMEOUT_MS },
-      ).then(([loaded]) => loaded.status === "fulfilled" ? loaded.value : null),
-    );
+    const loading = loadSettledBounded(
+      [url],
+      (selected, signal) => loadAvailability(selected, { signal }),
+      { concurrency: 1, timeoutMs: AVAILABILITY_TIMEOUT_MS },
+    ).then(([loaded]) => {
+      const availability = loaded.status === "fulfilled" ? loaded.value : null;
+      if (availability === null) availabilityLoads.delete(key);
+      return availability;
+    });
+    availabilityLoads.set(key, loading);
   }
   return availabilityLoads.get(key);
 }
@@ -549,6 +551,12 @@ async function renderIndex() {
   }
 }
 
+let landingLoad = null;
+function ensureLanding() {
+  if (!landingLoad) landingLoad = renderIndex();
+  return landingLoad;
+}
+
 function searchPageUrlFor(query) {
   const target = new URL("index.html", window.location.href);
   target.search = "";
@@ -559,35 +567,54 @@ function searchPageUrlFor(query) {
   return safeInternalUrl(target, window.location.href);
 }
 
+let searchGeneration = 0;
+let activeSearchController = null;
+
+function renderSearchCards(results, entries, availability = null) {
+  results.replaceChildren(...entries.map((entry) => entryCard(entry, { availability })));
+}
+
 async function renderSearch(query) {
+  const generation = searchGeneration + 1;
+  searchGeneration = generation;
+  activeSearchController?.abort(new Error("superseded registry search"));
+  activeSearchController = null;
   const status = document.querySelector("#search-status");
   const results = document.querySelector("#search-results");
-  const grid = document.querySelector("#entry-grid");
-  const toolbar = document.querySelector(".toolbar");
   if (!status || !results) return;
   results.replaceChildren();
   status.className = "status";
   const searching = Boolean(searchTerms(query).length);
-  if (grid) grid.hidden = searching;
-  if (toolbar) toolbar.hidden = searching;
+  document.body.classList.toggle("registry-searching", searching);
   if (!searching) {
     status.hidden = true;
+    ensureLanding();
     return;
   }
+  const controller = new AbortController();
+  activeSearchController = controller;
   status.hidden = false;
   status.textContent = "Searching the registry…";
   try {
     const { databaseBase, availabilityUrl } = dataSource();
-    const availabilityPromise = loadAvailabilityBounded(availabilityUrl);
-    const found = await searchRegistry(query, databaseBase);
-    const availability = await availabilityPromise;
+    const found = await searchRegistry(query, databaseBase, { signal: controller.signal });
+    if (generation !== searchGeneration) return;
     for (const problem of found.problems) {
       console.warn(
         `Search ${problem.stage} ${problem.item} could not be loaded: ` +
           `${problem.reason?.message || String(problem.reason)}`,
       );
     }
-    for (const entry of found.entries) results.append(entryCard(entry, { availability }));
+    // Availability changes only where a source link points. It must never hold
+    // verified registry results behind its own long timeout.
+    renderSearchCards(results, found.entries);
+    if (found.entries.length) {
+      void loadAvailabilityBounded(availabilityUrl).then((availability) => {
+        if (availability !== null && generation === searchGeneration) {
+          renderSearchCards(results, found.entries, availability);
+        }
+      });
+    }
     if (!found.terms.length) {
       // Every word of the query is one the indexer drops, so there is nothing
       // to ask for. Saying which words those were is the difference between an
@@ -623,15 +650,18 @@ async function renderSearch(query) {
       : `Showing the newest ${found.entries.length} results; narrow the search for older ones.`;
     status.classList.toggle("warning", Boolean(degraded));
   } catch (error) {
+    if (generation !== searchGeneration) return;
     status.textContent = `The search could not be run: ${error.message}`;
     status.classList.add("error");
+  } finally {
+    if (generation === searchGeneration) activeSearchController = null;
   }
 }
 
 function wireSearch() {
   const form = document.querySelector("#registry-search");
   const input = document.querySelector("#query");
-  if (!form || !input) return;
+  if (!form || !input) return false;
   const initial = params.get("q") || "";
   input.value = initial;
   form.addEventListener("submit", (event) => {
@@ -643,6 +673,7 @@ function wireSearch() {
     renderSearch(query);
   });
   if (initial) renderSearch(initial);
+  return Boolean(searchTerms(initial).length);
 }
 
 function detailRow(label, value) {
@@ -1752,10 +1783,10 @@ async function renderChallengePage() {
 }
 
 if (document.body.dataset.page === "index") {
-  // Wired first and run independently of the listing, so that arriving at a
-  // search link does not wait for every record on the landing page to load.
-  wireSearch();
-  renderIndex();
+  // A linked search is its own view. Avoid fetching and exposing a hidden
+  // recent listing until the query is cleared; then load it exactly once.
+  const hasInitialSearch = wireSearch();
+  if (!hasInitialSearch) ensureLanding();
 }
 if (document.body.dataset.page === "entry") renderEntryPage();
 if (document.body.dataset.page === "render") renderChallengePage();

--- a/assets/loading.mjs
+++ b/assets/loading.mjs
@@ -10,7 +10,7 @@
 export async function loadSettledBounded(
   items,
   load,
-  { concurrency, timeoutMs },
+  { concurrency, timeoutMs, signal = null },
 ) {
   if (!Array.isArray(items)) throw new TypeError("items must be an array");
   if (typeof load !== "function") throw new TypeError("load must be a function");
@@ -20,11 +20,17 @@ export async function loadSettledBounded(
   if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
     throw new RangeError("timeoutMs must be positive");
   }
+  if (signal !== null && !(signal instanceof AbortSignal)) {
+    throw new TypeError("signal must be an AbortSignal");
+  }
 
   const results = new Array(items.length);
   const controller = new AbortController();
   const deadlineError = new Error(`load deadline of ${timeoutMs}ms expired`);
   const timer = setTimeout(() => controller.abort(deadlineError), timeoutMs);
+  const abortFromParent = () => controller.abort(signal.reason);
+  if (signal?.aborted) abortFromParent();
+  else signal?.addEventListener("abort", abortFromParent, { once: true });
   let next = 0;
 
   /**
@@ -91,6 +97,7 @@ export async function loadSettledBounded(
     await Promise.all(workers);
   } finally {
     clearTimeout(timer);
+    signal?.removeEventListener("abort", abortFromParent);
   }
   return results;
 }

--- a/assets/searching.mjs
+++ b/assets/searching.mjs
@@ -229,20 +229,32 @@ export function createRegistrySearch(
       }
 
       const candidates = postings.slice(0, candidateLimit);
-      const recordResults = await settle(candidates, async (posting, signal) => {
-        const record = await fetchJson(postingRecordUrl(posting, databaseBase), { signal });
-        return validateEntry(record, postingSummary(posting, record));
-      });
       const entries = [];
       let examined = 0;
-      for (const [position, loaded] of recordResults.entries()) {
-        if (entries.length >= resultLimit) break;
-        examined += 1;
-        if (loaded.status === "rejected") {
-          note("record", candidates[position], loaded.reason);
-        } else if (carriesEveryTerm(loaded.value, terms)) {
-          entries.push(loaded.value);
+      // Load one concurrency-sized wave at a time. This keeps several records
+      // in flight without eagerly fetching all sixty when the first twenty are
+      // already results. A wave settles in input order, so the output remains
+      // deterministic however its requests complete.
+      for (
+        let first = 0;
+        first < candidates.length && entries.length < resultLimit;
+        first += concurrency
+      ) {
+        const batch = candidates.slice(first, first + concurrency);
+        const loadedBatch = await settle(batch, async (posting, signal) => {
+          const record = await fetchJson(postingRecordUrl(posting, databaseBase), { signal });
+          return validateEntry(record, postingSummary(posting, record));
+        });
+        for (const [position, loaded] of loadedBatch.entries()) {
+          if (entries.length >= resultLimit) break;
+          examined += 1;
+          if (loaded.status === "rejected") {
+            note("record", batch[position], loaded.reason);
+          } else if (carriesEveryTerm(loaded.value, terms)) {
+            entries.push(loaded.value);
+          }
         }
+        if (deadlineController.signal.aborted) break;
       }
 
       return result({

--- a/assets/searching.mjs
+++ b/assets/searching.mjs
@@ -41,6 +41,32 @@ function postingSummary(posting, entry) {
   };
 }
 
+/** Group postings by result under one record-read budget, newest version first. */
+function candidateGroups(postings, limit) {
+  const groups = new Map();
+  for (const [position, posting] of postings.entries()) {
+    const match = POSTING_RE.exec(posting);
+    const id = match[1];
+    const version = Number(match[2]);
+    if (!groups.has(id)) groups.set(id, { id, position, postings: new Map() });
+    groups.get(id).postings.set(version, posting);
+  }
+  const available = [...groups.values()]
+    .reduce((count, group) => count + group.postings.size, 0);
+  const selected = [];
+  let remaining = limit;
+  for (const group of [...groups.values()].sort((left, right) => left.position - right.position)) {
+    if (!remaining) break;
+    const candidates = [...group.postings.entries()]
+      .sort(([left], [right]) => right - left)
+      .slice(0, remaining)
+      .map(([, posting]) => posting);
+    selected.push({ ...group, postings: candidates });
+    remaining -= candidates.length;
+  }
+  return { groups: selected, complete: available <= limit };
+}
+
 /** Whether a record really carries every word of the query. */
 function carriesEveryTerm(entry, terms) {
   const words = new Set([
@@ -57,7 +83,8 @@ function carriesEveryTerm(entry, terms) {
  * Heads, posting pages and records each load concurrently through the same
  * bounded loader used by the landing page. Every stage shares one deadline,
  * so a sequence of slow stages cannot each claim a fresh timeout. Fulfilled
- * values retain publisher order even when requests complete out of order.
+ * values retain publisher order even when requests complete out of order. A
+ * caller signal joins that deadline so a new UI query can stop the old one.
  */
 export function createRegistrySearch(
   fetchJson,
@@ -84,13 +111,19 @@ export function createRegistrySearch(
   // cached, so a later query can recover without reloading the page.
   const stopwordsByBase = new Map();
 
-  return async function searchRegistry(query, databaseBase) {
+  return async function searchRegistry(query, databaseBase, { signal = null } = {}) {
+    if (signal !== null && !(signal instanceof AbortSignal)) {
+      throw new TypeError("signal must be an AbortSignal");
+    }
     const asked = [...new Set(searchTerms(query))];
     const problems = [];
     const deadlineController = new AbortController();
     const deadlineError = new Error(`search deadline of ${timeoutMs}ms expired`);
     deadlineError.name = "TimeoutError";
     const timer = setTimeout(() => deadlineController.abort(deadlineError), timeoutMs);
+    const abortFromCaller = () => deadlineController.abort(signal.reason);
+    if (signal?.aborted) abortFromCaller();
+    else signal?.addEventListener("abort", abortFromCaller, { once: true });
     const baseKey = new URL(databaseBase).href;
     const settle = (items, load) => loadSettledBounded(items, load, {
       concurrency,
@@ -99,7 +132,6 @@ export function createRegistrySearch(
     });
     const note = (stage, item, reason) => problems.push({ stage, item, reason });
     const result = (fields) => ({
-      asked,
       problems,
       timedOut: deadlineController.signal.reason === deadlineError,
       ...fields,
@@ -228,33 +260,55 @@ export function createRegistrySearch(
         return result({ terms, dropped, entries: [], whole: false, examined: 0, missing });
       }
 
-      const candidates = postings.slice(0, candidateLimit);
+      // Group the bounded page data before applying the record-read cap. That
+      // finds the numerically newest candidate even when v10 does not sort
+      // after v9 lexically, while the sum of every group's fallbacks remains
+      // capped at `candidateLimit`.
+      const candidatePlan = candidateGroups(postings, candidateLimit);
+      const candidates = candidatePlan.groups;
       const entries = [];
       let examined = 0;
-      // Load one concurrency-sized wave at a time. This keeps several records
-      // in flight without eagerly fetching all sixty when the first twenty are
-      // already results. A wave settles in input order, so the output remains
-      // deterministic however its requests complete.
-      for (
-        let first = 0;
-        first < candidates.length && entries.length < resultLimit;
-        first += concurrency
-      ) {
-        const batch = candidates.slice(first, first + concurrency);
-        const loadedBatch = await settle(batch, async (posting, signal) => {
-          const record = await fetchJson(postingRecordUrl(posting, databaseBase), { signal });
-          return validateEntry(record, postingSummary(posting, record));
-        });
-        for (const [position, loaded] of loadedBatch.entries()) {
-          if (entries.length >= resultLimit) break;
-          examined += 1;
-          if (loaded.status === "rejected") {
-            note("record", batch[position], loaded.reason);
-          } else if (carriesEveryTerm(loaded.value, terms)) {
-            entries.push(loaded.value);
+      let next = 0;
+      let position = 0;
+      const pending = new Map();
+      const start = (index) => {
+        const group = candidates[index];
+        pending.set(index, settle([group], async (selected, loadSignal) => {
+          // Usually only the newest candidate is read. An older version is a
+          // fallback only when the newer valid record does not carry every
+          // term that could not safely be intersected from complete postings.
+          for (const posting of selected.postings) {
+            const record = await fetchJson(postingRecordUrl(posting, databaseBase), {
+              signal: loadSignal,
+            });
+            examined += 1;
+            const entry = validateEntry(record, postingSummary(posting, record));
+            if (carriesEveryTerm(entry, terms)) return entry;
           }
+          return null;
+        }).then(([loaded]) => loaded));
+        next += 1;
+      };
+      while (next < Math.min(concurrency, candidates.length)) start(next);
+      while (position < candidates.length && entries.length < resultLimit) {
+        const loaded = await pending.get(position);
+        pending.delete(position);
+        if (loaded.status === "rejected") {
+          note("record", candidates[position].postings[0], loaded.reason);
+        } else if (loaded.value) {
+          entries.push(loaded.value);
+        }
+        position += 1;
+        // Keep at most `concurrency - 1` speculative groups ahead of the
+        // deterministic output cursor. Unlike fixed waves, one settled prefix
+        // position immediately admits the next candidate.
+        if (entries.length < resultLimit) {
+          while (next < candidates.length && next < position + concurrency) start(next);
         }
         if (deadlineController.signal.aborted) break;
+      }
+      if (entries.length === resultLimit && pending.size) {
+        deadlineController.abort(new Error("search result limit satisfied"));
       }
 
       return result({
@@ -262,11 +316,13 @@ export function createRegistrySearch(
         dropped,
         entries,
         missing,
-        whole: driverWhole && examined === postings.length && !problems.length,
+        whole: driverWhole && candidatePlan.complete &&
+          position === candidates.length && !problems.length,
         examined,
       });
     } finally {
       clearTimeout(timer);
+      signal?.removeEventListener("abort", abortFromCaller);
     }
   };
 }

--- a/assets/searching.mjs
+++ b/assets/searching.mjs
@@ -162,7 +162,7 @@ export function createRegistrySearch(
       const dropped = asked.filter((term) => dropping.has(term));
       const terms = asked.filter((term) => !dropping.has(term));
       if (!terms.length) {
-        return result({ terms, dropped, entries: [], whole: !problems.length, examined: 0, missing: [] });
+        return result({ terms, dropped, entries: [], whole: !problems.length, missing: [] });
       }
 
       // Input order is retained by the loader. The explicit position tie-break
@@ -196,7 +196,6 @@ export function createRegistrySearch(
           dropped,
           entries: [],
           whole: Boolean(missing.length) && !problems.length,
-          examined: 0,
           missing,
         });
       }
@@ -257,7 +256,7 @@ export function createRegistrySearch(
       }
 
       if (postings === null) {
-        return result({ terms, dropped, entries: [], whole: false, examined: 0, missing });
+        return result({ terms, dropped, entries: [], whole: false, missing });
       }
 
       // Group the bounded page data before applying the record-read cap. That
@@ -267,7 +266,6 @@ export function createRegistrySearch(
       const candidatePlan = candidateGroups(postings, candidateLimit);
       const candidates = candidatePlan.groups;
       const entries = [];
-      let examined = 0;
       let next = 0;
       let position = 0;
       const pending = new Map();
@@ -277,26 +275,34 @@ export function createRegistrySearch(
           // Usually only the newest candidate is read. An older version is a
           // fallback only when the newer valid record does not carry every
           // term that could not safely be intersected from complete postings.
+          const failures = [];
           for (const posting of selected.postings) {
-            const record = await fetchJson(postingRecordUrl(posting, databaseBase), {
-              signal: loadSignal,
-            });
-            examined += 1;
-            const entry = validateEntry(record, postingSummary(posting, record));
-            if (carriesEveryTerm(entry, terms)) return entry;
+            try {
+              const record = await fetchJson(postingRecordUrl(posting, databaseBase), {
+                signal: loadSignal,
+              });
+              const entry = validateEntry(record, postingSummary(posting, record));
+              if (carriesEveryTerm(entry, terms)) return { entry, failures };
+            } catch (reason) {
+              failures.push({ posting, reason });
+              if (loadSignal.aborted) break;
+            }
           }
-          return null;
+          return { entry: null, failures };
         }).then(([loaded]) => loaded));
         next += 1;
       };
-      while (next < Math.min(concurrency, candidates.length)) start(next);
+      while (next < Math.min(concurrency, candidates.length, resultLimit)) start(next);
       while (position < candidates.length && entries.length < resultLimit) {
         const loaded = await pending.get(position);
         pending.delete(position);
         if (loaded.status === "rejected") {
           note("record", candidates[position].postings[0], loaded.reason);
-        } else if (loaded.value) {
-          entries.push(loaded.value);
+        } else {
+          for (const failure of loaded.value.failures) {
+            note("record", failure.posting, failure.reason);
+          }
+          if (loaded.value.entry) entries.push(loaded.value.entry);
         }
         position += 1;
         // Keep at most `concurrency - 1` speculative groups ahead of the
@@ -318,7 +324,6 @@ export function createRegistrySearch(
         missing,
         whole: driverWhole && candidatePlan.complete &&
           position === candidates.length && !problems.length,
-        examined,
       });
     } finally {
       clearTimeout(timer);

--- a/assets/searching.mjs
+++ b/assets/searching.mjs
@@ -1,0 +1,260 @@
+import { loadSettledBounded } from "./loading.mjs";
+import {
+  postingRecordUrl,
+  searchHeadUrl,
+  searchPageUrl,
+  searchTerms,
+  stopwordsUrl,
+  validateEntry,
+  validateSearchHead,
+  validateSearchPage,
+  validateStopwords,
+} from "./security.mjs";
+
+// These are request bounds, not guesses about how large the registry will be.
+// A query can therefore become incomplete, but it cannot make browser work grow
+// without limit with either a common word or a large result set.
+export const SEARCH_PAGE_BUDGET = 16;
+export const SEARCH_RESULT_LIMIT = 20;
+export const SEARCH_CANDIDATE_LIMIT = 60;
+export const SEARCH_IO_CONCURRENCY = 8;
+export const SEARCH_TIMEOUT_MS = 30_000;
+
+const POSTING_RE = /^(PALOMAR-\d{4}-\d{2}-\d{2}-\d{6})-v([1-9]\d*)$/;
+
+/**
+ * The summary a fetched record is checked against.
+ *
+ * A posting claims only that a version carries one word. It does not carry the
+ * mutable facts a card might otherwise want, such as whether that version is
+ * current or how many active versions the result has. Those must not be
+ * invented here.
+ */
+function postingSummary(posting, entry) {
+  const match = POSTING_RE.exec(posting);
+  return {
+    id: match[1],
+    version: Number(match[2]),
+    title: entry.title,
+    status: entry.status,
+    path: `entries/${posting}.json`,
+  };
+}
+
+/** Whether a record really carries every word of the query. */
+function carriesEveryTerm(entry, terms) {
+  const words = new Set([
+    ...searchTerms(entry.title),
+    ...searchTerms(entry.abstract),
+    ...entry.authors.flatMap((author) => searchTerms(author.name)),
+  ]);
+  return terms.every((term) => words.has(term));
+}
+
+/**
+ * Build the page's registry search around its JSON transport.
+ *
+ * Heads, posting pages and records each load concurrently through the same
+ * bounded loader used by the landing page. Every stage shares one deadline,
+ * so a sequence of slow stages cannot each claim a fresh timeout. Fulfilled
+ * values retain publisher order even when requests complete out of order.
+ */
+export function createRegistrySearch(
+  fetchJson,
+  {
+    concurrency = SEARCH_IO_CONCURRENCY,
+    timeoutMs = SEARCH_TIMEOUT_MS,
+    pageBudget = SEARCH_PAGE_BUDGET,
+    resultLimit = SEARCH_RESULT_LIMIT,
+    candidateLimit = SEARCH_CANDIDATE_LIMIT,
+  } = {},
+) {
+  if (typeof fetchJson !== "function") throw new TypeError("fetchJson must be a function");
+  for (const [name, value] of [
+    ["pageBudget", pageBudget],
+    ["resultLimit", resultLimit],
+    ["candidateLimit", candidateLimit],
+  ]) {
+    if (!Number.isSafeInteger(value) || value < 1) {
+      throw new RangeError(`${name} must be a positive integer`);
+    }
+  }
+
+  // One editorial constant per selected data origin. A failed read is not
+  // cached, so a later query can recover without reloading the page.
+  const stopwordsByBase = new Map();
+
+  return async function searchRegistry(query, databaseBase) {
+    const asked = [...new Set(searchTerms(query))];
+    const problems = [];
+    const deadlineController = new AbortController();
+    const deadlineError = new Error(`search deadline of ${timeoutMs}ms expired`);
+    deadlineError.name = "TimeoutError";
+    const timer = setTimeout(() => deadlineController.abort(deadlineError), timeoutMs);
+    const baseKey = new URL(databaseBase).href;
+    const settle = (items, load) => loadSettledBounded(items, load, {
+      concurrency,
+      timeoutMs,
+      signal: deadlineController.signal,
+    });
+    const note = (stage, item, reason) => problems.push({ stage, item, reason });
+    const result = (fields) => ({
+      asked,
+      problems,
+      timedOut: deadlineController.signal.reason === deadlineError,
+      ...fields,
+    });
+
+    try {
+      let dropping = stopwordsByBase.get(baseKey);
+      if (!dropping) {
+        const [loaded] = await settle(
+          [baseKey],
+          async (_base, signal) =>
+            validateStopwords(await fetchJson(stopwordsUrl(databaseBase), { signal })),
+        );
+        if (loaded.status === "fulfilled") {
+          dropping = loaded.value;
+          stopwordsByBase.set(baseKey, dropping);
+        } else if (loaded.reason?.status === 404) {
+          // Legacy data origins did not publish the editorial list. Keeping
+          // every word is conservative: records still have to match exactly.
+          dropping = new Set();
+          stopwordsByBase.set(baseKey, dropping);
+        } else {
+          dropping = new Set();
+          note("stopwords", "search/stopwords.json", loaded.reason);
+        }
+      }
+
+      const dropped = asked.filter((term) => dropping.has(term));
+      const terms = asked.filter((term) => !dropping.has(term));
+      if (!terms.length) {
+        return result({ terms, dropped, entries: [], whole: !problems.length, examined: 0, missing: [] });
+      }
+
+      // Input order is retained by the loader. The explicit position tie-break
+      // below makes the rarest-word selection independent of completion order.
+      const headResults = await settle(terms, async (term, signal) => {
+        try {
+          return validateSearchHead(
+            await fetchJson(searchHeadUrl(term, databaseBase), { signal }),
+            term,
+          );
+        } catch (error) {
+          if (error.status === 404) return null;
+          throw error;
+        }
+      });
+      const heads = [];
+      const missing = [];
+      for (const [position, loaded] of headResults.entries()) {
+        const term = terms[position];
+        if (loaded.status === "rejected") note("head", term, loaded.reason);
+        else if (loaded.value?.results > 0) heads.push({ term, head: loaded.value, position });
+        else missing.push(term);
+      }
+
+      // A successfully read missing head proves the intersection empty. Failed
+      // independent requests are still reported, rather than being presented
+      // as a clean search.
+      if (missing.length || !heads.length) {
+        return result({
+          terms,
+          dropped,
+          entries: [],
+          whole: Boolean(missing.length) && !problems.length,
+          examined: 0,
+          missing,
+        });
+      }
+
+      heads.sort((left, right) =>
+        left.head.results - right.head.results || left.position - right.position,
+      );
+
+      // Choose the same bounded intersection plan as the former serial reader,
+      // then fetch the chosen pages together. Only a complete secondary
+      // sequence may narrow the driver; intersecting against half a sequence
+      // would silently remove genuine matches.
+      let budget = pageBudget;
+      const groups = [];
+      for (const item of heads) {
+        if (groups.length && item.head.pages > budget) break;
+        const wanted = Math.min(item.head.pages, budget);
+        if (wanted === 0) break;
+        const first = item.head.pages - wanted;
+        const pages = [];
+        for (let number = item.head.pages - 1; number >= first; number -= 1) {
+          pages.push({ ...item, number });
+        }
+        groups.push({ ...item, first, wanted, pages });
+        budget -= wanted;
+        if (budget === 0) break;
+      }
+      const requestedPages = groups.flatMap((group) => group.pages);
+      const pageResults = await settle(requestedPages, async (request, signal) =>
+        validateSearchPage(
+          await fetchJson(searchPageUrl(request.term, request.number, databaseBase), { signal }),
+          request.term,
+          request.number,
+          request.head,
+        ),
+      );
+
+      let offset = 0;
+      let postings = null;
+      let driverWhole = false;
+      for (const group of groups) {
+        const loaded = pageResults.slice(offset, offset + group.pages.length);
+        offset += group.pages.length;
+        const complete = loaded.every((page) => page.status === "fulfilled");
+        const pulled = [];
+        for (const [position, page] of loaded.entries()) {
+          if (page.status === "fulfilled") pulled.push(...[...page.value.postings].reverse());
+          else note("page", `${group.term}/${group.pages[position].number}`, page.reason);
+        }
+        if (!pulled.length) continue;
+        if (postings === null) {
+          postings = pulled;
+          driverWhole = complete && group.first === 0;
+        } else if (complete) {
+          const carried = new Set(pulled);
+          postings = postings.filter((posting) => carried.has(posting));
+        }
+      }
+
+      if (postings === null) {
+        return result({ terms, dropped, entries: [], whole: false, examined: 0, missing });
+      }
+
+      const candidates = postings.slice(0, candidateLimit);
+      const recordResults = await settle(candidates, async (posting, signal) => {
+        const record = await fetchJson(postingRecordUrl(posting, databaseBase), { signal });
+        return validateEntry(record, postingSummary(posting, record));
+      });
+      const entries = [];
+      let examined = 0;
+      for (const [position, loaded] of recordResults.entries()) {
+        if (entries.length >= resultLimit) break;
+        examined += 1;
+        if (loaded.status === "rejected") {
+          note("record", candidates[position], loaded.reason);
+        } else if (carriesEveryTerm(loaded.value, terms)) {
+          entries.push(loaded.value);
+        }
+      }
+
+      return result({
+        terms,
+        dropped,
+        entries,
+        missing,
+        whole: driverWhole && examined === postings.length && !problems.length,
+        examined,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -217,6 +217,12 @@ h3 {
   font: .85rem/1.3 var(--sans);
 }
 
+body.registry-searching .toolbar,
+body.registry-searching #status,
+body.registry-searching #entry-grid {
+  display: none;
+}
+
 .search {
   display: flex;
   align-items: center;

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 const root = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 export const htmlFiles = ["404.html", "about.html", "entry.html", "index.html", "render.html"];
 const publicFiles = [...htmlFiles, "site.webmanifest", "favicon.svg"];
-const appModules = ["loading.mjs", "rendering.js", "security.mjs"];
+const appModules = ["loading.mjs", "rendering.js", "searching.mjs", "security.mjs"];
 const assetFiles = [
   "about.js",
   "app.js",

--- a/tests/build-site.test.js
+++ b/tests/build-site.test.js
@@ -24,7 +24,9 @@ test("deployment build versions coupled browser assets", async () => {
     assert.match(app, /\.\/rendering\.js\?v=0123456789abcdef/);
     assert.match(app, /\.\/security\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/loading\.mjs\?v=0123456789abcdef/);
+    assert.match(app, /\.\/searching\.mjs\?v=0123456789abcdef/);
     await readFile(path.join(destination, "assets", "loading.mjs"), "utf8");
+    await readFile(path.join(destination, "assets", "searching.mjs"), "utf8");
     await readFile(path.join(destination, "assets", "security.mjs"), "utf8");
   } finally {
     await rm(destination, { recursive: true, force: true });

--- a/tests/loading.test.js
+++ b/tests/loading.test.js
@@ -61,3 +61,30 @@ test("the deadline settles a load that ignores its abort signal", async () => {
   assert.equal(results[0].status, "rejected");
   assert.match(results[0].reason.message, /deadline of 30ms expired/);
 });
+
+test("a parent deadline is shared across a sequence of bounded loads", async () => {
+  const controller = new AbortController();
+  const reason = new Error("overall search deadline expired");
+  const timer = setTimeout(() => controller.abort(reason), 30);
+  const before = Date.now();
+  try {
+    const first = await loadSettledBounded(
+      ["quick"],
+      async (value) => value,
+      { concurrency: 1, timeoutMs: 500, signal: controller.signal },
+    );
+    assert.equal(first[0].status, "fulfilled");
+
+    const second = await loadSettledBounded(
+      ["hung", "queued"],
+      () => new Promise(() => {}),
+      { concurrency: 1, timeoutMs: 500, signal: controller.signal },
+    );
+    assert.ok(Date.now() - before < 500, "the parent deadline did not bound both stages");
+    assert.deepEqual(second.map((result) => result.status), ["rejected", "rejected"]);
+    assert.equal(second[0].reason, reason);
+    assert.equal(second[1].reason, reason);
+  } finally {
+    clearTimeout(timer);
+  }
+});

--- a/tests/registry-fixture.mjs
+++ b/tests/registry-fixture.mjs
@@ -151,18 +151,21 @@ export function entry(overrides = {}) {
 /** A complete valid record with a different identity, for ordered-list tests. */
 export function identifiedEntry(serial, overrides = {}) {
   const id = `PALOMAR-2026-07-29-${String(serial).padStart(6, "0")}`;
-  const value = entry({
+  const version = overrides.version ?? 1;
+  const values = {
     id,
     title: `Search fixture ${serial}`,
     abstract: "Alpha beta searchable fixture.",
     ...overrides,
-  });
+  };
+  const value = version === 1 ? entry(values) : secondVersion(values);
   value.submission.submission_id = String(serial).padStart(12, "0");
-  value.verification.evidence_path = `evidence/${id}-v1/${value.verification.evidence_tree_sha256}/`;
+  value.verification.evidence_path =
+    `evidence/${id}-v${version}/${value.verification.evidence_tree_sha256}/`;
   value.challenge_render.artifact_path =
-    `renders/${id}-v1/${value.challenge_render.artifact_tree_sha256}/`;
+    `renders/${id}-v${version}/${value.challenge_render.artifact_tree_sha256}/`;
   for (const repository of value.preservation.repositories) {
-    repository.ref = `refs/tags/palomar/${id}-v1/${repository.commit}`;
+    repository.ref = `refs/tags/palomar/${id}-v${version}/${repository.commit}`;
   }
   return value;
 }

--- a/tests/registry-fixture.mjs
+++ b/tests/registry-fixture.mjs
@@ -1,0 +1,168 @@
+export const COMMIT = "1".repeat(40);
+export const DIGEST = "a".repeat(64);
+
+export function summary(overrides = {}) {
+  return {
+    id: "PALOMAR-2026-07-29-000123",
+    version: 1,
+    title: "Fixture theorem",
+    status: "accepted",
+    path: "entries/PALOMAR-2026-07-29-000123-v1.json",
+    ...overrides,
+  };
+}
+
+/** The same record as a second version, with every path that names the version moved. */
+export function secondVersion(overrides = {}) {
+  const value = entry({ version: 2, ...overrides });
+  value.challenge_render.artifact_path = `renders/${value.id}-v2/${DIGEST}/`;
+  value.verification.evidence_path = `evidence/${value.id}-v2/${"c".repeat(64)}/`;
+  for (const repository of value.preservation.repositories) {
+    repository.ref = `refs/tags/palomar/${value.id}-v2/${repository.commit}`;
+  }
+  return value;
+}
+
+export function recentRow(overrides = {}) {
+  return { ...summary(), published_at: "2026-07-29T09:14:07Z", versions: 1, ...overrides };
+}
+
+export function recent(entries = [recentRow()], overrides = {}) {
+  return { schema_version: 1, entries, ...overrides };
+}
+
+export function entry(overrides = {}) {
+  const evidenceTree = "c".repeat(64);
+  const value = {
+    schema_version: 2,
+    id: "PALOMAR-2026-07-29-000123",
+    accepted_at: "2026-07-29",
+    registered_at: "2026-07-29T09:14:07Z",
+    version: 1,
+    status: "accepted",
+    title: "Fixture theorem",
+    abstract: "A security fixture.",
+    authors: [{ name: "Example" }],
+    classification: { arxiv: ["math.CO"], msc2020: ["05C10"] },
+    submission: {
+      submission_id: "a1b2c3d4e5f6",
+      authorization: { relationship: "maintainer" },
+    },
+    provenance: {
+      result_origin: "original",
+      repository_role: "substantive-development",
+      responsible_maintainers: [{ name: "Example" }],
+      mathematical_sources: [],
+      related_formalizations: [],
+    },
+    source: {
+      repository: "example/challenge",
+      repository_url: "https://github.com/example/challenge",
+      commit: COMMIT,
+      tree_url: `https://github.com/example/challenge/tree/${COMMIT}`,
+      license: {
+        path: "LICENSE",
+        sha256: DIGEST,
+        declared_identifier: "Apache-2.0",
+        detected_identifier: "Apache-2.0",
+      },
+    },
+    preservation: {
+      archive_owner: "PalomarArchive",
+      archived_at: "2026-07-29T09:01:00Z",
+      receipt_sha256: "f".repeat(64),
+      repositories: [
+        {
+          source_repository: "example/challenge",
+          commit: COMMIT,
+          fork_repository: "PalomarArchive/example--challenge--fixture",
+          ref: `refs/tags/palomar/PALOMAR-2026-07-29-000123-v1/${COMMIT}`,
+        },
+        {
+          source_repository: "leanprover-community/mathlib4",
+          commit: COMMIT,
+          fork_repository: "PalomarArchive/mathlib4--fixture",
+          ref: `refs/tags/palomar/PALOMAR-2026-07-29-000123-v1/${COMMIT}`,
+        },
+      ],
+    },
+    formalization: {
+      challenge_path: "Challenge.lean",
+      solution_path: "Solution.lean",
+      comparator_config_path: "comparator.json",
+      formalization_metadata_path: "formalization.yaml",
+      lakefile_path: "lakefile.toml",
+      lean_toolchain: "leanprover/lean4:v4.31.0",
+      theorem_names: ["Example.theorem"],
+      definition_names: [],
+      permitted_axioms: [],
+      project_dependencies: [
+        { name: "mathlib", repository: "leanprover-community/mathlib4", revision: COMMIT },
+      ],
+    },
+    verification: {
+      repository: "PalomarRegistry/PalomarSubmission",
+      run_id: 12345,
+      workflow_path: ".github/workflows/submission.yml",
+      comparator_commit: "2".repeat(40),
+      lean4export_commit: "3".repeat(40),
+      landrun_commit: "4".repeat(40),
+      nanoda_commit: "9".repeat(40),
+      verified_at: "2026-07-29T08:46:32Z",
+      workflow_url: "https://github.com/PalomarRegistry/PalomarSubmission/actions/runs/12345",
+      workflow_commit: "8".repeat(40),
+      workflow_run_attempt: 1,
+      challenge_sha256: DIGEST,
+      solution_sha256: "b".repeat(64),
+      evidence_tree_sha256: evidenceTree,
+      mechanical_report_sha256: "d".repeat(64),
+      evidence_path: `evidence/PALOMAR-2026-07-29-000123-v1/${evidenceTree}/`,
+    },
+    trust: {
+      level: "high",
+      challenge_lines: 10,
+      challenge_bytes: 200,
+      challenge_imports: ["Mathlib"],
+      challenge_dependencies: [],
+      reasons: [],
+    },
+    review: {
+      reviewed_at: "2026-07-29T08:53:02Z",
+      policy_commit: "5".repeat(40),
+      verdict: "accept",
+      report: { sha256: "e".repeat(64) },
+      reviewer_models: ["fixture:model"],
+      warnings: [],
+    },
+    challenge_render: {
+      format: "verso-html",
+      artifact_path: `renders/PALOMAR-2026-07-29-000123-v1/${DIGEST}/`,
+      entrypoint: "Challenge/index.html",
+      artifact_tree_sha256: DIGEST,
+      verso_commit: "6".repeat(40),
+      renderer_commit: "7".repeat(40),
+      landrun_commit: "8".repeat(40),
+      rendered_at: "2026-07-29T09:00:00Z",
+    },
+  };
+  return Object.assign(value, overrides);
+}
+
+/** A complete valid record with a different identity, for ordered-list tests. */
+export function identifiedEntry(serial, overrides = {}) {
+  const id = `PALOMAR-2026-07-29-${String(serial).padStart(6, "0")}`;
+  const value = entry({
+    id,
+    title: `Search fixture ${serial}`,
+    abstract: "Alpha beta searchable fixture.",
+    ...overrides,
+  });
+  value.submission.submission_id = String(serial).padStart(12, "0");
+  value.verification.evidence_path = `evidence/${id}-v1/${value.verification.evidence_tree_sha256}/`;
+  value.challenge_render.artifact_path =
+    `renders/${id}-v1/${value.challenge_render.artifact_tree_sha256}/`;
+  for (const repository of value.preservation.repositories) {
+    repository.ref = `refs/tags/palomar/${id}-v1/${repository.commit}`;
+  }
+  return value;
+}

--- a/tests/searching.test.js
+++ b/tests/searching.test.js
@@ -126,7 +126,7 @@ test("one overall deadline bounds every search stage, including an abort-ignorin
   assert.deepEqual(result.problems.map((problem) => problem.stage), ["page"]);
 });
 
-test("page, candidate, result, and concurrency limits remain hard bounds", async () => {
+test("page, candidate, and concurrency limits remain hard bounds", async () => {
   const postings = Array.from({ length: 100 }, (_unused, index) => posting(index + 1));
   let active = 0;
   let maximumActive = 0;
@@ -149,7 +149,10 @@ test("page, candidate, result, and concurrency limits remain hard bounds", async
       await wait(1);
       active -= 1;
       const serial = Number(path.match(/-([0-9]{6})-v1\.json$/)[1]);
-      return identifiedEntry(serial);
+      return identifiedEntry(serial, {
+        title: `Nonmatching fixture ${serial}`,
+        abstract: "Gamma delta fixture.",
+      });
     }
     throw new Error(`unexpected request ${path}`);
   };
@@ -169,9 +172,38 @@ test("page, candidate, result, and concurrency limits remain hard bounds", async
     Array.from({ length: 16 }, (_unused, index) => index + 4),
   );
   assert.equal(recordRequests, 60);
+  assert.equal(result.entries.length, 0);
+  assert.ok(maximumActive <= 4);
+  assert.equal(result.whole, false);
+});
+
+test("record waves stop after the result limit instead of eagerly loading every candidate", async () => {
+  const postings = Array.from({ length: 100 }, (_unused, index) => posting(index + 1));
+  let recordRequests = 0;
+  const fetchJson = async (url) => {
+    const path = new URL(url).pathname;
+    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/t/alpha/head.json") return head("alpha", 100, 100);
+    if (path === "/search/t/alpha/0.json") return page("alpha", 0, postings);
+    if (path.startsWith("/entries/")) {
+      recordRequests += 1;
+      const serial = Number(path.match(/-([0-9]{6})-v1\.json$/)[1]);
+      return identifiedEntry(serial);
+    }
+    throw new Error(`unexpected request ${path}`);
+  };
+  const search = createRegistrySearch(fetchJson, {
+    concurrency: 8,
+    timeoutMs: 1_000,
+    candidateLimit: 60,
+    resultLimit: 20,
+  });
+
+  const result = await search("alpha", BASE);
+
+  assert.equal(recordRequests, 24, "more than the final partial wave was fetched");
   assert.equal(result.entries.length, 20);
   assert.equal(result.entries[0].id, "PALOMAR-2026-07-29-000100");
   assert.equal(result.entries.at(-1).id, "PALOMAR-2026-07-29-000081");
-  assert.ok(maximumActive <= 4);
   assert.equal(result.whole, false);
 });

--- a/tests/searching.test.js
+++ b/tests/searching.test.js
@@ -126,6 +126,165 @@ test("one overall deadline bounds every search stage, including an abort-ignorin
   assert.deepEqual(result.problems.map((problem) => problem.stage), ["page"]);
 });
 
+test("a caller can abort the shared search deadline without reporting a timeout", async () => {
+  const fetchJson = async (url) => {
+    const path = new URL(url).pathname;
+    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/t/alpha/head.json") return head("alpha", 1, 1);
+    if (path === "/search/t/alpha/0.json") return new Promise(() => {});
+    throw new Error(`unexpected request ${path}`);
+  };
+  const search = createRegistrySearch(fetchJson, { concurrency: 2, timeoutMs: 1_000 });
+  const controller = new AbortController();
+
+  const before = Date.now();
+  const pending = search("alpha", BASE, { signal: controller.signal });
+  setTimeout(() => controller.abort(new Error("query superseded")), 20);
+  const result = await pending;
+
+  assert.ok(Date.now() - before < 500, "caller abort did not settle the search promptly");
+  assert.equal(result.timedOut, false);
+  assert.equal(result.whole, false);
+  assert.deepEqual(result.problems.map((problem) => problem.stage), ["page"]);
+});
+
+test("one failed head degrades but does not discard exact results from a healthy driver", async () => {
+  const fetchJson = async (url) => {
+    const path = new URL(url).pathname;
+    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/t/alpha/head.json") throw new Error("head unavailable");
+    if (path === "/search/t/beta/head.json") return head("beta", 1, 1);
+    if (path === "/search/t/beta/0.json") return page("beta", 0, [posting(1)]);
+    if (path.startsWith("/entries/")) return identifiedEntry(1);
+    throw new Error(`unexpected request ${path}`);
+  };
+  const search = createRegistrySearch(fetchJson, { concurrency: 2, timeoutMs: 1_000 });
+
+  const result = await search("alpha beta", BASE);
+
+  assert.deepEqual(result.entries.map((entry) => entry.id), [
+    "PALOMAR-2026-07-29-000001",
+  ]);
+  assert.deepEqual(result.problems.map((problem) => problem.stage), ["head"]);
+  assert.equal(result.whole, false);
+});
+
+test("a non-404 stopword failure is reported and retried by the next search", async () => {
+  let stopwordRequests = 0;
+  const fetchJson = async (url) => {
+    const path = new URL(url).pathname;
+    if (path === "/search/stopwords.json") {
+      stopwordRequests += 1;
+      if (stopwordRequests === 1) {
+        const error = new Error("stopwords unavailable");
+        error.status = 503;
+        throw error;
+      }
+      return { schema_version: 1, stopwords: [] };
+    }
+    if (path === "/search/t/alpha/head.json") return head("alpha", 1, 1);
+    if (path === "/search/t/alpha/0.json") return page("alpha", 0, [posting(1)]);
+    if (path.startsWith("/entries/")) return identifiedEntry(1);
+    throw new Error(`unexpected request ${path}`);
+  };
+  const search = createRegistrySearch(fetchJson, { concurrency: 2, timeoutMs: 1_000 });
+
+  const first = await search("alpha", BASE);
+  const second = await search("alpha", BASE);
+
+  assert.deepEqual(first.problems.map((problem) => problem.stage), ["stopwords"]);
+  assert.deepEqual(second.problems, []);
+  assert.equal(stopwordRequests, 2);
+});
+
+test("a secondary term that cannot fit the remaining page budget is not partly requested", async () => {
+  const requestedPages = [];
+  const postings = [posting(1), posting(2)];
+  const fetchJson = async (url) => {
+    const path = new URL(url).pathname;
+    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/t/alpha/head.json") return head("alpha", 2, 1);
+    if (path === "/search/t/beta/head.json") return head("beta", 2, 1);
+    const match = path.match(/^\/search\/t\/(alpha|beta)\/([0-9]+)\.json$/);
+    if (match) {
+      requestedPages.push(`${match[1]}/${match[2]}`);
+      const number = Number(match[2]);
+      return page(match[1], number, [postings[number]]);
+    }
+    if (path.startsWith("/entries/")) {
+      const serial = Number(path.match(/-([0-9]{6})-v1\.json$/)[1]);
+      return identifiedEntry(serial);
+    }
+    throw new Error(`unexpected request ${path}`);
+  };
+  const search = createRegistrySearch(fetchJson, {
+    concurrency: 3,
+    timeoutMs: 1_000,
+    pageBudget: 3,
+  });
+
+  const result = await search("alpha beta", BASE);
+
+  assert.deepEqual(requestedPages, ["alpha/1", "alpha/0"]);
+  assert.equal(result.entries.length, 2);
+  assert.equal(result.whole, true);
+});
+
+test("matching versions of one result collapse to its newest matching version", async () => {
+  const id = "PALOMAR-2026-07-29-000001";
+  const requestedRecords = [];
+  const fetchJson = async (url) => {
+    const path = new URL(url).pathname;
+    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/t/alpha/head.json") return head("alpha", 2, 2);
+    if (path === "/search/t/alpha/0.json") {
+      // Publisher order is lexical, so the consumer must compare versions as
+      // integers rather than assuming the reversed posting sequence is enough.
+      return page("alpha", 0, [`${id}-v10`, `${id}-v9`]);
+    }
+    if (path.startsWith("/entries/")) {
+      requestedRecords.push(path);
+      return identifiedEntry(1, { version: Number(path.match(/-v([0-9]+)\.json$/)[1]) });
+    }
+    throw new Error(`unexpected request ${path}`);
+  };
+  const search = createRegistrySearch(fetchJson, { concurrency: 2, timeoutMs: 1_000 });
+
+  const result = await search("alpha", BASE);
+
+  assert.deepEqual(requestedRecords, [`/entries/${id}-v10.json`]);
+  assert.deepEqual(result.entries.map((entry) => [entry.id, entry.version]), [[id, 10]]);
+  assert.equal(result.whole, true);
+});
+
+test("a complete postings sequence remains incomplete when the candidate cap truncates it", async () => {
+  const postings = [posting(1), posting(2), posting(3)];
+  let recordRequests = 0;
+  const fetchJson = async (url) => {
+    const path = new URL(url).pathname;
+    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/t/alpha/head.json") return head("alpha", 3, 3);
+    if (path === "/search/t/alpha/0.json") return page("alpha", 0, postings);
+    if (path.startsWith("/entries/")) {
+      recordRequests += 1;
+      const serial = Number(path.match(/-([0-9]{6})-v1\.json$/)[1]);
+      return identifiedEntry(serial, { title: "Gamma", abstract: "Delta" });
+    }
+    throw new Error(`unexpected request ${path}`);
+  };
+  const search = createRegistrySearch(fetchJson, {
+    concurrency: 2,
+    timeoutMs: 1_000,
+    candidateLimit: 2,
+  });
+
+  const result = await search("alpha", BASE);
+
+  assert.equal(recordRequests, 2);
+  assert.equal(result.entries.length, 0);
+  assert.equal(result.whole, false);
+});
+
 test("page, candidate, and concurrency limits remain hard bounds", async () => {
   const postings = Array.from({ length: 100 }, (_unused, index) => posting(index + 1));
   let active = 0;
@@ -177,7 +336,7 @@ test("page, candidate, and concurrency limits remain hard bounds", async () => {
   assert.equal(result.whole, false);
 });
 
-test("record waves stop after the result limit instead of eagerly loading every candidate", async () => {
+test("the record window stops with at most concurrency minus one speculative requests", async () => {
   const postings = Array.from({ length: 100 }, (_unused, index) => posting(index + 1));
   let recordRequests = 0;
   const fetchJson = async (url) => {
@@ -201,7 +360,7 @@ test("record waves stop after the result limit instead of eagerly loading every 
 
   const result = await search("alpha", BASE);
 
-  assert.equal(recordRequests, 24, "more than the final partial wave was fetched");
+  assert.equal(recordRequests, 27, "more than seven speculative records were fetched");
   assert.equal(result.entries.length, 20);
   assert.equal(result.entries[0].id, "PALOMAR-2026-07-29-000100");
   assert.equal(result.entries.at(-1).id, "PALOMAR-2026-07-29-000081");

--- a/tests/searching.test.js
+++ b/tests/searching.test.js
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createRegistrySearch } from "../assets/searching.mjs";
+import { identifiedEntry } from "./registry-fixture.mjs";
+
+const BASE = "https://data.example.test/";
+
+function posting(serial) {
+  return `PALOMAR-2026-07-29-${String(serial).padStart(6, "0")}-v1`;
+}
+
+function head(term, results, pageSize) {
+  return {
+    schema_version: 1,
+    term,
+    page_size: pageSize,
+    pages: Math.ceil(results / pageSize),
+    results,
+  };
+}
+
+function page(term, number, postings) {
+  return { schema_version: 1, term, page: number, postings };
+}
+
+function wait(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+test("search pipelines I/O but retains validated publisher order", async () => {
+  const postings = [1, 2, 3, 4].map(posting);
+  const responses = new Map([
+    ["/search/stopwords.json", { schema_version: 1, stopwords: [] }],
+    ["/search/t/alpha/head.json", head("alpha", 4, 2)],
+    ["/search/t/beta/head.json", head("beta", 4, 2)],
+    ["/search/t/alpha/0.json", page("alpha", 0, postings.slice(0, 2))],
+    ["/search/t/alpha/1.json", page("alpha", 1, postings.slice(2))],
+    ["/search/t/beta/0.json", page("beta", 0, postings.slice(0, 2))],
+    ["/search/t/beta/1.json", page("beta", 1, postings.slice(2))],
+  ]);
+  const delays = new Map([
+    ["/search/t/alpha/head.json", 25],
+    ["/search/t/beta/head.json", 2],
+    ["/search/t/alpha/1.json", 30],
+    ["/search/t/alpha/0.json", 20],
+    ["/search/t/beta/1.json", 2],
+    ["/search/t/beta/0.json", 1],
+  ]);
+  let active = 0;
+  let maximumActive = 0;
+  const completed = [];
+  const fetchJson = async (url) => {
+    const path = new URL(url).pathname;
+    active += 1;
+    maximumActive = Math.max(maximumActive, active);
+    await wait(delays.get(path) ?? (path.includes("000004") ? 30 : 2));
+    active -= 1;
+    completed.push(path);
+    if (path.startsWith("/entries/")) {
+      const serial = Number(path.match(/-([0-9]{6})-v1\.json$/)[1]);
+      return identifiedEntry(serial);
+    }
+    if (!responses.has(path)) throw new Error(`unexpected request ${path}`);
+    return responses.get(path);
+  };
+
+  const search = createRegistrySearch(fetchJson, { concurrency: 3, timeoutMs: 1_000 });
+  const result = await search("alpha beta", BASE);
+
+  assert.ok(maximumActive > 1, "search requests stayed serial");
+  assert.ok(maximumActive <= 3, "search exceeded its concurrency bound");
+  assert.ok(
+    completed.indexOf("/entries/PALOMAR-2026-07-29-000004-v1.json") >
+      completed.indexOf("/entries/PALOMAR-2026-07-29-000003-v1.json"),
+    "the completion fixture did not finish out of posting order",
+  );
+  assert.deepEqual(result.entries.map((entry) => entry.id), [4, 3, 2, 1].map((serial) =>
+    `PALOMAR-2026-07-29-${String(serial).padStart(6, "0")}`,
+  ));
+  assert.equal(result.whole, true);
+  assert.deepEqual(result.problems, []);
+});
+
+test("failed pages and records yield only validated results and a degraded result", async () => {
+  const postings = [1, 2, 3, 4].map(posting);
+  const fetchJson = async (url) => {
+    const path = new URL(url).pathname;
+    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/t/alpha/head.json") return head("alpha", 4, 2);
+    if (path === "/search/t/alpha/1.json") throw new Error("posting page unavailable");
+    if (path === "/search/t/alpha/0.json") return page("alpha", 0, postings.slice(0, 2));
+    if (path.endsWith("000002-v1.json")) throw new Error("record unavailable");
+    if (path.startsWith("/entries/")) return identifiedEntry(1);
+    throw new Error(`unexpected request ${path}`);
+  };
+
+  const search = createRegistrySearch(fetchJson, { concurrency: 4, timeoutMs: 1_000 });
+  const result = await search("alpha", BASE);
+
+  assert.deepEqual(result.entries.map((entry) => entry.id), [
+    "PALOMAR-2026-07-29-000001",
+  ]);
+  assert.deepEqual(result.problems.map((problem) => problem.stage), ["page", "record"]);
+  assert.equal(result.whole, false);
+  assert.equal(result.timedOut, false);
+});
+
+test("one overall deadline bounds every search stage, including an abort-ignoring fetch", async () => {
+  const fetchJson = async (url) => {
+    const path = new URL(url).pathname;
+    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/t/alpha/head.json") return head("alpha", 1, 1);
+    if (path === "/search/t/alpha/0.json") return new Promise(() => {});
+    throw new Error(`unexpected request ${path}`);
+  };
+  const search = createRegistrySearch(fetchJson, { concurrency: 2, timeoutMs: 30 });
+
+  const before = Date.now();
+  const result = await search("alpha", BASE);
+
+  assert.ok(Date.now() - before < 500, "search exceeded its overall deadline");
+  assert.equal(result.timedOut, true);
+  assert.equal(result.whole, false);
+  assert.equal(result.entries.length, 0);
+  assert.deepEqual(result.problems.map((problem) => problem.stage), ["page"]);
+});
+
+test("page, candidate, result, and concurrency limits remain hard bounds", async () => {
+  const postings = Array.from({ length: 100 }, (_unused, index) => posting(index + 1));
+  let active = 0;
+  let maximumActive = 0;
+  const pageRequests = [];
+  let recordRequests = 0;
+  const fetchJson = async (url) => {
+    const path = new URL(url).pathname;
+    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/t/alpha/head.json") return head("alpha", 100, 5);
+    const pageMatch = path.match(/^\/search\/t\/alpha\/([0-9]+)\.json$/);
+    if (pageMatch) {
+      const number = Number(pageMatch[1]);
+      pageRequests.push(number);
+      return page("alpha", number, postings.slice(number * 5, number * 5 + 5));
+    }
+    if (path.startsWith("/entries/")) {
+      recordRequests += 1;
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await wait(1);
+      active -= 1;
+      const serial = Number(path.match(/-([0-9]{6})-v1\.json$/)[1]);
+      return identifiedEntry(serial);
+    }
+    throw new Error(`unexpected request ${path}`);
+  };
+  const search = createRegistrySearch(fetchJson, {
+    concurrency: 4,
+    timeoutMs: 1_000,
+    pageBudget: 16,
+    candidateLimit: 60,
+    resultLimit: 20,
+  });
+
+  const result = await search("alpha", BASE);
+
+  assert.equal(pageRequests.length, 16);
+  assert.deepEqual(
+    [...pageRequests].sort((left, right) => left - right),
+    Array.from({ length: 16 }, (_unused, index) => index + 4),
+  );
+  assert.equal(recordRequests, 60);
+  assert.equal(result.entries.length, 20);
+  assert.equal(result.entries[0].id, "PALOMAR-2026-07-29-000100");
+  assert.equal(result.entries.at(-1).id, "PALOMAR-2026-07-29-000081");
+  assert.ok(maximumActive <= 4);
+  assert.equal(result.whole, false);
+});

--- a/tests/searching.test.js
+++ b/tests/searching.test.js
@@ -257,6 +257,32 @@ test("matching versions of one result collapse to its newest matching version", 
   assert.equal(result.whole, true);
 });
 
+test("a version group reports broken postings in order and continues to an older match", async () => {
+  const id = "PALOMAR-2026-07-29-000001";
+  const fetchJson = async (url) => {
+    const path = new URL(url).pathname;
+    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/t/alpha/head.json") return head("alpha", 3, 3);
+    if (path === "/search/t/alpha/0.json") {
+      return page("alpha", 0, [`${id}-v10`, `${id}-v8`, `${id}-v9`]);
+    }
+    if (path.endsWith("-v10.json")) throw new Error("newest record unavailable");
+    if (path.endsWith("-v9.json")) return identifiedEntry(1, { version: 9, title: "" });
+    if (path.endsWith("-v8.json")) return identifiedEntry(1, { version: 8 });
+    throw new Error(`unexpected request ${path}`);
+  };
+  const search = createRegistrySearch(fetchJson, { concurrency: 2, timeoutMs: 1_000 });
+
+  const result = await search("alpha", BASE);
+
+  assert.deepEqual(result.entries.map((entry) => [entry.id, entry.version]), [[id, 8]]);
+  assert.deepEqual(result.problems.map((problem) => problem.item), [
+    `${id}-v10`,
+    `${id}-v9`,
+  ]);
+  assert.equal(result.whole, false);
+});
+
 test("a complete postings sequence remains incomplete when the candidate cap truncates it", async () => {
   const postings = [posting(1), posting(2), posting(3)];
   let recordRequests = 0;
@@ -336,7 +362,7 @@ test("page, candidate, and concurrency limits remain hard bounds", async () => {
   assert.equal(result.whole, false);
 });
 
-test("the record window stops with at most concurrency minus one speculative requests", async () => {
+test("the record window stops with at most concurrency minus one speculative groups", async () => {
   const postings = Array.from({ length: 100 }, (_unused, index) => posting(index + 1));
   let recordRequests = 0;
   const fetchJson = async (url) => {
@@ -360,9 +386,35 @@ test("the record window stops with at most concurrency minus one speculative req
 
   const result = await search("alpha", BASE);
 
-  assert.equal(recordRequests, 27, "more than seven speculative records were fetched");
+  assert.equal(recordRequests, 27, "more than seven speculative groups were started");
   assert.equal(result.entries.length, 20);
   assert.equal(result.entries[0].id, "PALOMAR-2026-07-29-000100");
   assert.equal(result.entries.at(-1).id, "PALOMAR-2026-07-29-000081");
   assert.equal(result.whole, false);
+});
+
+test("the initial record window never exceeds the result limit", async () => {
+  const postings = Array.from({ length: 20 }, (_unused, index) => posting(index + 1));
+  let recordRequests = 0;
+  const fetchJson = async (url) => {
+    const path = new URL(url).pathname;
+    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/t/alpha/head.json") return head("alpha", 20, 20);
+    if (path === "/search/t/alpha/0.json") return page("alpha", 0, postings);
+    if (path.startsWith("/entries/")) {
+      recordRequests += 1;
+      return new Promise(() => {});
+    }
+    throw new Error(`unexpected request ${path}`);
+  };
+  const search = createRegistrySearch(fetchJson, {
+    concurrency: 8,
+    timeoutMs: 30,
+    resultLimit: 2,
+  });
+
+  const result = await search("alpha", BASE);
+
+  assert.equal(recordRequests, 2);
+  assert.equal(result.timedOut, true);
 });

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -3,6 +3,15 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import { htmlFiles } from "../scripts/build-site.mjs";
+import {
+  COMMIT,
+  DIGEST,
+  entry,
+  recent,
+  recentRow,
+  secondVersion,
+  summary,
+} from "./registry-fixture.mjs";
 
 import {
   DEFAULT_DATABASE,
@@ -43,156 +52,6 @@ import {
 
 // The website's own origin, for the cross-origin assertion below.
 const CANONICAL_WEB_BASE_FOR_TEST = "https://palomar-registry.org/";
-
-const COMMIT = "1".repeat(40);
-const DIGEST = "a".repeat(64);
-
-function summary(overrides = {}) {
-  return {
-    id: "PALOMAR-2026-07-29-000123",
-    version: 1,
-    title: "Fixture theorem",
-    status: "accepted",
-    path: "entries/PALOMAR-2026-07-29-000123-v1.json",
-    ...overrides,
-  };
-}
-
-/** The same record as a second version, with every path that names the version moved. */
-function secondVersion(overrides = {}) {
-  const value = entry({ version: 2, ...overrides });
-  value.challenge_render.artifact_path = `renders/${value.id}-v2/${DIGEST}/`;
-  value.verification.evidence_path = `evidence/${value.id}-v2/${"c".repeat(64)}/`;
-  for (const repository of value.preservation.repositories) {
-    repository.ref = `refs/tags/palomar/${value.id}-v2/${repository.commit}`;
-  }
-  return value;
-}
-
-function recentRow(overrides = {}) {
-  return { ...summary(), published_at: "2026-07-29T09:14:07Z", versions: 1, ...overrides };
-}
-
-function recent(entries = [recentRow()], overrides = {}) {
-  return { schema_version: 1, entries, ...overrides };
-}
-
-function entry(overrides = {}) {
-  const evidenceTree = "c".repeat(64);
-  const value = {
-    schema_version: 2,
-    id: "PALOMAR-2026-07-29-000123",
-    accepted_at: "2026-07-29",
-    registered_at: "2026-07-29T09:14:07Z",
-    version: 1,
-    status: "accepted",
-    title: "Fixture theorem",
-    abstract: "A security fixture.",
-    authors: [{ name: "Example" }],
-    classification: { arxiv: ["math.CO"], msc2020: ["05C10"] },
-    submission: {
-      submission_id: "a1b2c3d4e5f6",
-      authorization: { relationship: "maintainer" },
-    },
-    provenance: {
-      result_origin: "original",
-      repository_role: "substantive-development",
-      responsible_maintainers: [{ name: "Example" }],
-      mathematical_sources: [],
-      related_formalizations: [],
-    },
-    source: {
-      repository: "example/challenge",
-      repository_url: "https://github.com/example/challenge",
-      commit: COMMIT,
-      tree_url: `https://github.com/example/challenge/tree/${COMMIT}`,
-      license: {
-        path: "LICENSE",
-        sha256: DIGEST,
-        declared_identifier: "Apache-2.0",
-        detected_identifier: "Apache-2.0",
-      },
-    },
-    preservation: {
-      archive_owner: "PalomarArchive",
-      archived_at: "2026-07-29T09:01:00Z",
-      receipt_sha256: "f".repeat(64),
-      repositories: [
-        {
-          source_repository: "example/challenge",
-          commit: COMMIT,
-          fork_repository: "PalomarArchive/example--challenge--fixture",
-          ref: `refs/tags/palomar/PALOMAR-2026-07-29-000123-v1/${COMMIT}`,
-        },
-        {
-          source_repository: "leanprover-community/mathlib4",
-          commit: COMMIT,
-          fork_repository: "PalomarArchive/mathlib4--fixture",
-          ref: `refs/tags/palomar/PALOMAR-2026-07-29-000123-v1/${COMMIT}`,
-        },
-      ],
-    },
-    formalization: {
-      challenge_path: "Challenge.lean",
-      solution_path: "Solution.lean",
-      comparator_config_path: "comparator.json",
-      formalization_metadata_path: "formalization.yaml",
-      lakefile_path: "lakefile.toml",
-      lean_toolchain: "leanprover/lean4:v4.31.0",
-      theorem_names: ["Example.theorem"],
-      definition_names: [],
-      permitted_axioms: [],
-      project_dependencies: [
-        { name: "mathlib", repository: "leanprover-community/mathlib4", revision: COMMIT },
-      ],
-    },
-    verification: {
-      repository: "PalomarRegistry/PalomarSubmission",
-      run_id: 12345,
-      workflow_path: ".github/workflows/submission.yml",
-      comparator_commit: "2".repeat(40),
-      lean4export_commit: "3".repeat(40),
-      landrun_commit: "4".repeat(40),
-      nanoda_commit: "9".repeat(40),
-      verified_at: "2026-07-29T08:46:32Z",
-      workflow_url: "https://github.com/PalomarRegistry/PalomarSubmission/actions/runs/12345",
-      workflow_commit: "8".repeat(40),
-      workflow_run_attempt: 1,
-      challenge_sha256: DIGEST,
-      solution_sha256: "b".repeat(64),
-      evidence_tree_sha256: evidenceTree,
-      mechanical_report_sha256: "d".repeat(64),
-      evidence_path: `evidence/PALOMAR-2026-07-29-000123-v1/${evidenceTree}/`,
-    },
-    trust: {
-      level: "high",
-      challenge_lines: 10,
-      challenge_bytes: 200,
-      challenge_imports: ["Mathlib"],
-      challenge_dependencies: [],
-      reasons: [],
-    },
-    review: {
-      reviewed_at: "2026-07-29T08:53:02Z",
-      policy_commit: "5".repeat(40),
-      verdict: "accept",
-      report: { sha256: "e".repeat(64) },
-      reviewer_models: ["fixture:model"],
-      warnings: [],
-    },
-    challenge_render: {
-      format: "verso-html",
-      artifact_path: `renders/PALOMAR-2026-07-29-000123-v1/${DIGEST}/`,
-      entrypoint: "Challenge/index.html",
-      artifact_tree_sha256: DIGEST,
-      verso_commit: "6".repeat(40),
-      renderer_commit: "7".repeat(40),
-      landrun_commit: "8".repeat(40),
-      rendered_at: "2026-07-29T09:00:00Z",
-    },
-  };
-  return Object.assign(value, overrides);
-}
 
 test("production ignores every database query override", () => {
   for (const override of [

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -408,10 +408,31 @@ test("a card for a result accepted before archiving does not call its original u
 });
 
 test("a card says the original is unavailable exactly when the manifest says so", async ({ page }) => {
+  let releaseAvailability;
+  let noteAvailabilityRequest;
+  const availabilityRequested = new Promise((resolve) => { noteAvailabilityRequest = resolve; });
+  await page.route("**/database/source-availability-missing.json", async (route) => {
+    noteAvailabilityRequest();
+    await new Promise((resolve) => { releaseAvailability = resolve; });
+    await route.continue();
+  });
   await page.goto(`/?database=${database}&availability=${missingAvailability}`);
   const card = page.locator(".entry-card").first();
+  await expect(card).toHaveCount(1);
+  await availabilityRequested;
+  await page.locator("#search").fill("000123");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(1);
+  await page.locator("#search").evaluate((input) => input.focus());
+  await card.evaluate((node) => { node.dataset.progressiveFixture = "same-card"; });
+  // Cards and filters are usable while availability is still pending.
+  await expect(card.locator(".repo-link")).toHaveText("example/challenge");
+  releaseAvailability();
   await expect(card.locator(".source-status.missing")).toHaveText("Original unavailable");
   await expect(card.locator(".repo-link")).toHaveText("Palomar preserved copy");
+  await expect(card).toHaveAttribute("data-progressive-fixture", "same-card");
+  await expect(page.locator("#search")).toBeFocused();
+  await expect(page.locator("#search")).toHaveValue("000123");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(1);
 
   await page.goto(`/?database=${database}`);
   await expect(page.locator(".entry-card .source-status")).toHaveCount(0);
@@ -901,7 +922,34 @@ test("a failed posting page leaves validated search cards and reports degradatio
   await expect(page.locator("#search-status")).toHaveClass(/warning/);
 });
 
-test("search cards render before availability and retry a failed decoration", async ({ page }) => {
+test("search availability decorates the existing focused card in place", async ({ page }) => {
+  let releaseAvailability;
+  let noteAvailabilityRequest;
+  const availabilityRequested = new Promise((resolve) => { noteAvailabilityRequest = resolve; });
+  await page.route("**/database/source-availability-missing.json", async (route) => {
+    noteAvailabilityRequest();
+    await new Promise((resolve) => { releaseAvailability = resolve; });
+    await route.continue();
+  });
+
+  await page.goto(
+    `/?database=${database}&availability=${missingAvailability}&q=synthetically`,
+  );
+  const card = page.locator("#search-results .entry-card");
+  await expect(card).toHaveCount(1);
+  await availabilityRequested;
+  await card.evaluate((node) => { node.dataset.progressiveFixture = "same-card"; });
+  await card.locator(".repo-link").focus();
+  await expect(card.locator(".repo-link")).toHaveText("example/challenge");
+
+  releaseAvailability();
+  await expect(card.locator(".repo-link")).toHaveText("Palomar preserved copy");
+  await expect(card.locator(".source-status.missing")).toHaveText("Original unavailable");
+  await expect(card).toHaveAttribute("data-progressive-fixture", "same-card");
+  await expect(card.locator(".repo-link")).toBeFocused();
+});
+
+test("transient and invalid availability responses are both retried", async ({ page }) => {
   let availabilityRequests = 0;
   let releaseFirst;
   let noteFirstRequest;
@@ -915,6 +963,10 @@ test("search cards render before availability and retry a failed decoration", as
       noteFirstRequest();
       await new Promise((resolve) => { releaseFirst = resolve; });
       await route.fulfill({ status: 503, body: "temporarily unavailable" });
+      return;
+    }
+    if (availabilityRequests === 2) {
+      await route.fulfill({ status: 200, json: { schema_version: 1 } });
       return;
     }
     await route.continue();
@@ -933,11 +985,40 @@ test("search cards render before availability and retry a failed decoration", as
   releaseFirst();
   await firstFailureLogged;
 
+  const invalidLogged = page.waitForEvent("console", {
+    predicate: (message) => message.text().includes("Source availability is unavailable"),
+  });
   await page.getByRole("button", { name: "Search" }).click();
   await expect.poll(() => availabilityRequests).toBe(2);
+  await invalidLogged;
+  await expect(card.locator(".repo-link")).toHaveText("example/challenge");
+
+  await page.getByRole("button", { name: "Search" }).click();
+  await expect.poll(() => availabilityRequests).toBe(3);
   await expect(card.locator(".repo-link")).toHaveText("Palomar preserved copy");
   await expect(card.locator(".source-status.missing")).toHaveText("Original unavailable");
   await expect(card.locator(".version-history-link")).toHaveCount(0);
+});
+
+test("a missing availability manifest is cached for the page", async ({ page }) => {
+  let availabilityRequests = 0;
+  await page.route("**/database/no-source-availability.json", async (route) => {
+    availabilityRequests += 1;
+    await route.fulfill({ status: 404, body: "not published" });
+  });
+  const absentAvailability = encodeURIComponent(
+    "http://127.0.0.1:4173/database/no-source-availability.json",
+  );
+
+  await page.goto(
+    `/?database=${database}&availability=${absentAvailability}&q=synthetically`,
+  );
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
+  await expect.poll(() => availabilityRequests).toBe(1);
+  await page.getByRole("button", { name: "Search" }).click();
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
+  await page.waitForTimeout(50);
+  expect(availabilityRequests).toBe(1);
 });
 
 test("a superseded slow search cannot repaint a newer query", async ({ page }) => {
@@ -965,26 +1046,52 @@ test("a superseded slow search cannot repaint a newer query", async ({ page }) =
   await expect(page).toHaveURL(/q=synthetically/);
 });
 
-test("a linked search defers the landing pipeline until it is cleared", async ({ page }) => {
+test("a linked search hides landing DOM and retries one failed landing load", async ({ page }) => {
   let recentRequests = 0;
-  page.on("request", (request) => {
-    if (new URL(request.url()).pathname === "/database/recent.json") recentRequests += 1;
+  let releaseFirstRecent;
+  let noteFirstRecent;
+  const firstRecent = new Promise((resolve) => { noteFirstRecent = resolve; });
+  await page.route("**/database/recent.json", async (route) => {
+    recentRequests += 1;
+    if (recentRequests === 1) {
+      noteFirstRecent();
+      await new Promise((resolve) => { releaseFirstRecent = resolve; });
+      await route.fulfill({ status: 503, body: "temporarily unavailable" });
+      return;
+    }
+    await route.continue();
   });
 
   await page.goto(`/?database=${database}&q=synthetically`);
   await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
   expect(recentRequests).toBe(0);
-  await expect(page.locator("#status")).toBeHidden();
+  expect(await page.evaluate(() => ({
+    grid: document.querySelector("#entry-grid").hidden,
+    status: document.querySelector("#status").hidden,
+    toolbar: document.querySelector(".toolbar").hidden,
+  }))).toEqual({ grid: true, status: true, toolbar: true });
   await expect(page.locator("#entry-grid .entry-card")).toHaveCount(0);
 
   await page.locator("#query").fill("");
   await page.getByRole("button", { name: "Search" }).click();
-  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
-  expect(recentRequests).toBe(1);
+  await firstRecent;
+  expect(await page.evaluate(() => ({
+    grid: document.querySelector("#entry-grid").hidden,
+    status: document.querySelector("#status").hidden,
+    toolbar: document.querySelector(".toolbar").hidden,
+  }))).toEqual({ grid: false, status: false, toolbar: false });
 
+  // Clearing again while the first landing request is pending shares it.
   await page.getByRole("button", { name: "Search" }).click();
   await page.waitForTimeout(50);
   expect(recentRequests).toBe(1);
+  releaseFirstRecent();
+  await expect(page.locator("#status")).toContainText("could not be loaded");
+
+  // Once that attempt has settled as failed, clearing retries it.
+  await page.getByRole("button", { name: "Search" }).click();
+  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
+  expect(recentRequests).toBe(2);
 });
 
 test("a search runs from a link, and says so when nothing carries the words", async ({ page }) => {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -877,11 +877,10 @@ test("search cards retain posting order when posting pages finish out of order",
 
   await page.goto(`/?database=${database}&q=quasicoherent`);
 
-  await expect(page.locator("#search-results .entry-card")).toHaveCount(3);
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(2);
   await expect(page.locator("#search-results .entry-id")).toHaveText([
     "PALOMAR-2026-07-29-000124 v1",
     "PALOMAR-2026-07-29-000123 v2",
-    "PALOMAR-2026-07-29-000123 v1",
   ]);
 });
 
@@ -892,33 +891,105 @@ test("a failed posting page leaves validated search cards and reports degradatio
 
   await page.goto(`/?database=${database}&q=quasicoherent`);
 
-  await expect(page.locator("#search-results .entry-card")).toHaveCount(2);
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
   await expect(page.locator("#search-results .entry-id")).toHaveText([
     "PALOMAR-2026-07-29-000123 v2",
-    "PALOMAR-2026-07-29-000123 v1",
   ]);
   await expect(page.locator("#search-status")).toContainText(
-    "Showing 2 verified results. The search is incomplete because 1 data request failed.",
+    "Showing 1 verified result. The search is incomplete because 1 data request failed.",
   );
   await expect(page.locator("#search-status")).toHaveClass(/warning/);
 });
 
-test("search cards use real availability without inventing version metadata", async ({ page }) => {
+test("search cards render before availability and retry a failed decoration", async ({ page }) => {
+  let availabilityRequests = 0;
+  let releaseFirst;
+  let noteFirstRequest;
+  const firstRequest = new Promise((resolve) => { noteFirstRequest = resolve; });
+  const firstFailureLogged = page.waitForEvent("console", {
+    predicate: (message) => message.text().includes("Source availability is unavailable"),
+  });
+  await page.route("**/database/source-availability-missing.json", async (route) => {
+    availabilityRequests += 1;
+    if (availabilityRequests === 1) {
+      noteFirstRequest();
+      await new Promise((resolve) => { releaseFirst = resolve; });
+      await route.fulfill({ status: 503, body: "temporarily unavailable" });
+      return;
+    }
+    await route.continue();
+  });
+
   await page.goto(
     `/?database=${database}&availability=${missingAvailability}&q=synthetically`,
   );
 
   const card = page.locator("#search-results .entry-card");
   await expect(card).toHaveCount(1);
+  await firstRequest;
+  // The decorative manifest is still blocked, but the verified record is not.
+  await expect(card.locator(".repo-link")).toHaveText("example/challenge");
   await expect(card.locator(".entry-id")).toHaveText("PALOMAR-2026-07-29-000124 v1");
+  releaseFirst();
+  await firstFailureLogged;
+
+  await page.getByRole("button", { name: "Search" }).click();
+  await expect.poll(() => availabilityRequests).toBe(2);
   await expect(card.locator(".repo-link")).toHaveText("Palomar preserved copy");
   await expect(card.locator(".source-status.missing")).toHaveText("Original unavailable");
   await expect(card.locator(".version-history-link")).toHaveCount(0);
 });
 
+test("a superseded slow search cannot repaint a newer query", async ({ page }) => {
+  let slowHeadRequests = 0;
+  await page.route("**/database/search/t/quasicoherent/head.json", async (route) => {
+    slowHeadRequests += 1;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await route.continue().catch(() => {});
+  });
+  await page.goto(`/?database=${database}`);
+
+  await page.locator("#query").fill("quasicoherent");
+  await page.getByRole("button", { name: "Search" }).click();
+  await expect.poll(() => slowHeadRequests).toBe(1);
+  await page.locator("#query").fill("synthetically");
+  await page.getByRole("button", { name: "Search" }).click();
+
+  await expect(page.locator("#search-results .entry-id")).toHaveText(
+    "PALOMAR-2026-07-29-000124 v1",
+  );
+  await page.waitForTimeout(300);
+  await expect(page.locator("#search-results .entry-id")).toHaveText(
+    "PALOMAR-2026-07-29-000124 v1",
+  );
+  await expect(page).toHaveURL(/q=synthetically/);
+});
+
+test("a linked search defers the landing pipeline until it is cleared", async ({ page }) => {
+  let recentRequests = 0;
+  page.on("request", (request) => {
+    if (new URL(request.url()).pathname === "/database/recent.json") recentRequests += 1;
+  });
+
+  await page.goto(`/?database=${database}&q=synthetically`);
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
+  expect(recentRequests).toBe(0);
+  await expect(page.locator("#status")).toBeHidden();
+  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(0);
+
+  await page.locator("#query").fill("");
+  await page.getByRole("button", { name: "Search" }).click();
+  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
+  expect(recentRequests).toBe(1);
+
+  await page.getByRole("button", { name: "Search" }).click();
+  await page.waitForTimeout(50);
+  expect(recentRequests).toBe(1);
+});
+
 test("a search runs from a link, and says so when nothing carries the words", async ({ page }) => {
   await page.goto(`/?database=${database}&q=quasicoherent`);
-  await expect(page.locator("#search-results .entry-card")).toHaveCount(3);
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(2);
 
   await page.locator("#query").fill("quasicoherent unobtainium");
   await page.getByRole("button", { name: "Search" }).click();

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -842,6 +842,11 @@ test("a search reads one postings sequence per word and confirms every hit", asy
 
   await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
   await expect(page.locator("#search-results .entry-card")).toContainText("000124");
+  // A posting names an immutable version, but does not claim that it is
+  // current or say how many active versions the result has. Search cards omit
+  // both claims until the public search contract publishes them.
+  await expect(page.locator("#search-results .entry-id")).not.toContainText("current");
+  await expect(page.locator("#search-results .version-history-link")).toHaveCount(0);
   // The listing is a different question, and answering both at once would show
   // one reader two sets of results with nothing saying which was which.
   await expect(page.locator("#entry-grid")).toBeHidden();
@@ -860,6 +865,55 @@ test("a search reads one postings sequence per word and confirms every hit", asy
   // nothing on top of that.
   expect(asked.filter((path) => path.startsWith("/database/entries/")))
     .toEqual(["/database/entries/PALOMAR-2026-07-29-000124-v1.json"]);
+});
+
+test("search cards retain posting order when posting pages finish out of order", async ({ page }) => {
+  await page.route("**/database/search/t/quasicoherent/*.json", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    if (path.endsWith("/1.json")) await new Promise((resolve) => setTimeout(resolve, 100));
+    if (path.endsWith("/0.json")) await new Promise((resolve) => setTimeout(resolve, 5));
+    await route.continue();
+  });
+
+  await page.goto(`/?database=${database}&q=quasicoherent`);
+
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(3);
+  await expect(page.locator("#search-results .entry-id")).toHaveText([
+    "PALOMAR-2026-07-29-000124 v1",
+    "PALOMAR-2026-07-29-000123 v2",
+    "PALOMAR-2026-07-29-000123 v1",
+  ]);
+});
+
+test("a failed posting page leaves validated search cards and reports degradation", async ({ page }) => {
+  await page.route("**/database/search/t/quasicoherent/1.json", (route) =>
+    route.fulfill({ status: 503, body: "temporarily unavailable" }),
+  );
+
+  await page.goto(`/?database=${database}&q=quasicoherent`);
+
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(2);
+  await expect(page.locator("#search-results .entry-id")).toHaveText([
+    "PALOMAR-2026-07-29-000123 v2",
+    "PALOMAR-2026-07-29-000123 v1",
+  ]);
+  await expect(page.locator("#search-status")).toContainText(
+    "Showing 2 verified results. The search is incomplete because 1 data request failed.",
+  );
+  await expect(page.locator("#search-status")).toHaveClass(/warning/);
+});
+
+test("search cards use real availability without inventing version metadata", async ({ page }) => {
+  await page.goto(
+    `/?database=${database}&availability=${missingAvailability}&q=synthetically`,
+  );
+
+  const card = page.locator("#search-results .entry-card");
+  await expect(card).toHaveCount(1);
+  await expect(card.locator(".entry-id")).toHaveText("PALOMAR-2026-07-29-000124 v1");
+  await expect(card.locator(".repo-link")).toHaveText("Palomar preserved copy");
+  await expect(card.locator(".source-status.missing")).toHaveText("Original unavailable");
+  await expect(card.locator(".version-history-link")).toHaveCount(0);
 });
 
 test("a search runs from a link, and says so when nothing carries the words", async ({ page }) => {


### PR DESCRIPTION
## What changed

- extract registry search into a testable data-client module;
- load term heads, selected posting pages, and candidate records with concurrency capped at eight and one shared 30-second deadline;
- advance record reads through a sliding window, stopping once 20 results are verified with at most seven speculative result groups;
- keep fulfilled pages and records in validated publisher order even when requests complete out of order;
- retain validated results after page or record failures and show an explicit incomplete-search warning;
- preserve the existing 16-page, 60-candidate, and 20-result limits;
- collapse matching versions of one Palomar ID to its newest matching candidate without calling it current;
- report a broken versioned record precisely and continue to older matching candidates for that ID;
- abort superseded searches and guard every render and later decoration by search generation;
- skip and explicitly hide the recent-listing pipeline on a linked `?q=` search, loading it once if the search is cleared and retrying a failed landing attempt;
- render landing and search cards without waiting for source availability, update their source controls in place, cache successful or missing-manifest answers, and retry transport or validation failures;
- stop labelling search results as current or implying a one-version history when postings do not publish either fact; and
- use the real availability manifest for source/archive links on search cards.

## Why

The previous search loop could fetch as many as 16 posting pages and then 60 records serially. One slow or malformed response failed the entire search, and there was no overall deadline. Search cards also called the common card renderer with a fabricated version count of `1` and no availability data.

The new pipeline reuses the landing page's settled bounded loader and gives sequential stages one parent deadline. Every displayed result still passes the existing posting, page, record, and exact-term validators. Search and recent-listing work are now separate views rather than two hidden pipelines competing on a direct search load.

## Public-data contract follow-up

No Database change is required for correctness: unknown card metadata is now omitted. If search cards should regain a current-version badge and history link, the minimal follow-up is a validated bounded search summary carrying the current version and active-version count. The present posting contract contains only immutable versioned IDs, so Web should not infer those mutable facts.

## Validation

- `PALOMAR_DATABASE_CHECKOUT=../PalomarDatabase npm test` — 78 passed
- `npm run build -- --version test --output .site` — passed
- `nix shell nixpkgs#chromium -c bash -lc 'export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=$(command -v chromium); npm run test:browser'` — 44 passed, 2 expected previous-deployment tests skipped without CI's `PALOMAR_PREVIOUS_REF`
- `git diff --check` — passed
