### PR TITLE
Bound registry search term fanout

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,18 @@ before that classification has an entry. The filter is over `recent.json`, which
 is the newest 200 current versions and not the registry, so it narrows what is
 on the page rather than searching everything; the search box does the latter,
 a word at a time, over titles, abstracts and author names.
-Search heads, posting pages and records load with bounded concurrency under one
-30-second deadline. A failed page or record leaves already validated results
-visible with an incomplete-search warning. The record loader advances as a
-bounded sliding window, keeps publisher order however requests finish, and
-stops at the result limit with at most seven speculative result groups. Multiple
-matching versions of one Palomar ID collapse to the newest matching version in
-the bounded candidate set, so a result is not repeated. A posting still says
-neither that a version is current nor how many active versions exist, so search
-cards make neither claim; landing cards get both facts from `recent.json`.
+Search accepts at most 20 distinct normalized words; a longer linked or typed
+query is rejected before any registry-data request. At most 20 search heads and
+16 posting pages are then loaded with concurrency at most eight under one
+30-second deadline. At most 60 candidate records are read and at most 20 results
+are displayed. A failed page or record leaves already validated results visible
+with an incomplete-search warning. The record loader advances as a bounded
+sliding window, keeps publisher order however requests finish, and stops at the
+result limit with at most seven speculative result groups. Multiple matching
+versions of one Palomar ID collapse to the newest matching version in the
+bounded candidate set, so a result is not repeated. A posting still says neither
+that a version is current nor how many active versions exist, so search cards
+make neither claim; landing cards get both facts from `recent.json`.
 Landing and verified search cards render before the source-availability
 manifest; if it arrives, their existing source controls are decorated in place.
 A linked `?q=` search does not also load the hidden recent listing; clearing the

--- a/README.md
+++ b/README.md
@@ -26,18 +26,22 @@ before that classification has an entry. The filter is over `recent.json`, which
 is the newest 200 current versions and not the registry, so it narrows what is
 on the page rather than searching everything; the search box does the latter,
 a word at a time, over titles, abstracts and author names.
-Search accepts at most 20 distinct normalized words; a longer linked or typed
-query is rejected before any registry-data request. At most 20 search heads and
-16 posting pages are then loaded with concurrency at most eight under one
-30-second deadline. At most 60 candidate records are read and at most 20 results
-are displayed. A failed page or record leaves already validated results visible
-with an incomplete-search warning. The record loader advances as a bounded
-sliding window, keeps publisher order however requests finish, and stops at the
-result limit with at most seven speculative result groups. Multiple matching
-versions of one Palomar ID collapse to the newest matching version in the
-bounded candidate set, so a result is not repeated. A posting still says neither
-that a version is current nor how many active versions exist, so search cards
-make neither claim; landing cards get both facts from `recent.json`.
+Search accepts at most 4,096 characters and 20 distinct normalized words. The
+word limit is checked before the stopword list is loaded, so common words that
+the index later drops still count. An over-limit linked or typed query is
+rejected before any registry-data request or browser-history update. At most 20
+search heads, 16 posting pages and 60 candidate records are then read with
+concurrency at most eight under one 30-second deadline. Including the stopword
+list and optional source-availability manifest, that is at most 98 dynamic data
+requests per search; at most 20 results are displayed. A failed page or record
+leaves already validated results visible with an incomplete-search warning. The
+record loader advances as a bounded sliding window, keeps publisher order
+however requests finish, and stops at the result limit with at most seven
+speculative result groups. Multiple matching versions of one Palomar ID collapse
+to the newest matching version in the bounded candidate set, so a result is not
+repeated. A posting still says neither that a version is current nor how many
+active versions exist, so search cards make neither claim; landing cards get
+both facts from `recent.json`.
 Landing and verified search cards render before the source-availability
 manifest; if it arrives, their existing source controls are decorated in place.
 A linked `?q=` search does not also load the hidden recent listing; clearing the

--- a/assets/app.js
+++ b/assets/app.js
@@ -16,7 +16,6 @@ import {
   safeDataUrl,
   safeExternalUrl,
   safeInternalUrl,
-  searchTerms,
   selectDatabaseUrl,
   selectAvailabilityUrl,
   recentUrl,
@@ -31,7 +30,7 @@ import {
   workflowRunId,
 } from "./security.mjs";
 import { loadSettledBounded } from "./loading.mjs";
-import { createRegistrySearch } from "./searching.mjs";
+import { createRegistrySearch, validateSearchQuery } from "./searching.mjs";
 
 const CANONICAL_WEB_BASE = "https://palomar-registry.org/";
 
@@ -659,6 +658,19 @@ function renderSearchCards(results, entries) {
   return cards;
 }
 
+function clearSearchQueryWarning(input) {
+  input?.removeAttribute("aria-invalid");
+  input?.removeAttribute("aria-describedby");
+}
+
+function showSearchQueryWarning(input, status, error) {
+  status.hidden = false;
+  status.textContent = error.message;
+  status.classList.add("warning");
+  input?.setAttribute("aria-invalid", "true");
+  input?.setAttribute("aria-describedby", status.id);
+}
+
 async function renderSearch(query) {
   const generation = searchGeneration + 1;
   searchGeneration = generation;
@@ -666,10 +678,25 @@ async function renderSearch(query) {
   activeSearchController = null;
   const status = document.querySelector("#search-status");
   const results = document.querySelector("#search-results");
+  const input = document.querySelector("#query");
   if (!status || !results) return;
   results.replaceChildren();
   status.className = "status";
-  const searching = Boolean(searchTerms(query).length);
+  let asked;
+  try {
+    asked = validateSearchQuery(query);
+    clearSearchQueryWarning(input);
+  } catch (error) {
+    setLandingSuppressed(Boolean(query));
+    if (error instanceof RangeError) showSearchQueryWarning(input, status, error);
+    else {
+      status.hidden = false;
+      status.textContent = `The search could not be run: ${error.message}`;
+      status.classList.add("error");
+    }
+    return;
+  }
+  const searching = Boolean(asked.length);
   setLandingSuppressed(searching);
   if (!searching) {
     status.hidden = true;
@@ -740,8 +767,11 @@ async function renderSearch(query) {
     status.classList.toggle("warning", Boolean(degraded));
   } catch (error) {
     if (generation !== searchGeneration) return;
-    status.textContent = `The search could not be run: ${error.message}`;
-    status.classList.add("error");
+    if (error instanceof RangeError) showSearchQueryWarning(input, status, error);
+    else {
+      status.textContent = `The search could not be run: ${error.message}`;
+      status.classList.add("error");
+    }
   } finally {
     if (generation === searchGeneration) activeSearchController = null;
   }
@@ -757,12 +787,21 @@ function wireSearch() {
     // The page's own content security policy forbids form submission, which is
     // right: nothing here posts anywhere. The query is a link to this page.
     event.preventDefault();
-    const query = input.value.trim();
+    const rawQuery = input.value;
+    try {
+      // Validate before trimming or constructing the shareable URL. This also
+      // keeps an over-limit value out of history.replaceState.
+      validateSearchQuery(rawQuery);
+    } catch (error) {
+      renderSearch(rawQuery);
+      return;
+    }
+    const query = rawQuery.trim();
     window.history.replaceState(null, "", searchPageUrlFor(query));
     renderSearch(query);
   });
   if (initial) renderSearch(initial);
-  return Boolean(searchTerms(initial).length);
+  return Boolean(initial);
 }
 
 function detailRow(label, value) {

--- a/assets/searching.mjs
+++ b/assets/searching.mjs
@@ -12,8 +12,10 @@ import {
 } from "./security.mjs";
 
 // These are request bounds, not guesses about how large the registry will be.
-// A query can therefore become incomplete, but it cannot make browser work grow
-// without limit with either a common word or a large result set.
+// A query can therefore be rejected or become incomplete, but it cannot make
+// browser work grow without limit through many words, a common word, or a large
+// result set.
+export const SEARCH_TERM_LIMIT = 20;
 export const SEARCH_PAGE_BUDGET = 16;
 export const SEARCH_RESULT_LIMIT = 20;
 export const SEARCH_CANDIDATE_LIMIT = 60;
@@ -116,6 +118,11 @@ export function createRegistrySearch(
       throw new TypeError("signal must be an AbortSignal");
     }
     const asked = [...new Set(searchTerms(query))];
+    if (asked.length > SEARCH_TERM_LIMIT) {
+      throw new RangeError(
+        `Search queries may contain at most ${SEARCH_TERM_LIMIT} distinct words.`,
+      );
+    }
     const problems = [];
     const deadlineController = new AbortController();
     const deadlineError = new Error(`search deadline of ${timeoutMs}ms expired`);

--- a/assets/searching.mjs
+++ b/assets/searching.mjs
@@ -15,6 +15,7 @@ import {
 // A query can therefore be rejected or become incomplete, but it cannot make
 // browser work grow without limit through many words, a common word, or a large
 // result set.
+export const SEARCH_QUERY_CHARACTER_LIMIT = 4_096;
 export const SEARCH_TERM_LIMIT = 20;
 export const SEARCH_PAGE_BUDGET = 16;
 export const SEARCH_RESULT_LIMIT = 20;
@@ -23,6 +24,25 @@ export const SEARCH_IO_CONCURRENCY = 8;
 export const SEARCH_TIMEOUT_MS = 30_000;
 
 const POSTING_RE = /^(PALOMAR-\d{4}-\d{2}-\d{2}-\d{6})-v([1-9]\d*)$/;
+
+/** Validate the user-controlled query before doing work proportional to it. */
+export function validateSearchQuery(query) {
+  if (typeof query !== "string") throw new TypeError("search query must be a string");
+  if (query.length > SEARCH_QUERY_CHARACTER_LIMIT) {
+    throw new RangeError(
+      `Shorten the search to at most ${SEARCH_QUERY_CHARACTER_LIMIT} characters; ` +
+        `it currently has ${query.length}.`,
+    );
+  }
+  const terms = [...new Set(searchTerms(query))];
+  if (terms.length > SEARCH_TERM_LIMIT) {
+    throw new RangeError(
+      `Use at most ${SEARCH_TERM_LIMIT} distinct normalized words; ` +
+        `this search has ${terms.length}. Common words count toward this limit.`,
+    );
+  }
+  return terms;
+}
 
 /**
  * The summary a fetched record is checked against.
@@ -117,12 +137,7 @@ export function createRegistrySearch(
     if (signal !== null && !(signal instanceof AbortSignal)) {
       throw new TypeError("signal must be an AbortSignal");
     }
-    const asked = [...new Set(searchTerms(query))];
-    if (asked.length > SEARCH_TERM_LIMIT) {
-      throw new RangeError(
-        `Search queries may contain at most ${SEARCH_TERM_LIMIT} distinct words.`,
-      );
-    }
+    const asked = validateSearchQuery(query);
     const problems = [];
     const deadlineController = new AbortController();
     const deadlineError = new Error(`search deadline of ${timeoutMs}ms expired`);

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
 
         <form id="registry-search" class="registry-search" role="search">
           <label for="query">Search the registry:</label>
-          <input id="query" name="q" type="search" placeholder="words from a title, abstract, or author" autocomplete="off" spellcheck="false" maxlength="200">
+          <input id="query" name="q" type="search" placeholder="words from a title, abstract, or author" autocomplete="off" spellcheck="false">
           <button type="submit">Search</button>
         </form>
         <div id="search-status" class="status" role="status" hidden></div>

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
 
         <form id="registry-search" class="registry-search" role="search">
           <label for="query">Search the registry:</label>
-          <input id="query" name="q" type="search" placeholder="words from a title, abstract, or author" autocomplete="off" spellcheck="false">
+          <input id="query" name="q" type="search" placeholder="words from a title, abstract, or author" autocomplete="off" spellcheck="false" maxlength="4096">
           <button type="submit">Search</button>
         </form>
         <div id="search-status" class="status" role="status" hidden></div>

--- a/tests/searching.test.js
+++ b/tests/searching.test.js
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { createRegistrySearch, SEARCH_TERM_LIMIT } from "../assets/searching.mjs";
+import {
+  createRegistrySearch,
+  SEARCH_QUERY_CHARACTER_LIMIT,
+  SEARCH_TERM_LIMIT,
+  validateSearchQuery,
+} from "../assets/searching.mjs";
 import { identifiedEntry } from "./registry-fixture.mjs";
 
 const BASE = "https://data.example.test/";
@@ -59,9 +64,36 @@ test("the distinct-term limit is a hard head-request bound", async () => {
   });
   await assert.rejects(
     rejectOverLimit([...terms, "onewordmore"].join(" "), BASE),
-    new RangeError(`Search queries may contain at most ${SEARCH_TERM_LIMIT} distinct words.`),
+    new RangeError(
+      `Use at most ${SEARCH_TERM_LIMIT} distinct normalized words; ` +
+        `this search has ${SEARCH_TERM_LIMIT + 1}. Common words count toward this limit.`,
+    ),
   );
+  await wait(20);
   assert.equal(overLimitRequests, 0);
+});
+
+test("query validation checks characters first and deduplicates normalized terms", async () => {
+  const repeated = Array.from({ length: SEARCH_TERM_LIMIT + 10 }, () => "Repeated").join(" ");
+  assert.deepEqual(validateSearchQuery(repeated), ["repeated"]);
+
+  const tooLong = "echo ".repeat(Math.ceil((SEARCH_QUERY_CHARACTER_LIMIT + 1) / 5));
+  assert.ok(tooLong.length > SEARCH_QUERY_CHARACTER_LIMIT);
+  let requests = 0;
+  const search = createRegistrySearch(async () => {
+    requests += 1;
+    throw new Error("an over-limit query must not read registry data");
+  });
+
+  await assert.rejects(
+    search(tooLong, BASE),
+    new RangeError(
+      `Shorten the search to at most ${SEARCH_QUERY_CHARACTER_LIMIT} characters; ` +
+        `it currently has ${tooLong.length}.`,
+    ),
+  );
+  await wait(20);
+  assert.equal(requests, 0);
 });
 
 test("search pipelines I/O but retains validated publisher order", async () => {

--- a/tests/searching.test.js
+++ b/tests/searching.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { createRegistrySearch } from "../assets/searching.mjs";
+import { createRegistrySearch, SEARCH_TERM_LIMIT } from "../assets/searching.mjs";
 import { identifiedEntry } from "./registry-fixture.mjs";
 
 const BASE = "https://data.example.test/";
@@ -27,6 +27,42 @@ function page(term, number, postings) {
 function wait(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
+
+test("the distinct-term limit is a hard head-request bound", async () => {
+  const terms = Array.from(
+    { length: SEARCH_TERM_LIMIT },
+    (_unused, index) => `word${String(index).padStart(2, "0")}`,
+  );
+  let headRequests = 0;
+  const fetchJson = async (url) => {
+    const path = new URL(url).pathname;
+    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path.endsWith("/head.json")) {
+      headRequests += 1;
+      const error = new Error("not indexed");
+      error.status = 404;
+      throw error;
+    }
+    throw new Error(`unexpected request ${path}`);
+  };
+  const search = createRegistrySearch(fetchJson, { concurrency: 8, timeoutMs: 1_000 });
+
+  const atLimit = await search(terms.join(" "), BASE);
+
+  assert.equal(headRequests, SEARCH_TERM_LIMIT);
+  assert.deepEqual(atLimit.missing, terms);
+
+  let overLimitRequests = 0;
+  const rejectOverLimit = createRegistrySearch(async () => {
+    overLimitRequests += 1;
+    throw new Error("an over-limit query must not read registry data");
+  });
+  await assert.rejects(
+    rejectOverLimit([...terms, "onewordmore"].join(" "), BASE),
+    new RangeError(`Search queries may contain at most ${SEARCH_TERM_LIMIT} distinct words.`),
+  );
+  assert.equal(overLimitRequests, 0);
+});
 
 test("search pipelines I/O but retains validated publisher order", async () => {
   const postings = [1, 2, 3, 4].map(posting);

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -3,6 +3,8 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
+import { SEARCH_TERM_LIMIT } from "../assets/searching.mjs";
+
 const database = encodeURIComponent("http://127.0.0.1:4173/database/");
 const missingAvailability = encodeURIComponent(
   "http://127.0.0.1:4173/database/source-availability-missing.json",
@@ -886,6 +888,39 @@ test("a search reads one postings sequence per word and confirms every hit", asy
   // nothing on top of that.
   expect(asked.filter((path) => path.startsWith("/database/entries/")))
     .toEqual(["/database/entries/PALOMAR-2026-07-29-000124-v1.json"]);
+});
+
+test("an over-limit linked or typed query starts no search or hidden landing work", async ({ page }) => {
+  const query = Array.from(
+    { length: SEARCH_TERM_LIMIT + 20 },
+    (_unused, index) => `word${String(index).padStart(2, "0")}`,
+  ).join(" ");
+  const asked = [];
+  page.on("request", (request) => {
+    const path = new URL(request.url()).pathname;
+    if (path.startsWith("/database/")) asked.push(path);
+  });
+
+  await page.goto(`/?database=${database}&q=${encodeURIComponent(query)}`);
+  await expect(page.locator("#query")).toHaveValue(query);
+  await expect(page.locator("#search-status")).toHaveText(
+    `The search could not be run: Search queries may contain at most ${SEARCH_TERM_LIMIT} distinct words.`,
+  );
+  await expect(page.locator("#search-status")).toHaveClass(/error/);
+  expect(asked.filter((path) => path.includes("/database/search/"))).toEqual([]);
+  expect(asked.filter((path) => path === "/database/recent.json")).toEqual([]);
+  await expect(page.locator("#entry-grid")).toBeHidden();
+
+  await page.goto(`/?database=${database}`);
+  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
+  asked.length = 0;
+  await page.locator("#query").fill(query);
+  await page.getByRole("button", { name: "Search" }).click();
+  await expect(page.locator("#query")).toHaveValue(query);
+  await expect(page.locator("#search-status")).toHaveText(
+    `The search could not be run: Search queries may contain at most ${SEARCH_TERM_LIMIT} distinct words.`,
+  );
+  expect(asked.filter((path) => path.includes("/database/search/"))).toEqual([]);
 });
 
 test("search cards retain posting order when posting pages finish out of order", async ({ page }) => {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -3,7 +3,10 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { SEARCH_TERM_LIMIT } from "../assets/searching.mjs";
+import {
+  SEARCH_QUERY_CHARACTER_LIMIT,
+  SEARCH_TERM_LIMIT,
+} from "../assets/searching.mjs";
 
 const database = encodeURIComponent("http://127.0.0.1:4173/database/");
 const missingAvailability = encodeURIComponent(
@@ -890,9 +893,9 @@ test("a search reads one postings sequence per word and confirms every hit", asy
     .toEqual(["/database/entries/PALOMAR-2026-07-29-000124-v1.json"]);
 });
 
-test("an over-limit linked or typed query starts no search or hidden landing work", async ({ page }) => {
+test("an over-limit term count is an accessible warning and can be corrected", async ({ page }) => {
   const query = Array.from(
-    { length: SEARCH_TERM_LIMIT + 20 },
+    { length: SEARCH_TERM_LIMIT + 1 },
     (_unused, index) => `word${String(index).padStart(2, "0")}`,
   ).join(" ");
   const asked = [];
@@ -904,9 +907,14 @@ test("an over-limit linked or typed query starts no search or hidden landing wor
   await page.goto(`/?database=${database}&q=${encodeURIComponent(query)}`);
   await expect(page.locator("#query")).toHaveValue(query);
   await expect(page.locator("#search-status")).toHaveText(
-    `The search could not be run: Search queries may contain at most ${SEARCH_TERM_LIMIT} distinct words.`,
+    `Use at most ${SEARCH_TERM_LIMIT} distinct normalized words; ` +
+      `this search has ${SEARCH_TERM_LIMIT + 1}. Common words count toward this limit.`,
   );
-  await expect(page.locator("#search-status")).toHaveClass(/error/);
+  await expect(page.locator("#search-status")).toHaveClass(/warning/);
+  await expect(page.locator("#search-status")).not.toHaveClass(/error/);
+  await expect(page.locator("#query")).toHaveAttribute("aria-invalid", "true");
+  await expect(page.locator("#query")).toHaveAttribute("aria-describedby", "search-status");
+  await page.waitForTimeout(100);
   expect(asked.filter((path) => path.includes("/database/search/"))).toEqual([]);
   expect(asked.filter((path) => path === "/database/recent.json")).toEqual([]);
   await expect(page.locator("#entry-grid")).toBeHidden();
@@ -918,9 +926,63 @@ test("an over-limit linked or typed query starts no search or hidden landing wor
   await page.getByRole("button", { name: "Search" }).click();
   await expect(page.locator("#query")).toHaveValue(query);
   await expect(page.locator("#search-status")).toHaveText(
-    `The search could not be run: Search queries may contain at most ${SEARCH_TERM_LIMIT} distinct words.`,
+    `Use at most ${SEARCH_TERM_LIMIT} distinct normalized words; ` +
+      `this search has ${SEARCH_TERM_LIMIT + 1}. Common words count toward this limit.`,
   );
+  await page.waitForTimeout(100);
   expect(asked.filter((path) => path.includes("/database/search/"))).toEqual([]);
+
+  await page.locator("#query").fill("synthetically");
+  await page.getByRole("button", { name: "Search" }).click();
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
+  await expect(page.locator("#query")).not.toHaveAttribute("aria-invalid");
+  await expect(page.locator("#query")).not.toHaveAttribute("aria-describedby");
+
+  await page.locator("#query").fill("");
+  await page.getByRole("button", { name: "Search" }).click();
+  await expect(page.locator("#entry-grid")).toBeVisible();
+  await expect(page.locator("#search-status")).toBeHidden();
+});
+
+test("huge few-distinct linked and typed queries fail before I/O or history", async ({ page }) => {
+  const query = "echo ".repeat(Math.ceil((SEARCH_QUERY_CHARACTER_LIMIT + 1) / 5));
+  const asked = [];
+  const pageErrors = [];
+  page.on("request", (request) => {
+    const path = new URL(request.url()).pathname;
+    if (path.startsWith("/database/")) asked.push(path);
+  });
+  page.on("pageerror", (error) => pageErrors.push(error));
+
+  await page.goto(`/?database=${database}&q=${encodeURIComponent(query)}`);
+  await expect(page.locator("#search-status")).toContainText(
+    `Shorten the search to at most ${SEARCH_QUERY_CHARACTER_LIMIT} characters`,
+  );
+  await expect(page.locator("#query")).toHaveAttribute(
+    "maxlength",
+    String(SEARCH_QUERY_CHARACTER_LIMIT),
+  );
+  await expect(page.locator("#query")).toHaveAttribute("aria-invalid", "true");
+  await page.waitForTimeout(100);
+  expect(asked.filter((path) => path.startsWith("/database/search/"))).toEqual([]);
+  expect(asked.filter((path) => path === "/database/recent.json")).toEqual([]);
+  expect(pageErrors).toEqual([]);
+
+  await page.goto(`/?database=${database}`);
+  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
+  const before = page.url();
+  asked.length = 0;
+  await page.locator("#query").evaluate((input, value) => { input.value = value; }, query);
+  await page.locator("#registry-search").evaluate((form) => {
+    form.dispatchEvent(new SubmitEvent("submit", { bubbles: true, cancelable: true }));
+  });
+  await expect(page.locator("#search-status")).toContainText(
+    `Shorten the search to at most ${SEARCH_QUERY_CHARACTER_LIMIT} characters`,
+  );
+  await page.waitForTimeout(100);
+  expect(page.url()).toBe(before);
+  expect(asked.filter((path) => path.startsWith("/database/search/"))).toEqual([]);
+  expect(pageErrors).toEqual([]);
 });
 
 test("search cards retain posting order when posting pages finish out of order", async ({ page }) => {


### PR DESCRIPTION
## What changed

- validate a hard 4,096-character limit before normalization and a hard 20-distinct-normalized-word limit before any registry-data read
- use the same query-policy helper in the search engine, linked-query controller, and typed-query controller
- reject over-limit queries before browser-history construction or replacement, without silently truncating their terms
- mirror the character policy with HTML `maxlength` for immediate typing feedback
- present policy failures as actionable warnings and connect them to the search input with `aria-invalid` and `aria-describedby`
- document the complete 98-request maximum: one stopword list, 20 heads, 16 posting pages, 60 records, and one optional availability manifest

## Why

The bounded search pipeline capped pages, candidates, results, concurrency, and elapsed time, but a direct `?q=` could still contain arbitrarily many distinct accepted terms and start one head request per term. A term-only cap would still leave giant repeated-word queries doing unbounded normalization and URL/history work.

## User impact

Queries with at most 4,096 characters and 20 distinct normalized words behave as before. Common stopwords count toward the word limit because policy validation happens before loading the stopword list. Longer queries remain visible and receive a clear accessible warning telling the reader the actual length or term count, identically whether entered in the form or opened as a link. Correcting or clearing the query restores the normal state.

## Validation

- `PALOMAR_DATABASE_CHECKOUT=/home/kim/palomar/PalomarDatabase npm test` — 80 passed
- `nix shell nixpkgs#chromium -c bash -lc 'export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=$(command -v chromium); npm run test:browser'` — 46 passed, 2 expected compatibility skips
- `npm run build -- --version term-cap-review-2 --output .site`
- `git diff --check`

Regressions cover exact-limit head fanout, actual-count errors, repeated-term deduplication, huge few-distinct linked and typed queries, zero and settled-late I/O, no rejected-query history update or page error, warning accessibility state, valid-search recovery, and clear-to-landing recovery.
