### PR TITLE
Render landing cards from self-contained recent rows

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,20 +23,23 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      # The canonical database is private. The site re-validates every public
-      # record client-side, so compare against the schemas from the filtered
-      # public snapshot rather than cloning the canonical repository.
-      - name: Download the published schemas
+      # The canonical database is private. Exercise the contracts through the
+      # filtered public snapshot: its schemas and the producer-owned recent
+      # projection that the landing page consumes directly.
+      - name: Download the published Database contracts
         env:
           PUBLIC_DATA_ORIGIN: https://data.palomar-registry.org
         run: |
-          mkdir palomar-database
+          mkdir -p palomar-database/tests/fixtures
           curl --fail --silent --show-error --retry 3 \
             "$PUBLIC_DATA_ORIGIN/schema-v1.json" \
             --output palomar-database/schema-v1.json
           curl --fail --silent --show-error --retry 3 \
             "$PUBLIC_DATA_ORIGIN/schema-v2.json" \
             --output palomar-database/schema-v2.json
+          curl --fail --silent --show-error --retry 3 \
+            "$PUBLIC_DATA_ORIGIN/recent.json" \
+            --output palomar-database/tests/fixtures/recent.json
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.4.1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,20 +15,23 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      # The canonical database is private. The site re-validates every public
-      # record client-side, so compare against the schemas from the filtered
-      # public snapshot rather than cloning the canonical repository.
-      - name: Download the published schemas
+      # The canonical database is private. Exercise the contracts through the
+      # filtered public snapshot: its schemas and the producer-owned recent
+      # projection that the landing page consumes directly.
+      - name: Download the published Database contracts
         env:
           PUBLIC_DATA_ORIGIN: https://data.palomar-registry.org
         run: |
-          mkdir palomar-database
+          mkdir -p palomar-database/tests/fixtures
           curl --fail --silent --show-error --retry 3 \
             "$PUBLIC_DATA_ORIGIN/schema-v1.json" \
             --output palomar-database/schema-v1.json
           curl --fail --silent --show-error --retry 3 \
             "$PUBLIC_DATA_ORIGIN/schema-v2.json" \
             --output palomar-database/schema-v2.json
+          curl --fail --silent --show-error --retry 3 \
+            "$PUBLIC_DATA_ORIGIN/recent.json" \
+            --output palomar-database/tests/fixtures/recent.json
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.4.1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,11 @@
   agrees with everything. Without a checkout you get hard failures and no hint
   why, so this is the first thing to check.
 
+- `recent.json` is an exact closed producer/consumer contract. Shape changes
+  require a coordinated producer-first deployment from PalomarDatabase before
+  the matching Web deployment. Do not add an old-shape or per-entry fallback;
+  invalid projections are supposed to fail closed.
+
 - The browser suite needs `python3` on `PATH`, for the fixture server. Two of
   its tests want `PALOMAR_PREVIOUS_REF` and skip silently without it, which only
   CI sets.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,14 @@
     'export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=$(command -v chromium); npm run test:browser'
   ```
 
-- `npm test` reads `schema-v2.json` out of a PalomarDatabase checkout, from
+- `npm test` reads `schema-v2.json` and `tests/fixtures/recent.json` out of a
+  PalomarDatabase checkout, from
   `PALOMAR_DATABASE_CHECKOUT` or a sibling `../PalomarDatabase/`. An
-  unavailable schema is a failure rather than a skip, deliberately: the point of
-  the test is that this repository's validators agree with the schema the
-  records are written against, and a version of that test which quietly does
-  nothing agrees with everything. Without a checkout you get two hard failures
-  and no hint why, so this is the first thing to check.
+  unavailable contract is a failure rather than a skip, deliberately: the point
+  of the tests is that this repository's validators agree with the Database
+  outputs they read, and a version of those tests which quietly does nothing
+  agrees with everything. Without a checkout you get hard failures and no hint
+  why, so this is the first thing to check.
 
 - The browser suite needs `python3` on `PATH`, for the fixture server. Two of
   its tests want `PALOMAR_PREVIOUS_REF` and skip silently without it, which only

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ that complete closed shape and renders it directly. A normal landing load is
 therefore exactly two dynamic data requests—`recent.json` and the optional
 source-availability manifest—with no per-card entry reads. Invalid or partial
 projections fail closed before any card is rendered.
+This is one exact closed producer/consumer contract, not an extensible summary:
+a shape change must be published by PalomarDatabase first and followed by the
+matching website deployment. The consumer deliberately has no old-row fallback
+or per-entry recovery path.
 Landing and verified search cards render before the source-availability
 manifest; if it arrives, their existing source controls are decorated in place.
 A linked `?q=` search does not also load the hidden recent listing; clearing the

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ The site is static and deployed with GitHub Pages. It reads
 <https://data.palomar-registry.org/> at runtime, so publishing a database change
 does not require a coordinated website deployment. There is no whole-registry
 document there any more, and the pages are shaped by that: the landing page
-reads `recent.json`, an entry page reads `versions/<id>.json` and then the one
-record it wants, a search reads `search/stopwords.json` and a word's postings,
-and a withdrawn version reads its tombstone. Fetching the index and filtering it
-in a browser meant every visitor paid for the whole registry to see a couple of
-hundred rows, and paid more every time somebody else published anything.
+reads one self-contained `recent.json` projection, an entry page reads
+`versions/<id>.json` and then the one record it wants, a search reads
+`search/stopwords.json` and a word's postings, and a withdrawn version reads its
+tombstone. Fetching the index and filtering it in a browser meant every visitor
+paid for the whole registry to see a couple of hundred rows, and paid more every
+time somebody else published anything.
 
 The landing page and entry pages also load the current source-availability
 manifest. When an original pinned commit has been confirmed missing and the
@@ -42,10 +43,24 @@ to the newest matching version in the bounded candidate set, so a result is not
 repeated. A posting still says neither that a version is current nor how many
 active versions exist, so search cards make neither claim; landing cards get
 both facts from `recent.json`.
+Each `recent.json` row is the exact landing-card projection built from a
+validated canonical entry: identity, current/history count, registration time,
+title, abstract, authors, classifications, theorem names, trust, source commit
+and project path, and the source's preservation mapping. The browser validates
+that complete closed shape and renders it directly. A normal landing load is
+therefore exactly two dynamic data requests—`recent.json` and the optional
+source-availability manifest—with no per-card entry reads. Invalid or partial
+projections fail closed before any card is rendered.
 Landing and verified search cards render before the source-availability
 manifest; if it arrives, their existing source controls are decorated in place.
 A linked `?q=` search does not also load the hidden recent listing; clearing the
 search starts one landing attempt, and a failed attempt can be retried.
+
+Runtime reads use the browser's normal HTTP cache behavior. The public data
+service gives successful documents a 60-second browser/shared-cache lifetime,
+so repeat reads can be reused for that interval; missing and error responses are
+not stored. A withdrawn object can consequently remain visible from an already
+populated client or shared cache for at most 60 seconds.
 
 Local preview:
 
@@ -127,7 +142,4 @@ snapshot URLs remain permanent.
 
 This remains a runtime-JSON site: JavaScript is required for registry and entry
 content. The static shells explain this and point a no-JavaScript reader at the
-machine-readable data. Those links, and the footer's, still name the
-whole-registry `index.json` that the data service no longer serves, so they
-currently answer 404; they want to be `recent.json` on the landing page and
-`entries/<id>-v<n>.json` on an entry page.
+bounded newest-results or browse documents on the machine-readable data origin.

--- a/assets/app.js
+++ b/assets/app.js
@@ -40,8 +40,6 @@ const VERSION_PARAMETER = /^[1-9][0-9]*$/;
 const ARXIV_FILTER_RE = /^[a-z]+(?:-[a-z]+)*(?:\.[A-Za-z-]+)?$/;
 const MSC2020_FILTER_RE = /^[0-9]{2}(?:[A-Z][0-9]{2}|-[0-9]{2})$/;
 const FILTER_UPDATE_DELAY_MS = 200;
-const RECENT_ENTRY_CONCURRENCY = 8;
-const RECENT_ENTRY_TIMEOUT_MS = 30_000;
 const AVAILABILITY_TIMEOUT_MS = 30_000;
 
 function dataSource() {
@@ -88,7 +86,7 @@ function setOptionalText(selector, text) {
 }
 
 async function fetchJson(url, { signal } = {}) {
-  const response = await fetch(url, { cache: "no-cache", signal });
+  const response = await fetch(url, { signal });
   if (!response.ok) {
     const error = new Error(`${response.status} ${response.statusText}`);
     error.status = response.status;
@@ -234,8 +232,7 @@ function categoryTokens(entry) {
  * the registration it leads to are different moments, and the record carries
  * `registered_at` for exactly this.
  */
-function registrationDate(entry) {
-  const value = entry.registered_at;
+function registrationDate(value) {
   if (!/^\d{4}-\d{2}-\d{2}T/.test(value || "")) {
     throw new Error("entry is missing a valid registration date");
   }
@@ -327,7 +324,7 @@ function decorateCardSet(cards, entries, availability, context) {
 
 function entryCard(
   entry,
-  { versionCount = null, current = false } = {},
+  { versionCount = null, current = false, registeredAt = entry.registered_at } = {},
 ) {
   const categories = classification(entry);
   const card = el("article", "entry-card");
@@ -350,7 +347,7 @@ function entryCard(
   const identity = el("div", "card-identity");
   identity.append(
     el("span", "entry-id", `${entry.id} v${entry.version}${current ? " · current" : ""}`),
-    el("span", "entry-date", `Registered ${displayDate(registrationDate(entry))}`),
+    el("span", "entry-date", `Registered ${displayDate(registrationDate(registeredAt))}`),
   );
   top.append(identity, trustBadge(entry));
   const title = el("h3");
@@ -406,36 +403,6 @@ function entryCard(
   return card;
 }
 
-async function loadEntries(page, databaseBase) {
-  const settled = await loadSettledBounded(
-    page.entries,
-    async (summary, signal) => {
-      const entry = await fetchJson(entryRecordUrl(summary, databaseBase), { signal });
-      // Every response is still untrusted independently. Degraded loading
-      // means a malformed record is omitted, never rendered provisionally.
-      return validateEntry(entry, summary);
-    },
-    {
-      concurrency: RECENT_ENTRY_CONCURRENCY,
-      timeoutMs: RECENT_ENTRY_TIMEOUT_MS,
-    },
-  );
-  const entries = [];
-  let failed = 0;
-  for (const [position, result] of settled.entries()) {
-    if (result.status === "fulfilled") {
-      entries.push(result.value);
-    } else {
-      failed += 1;
-      console.warn(
-        `Recent entry ${page.entries[position].id} v${page.entries[position].version} ` +
-          `could not be loaded: ${result.reason?.message || String(result.reason)}`,
-      );
-    }
-  }
-  return { entries, failed };
-}
-
 let landingSuppressed = false;
 let landingStatusHidden = document.querySelector("#status")?.hidden ?? true;
 
@@ -466,55 +433,33 @@ async function renderIndex() {
     grid.replaceChildren();
     const { databaseBase, availabilityUrl } = dataSource();
     const availabilityPromise = loadAvailabilityBounded(availabilityUrl);
-    // What is new, not the whole registry. This page used to read a document
-    // naming every active version and then sort and filter it here, which was
-    // tens of megabytes for a screen of cards and grew every time anybody else
-    // published anything. The publisher decides which results are current and
-    // how many versions each has, so neither is worked out again here.
+    // The publisher projects every landing-card field from validated canonical
+    // entries into this bounded newest-first document. Rendering the selection
+    // therefore costs one summary read, not one record read per card.
     const recent = validateRecent(await fetchJson(recentUrl(databaseBase)));
-    const versionCounts = new Map(recent.entries.map((row) => [row.id, row.versions]));
-    const loaded = await loadEntries(recent, databaseBase);
-    const { entries } = loaded;
-    const recentTotal = recent.entries.length;
+    const entries = recent.entries;
     // GitHub Pages may briefly pair HTML and JavaScript from adjacent deployments.
     // Metrics are presentation-only, so a removed metric must not abort the registry.
-    // The validated summary still names every accepted result when an
-    // individual record is temporarily unavailable. Counting only rendered
-    // cards would make a transport failure look like a registry withdrawal.
-    setOptionalText("#metric-results", String(recentTotal));
+    setOptionalText("#metric-results", String(entries.length));
     setOptionalText(
       "#metric-projects",
       new Set(entries.map((entry) => entry.source.repository)).size,
     );
-    if (!entries.length && !recentTotal) {
+    if (!entries.length) {
       setLandingStatusHidden(false);
       status.textContent =
         "The telescope is ready. No entries have been published yet; the first accepted database PR will appear here automatically.";
       status.classList.add("empty");
       return true;
     }
-    if (!entries.length) {
-      setLandingStatusHidden(false);
-      status.textContent =
-        `No recent registry entries could be loaded (${loaded.failed} of ${recentTotal} failed). ` +
-        "Try again later.";
-      status.className = "status error";
-      return false;
-    }
-    const degradedMessage = loaded.failed
-      ? `The recent listing is incomplete: ${loaded.failed} of ${recentTotal} entries ` +
-        "could not be loaded."
-      : "";
-    setLandingStatusHidden(!degradedMessage);
-    status.textContent = degradedMessage;
-    status.className = degradedMessage ? "status warning" : "status";
-    // `loadEntries` keeps fulfilled values in recent.entries order even when
-    // its bounded parallel fetches finish out of order, so render the
-    // publisher's newest-first list.
+    setLandingStatusHidden(true);
+    status.textContent = "";
+    status.className = "status";
     const cards = entries.map((entry) =>
       entryCard(entry, {
-        versionCount: versionCounts.get(entry.id),
+        versionCount: entry.versions,
         current: true,
+        registeredAt: entry.published_at,
       }));
     grid.append(...cards);
     void availabilityPromise.then((availability) => {
@@ -577,7 +522,7 @@ async function renderIndex() {
         card.hidden = !visible;
         if (visible) shown += 1;
       }
-      setLandingStatusHidden(shown !== 0 && !degradedMessage);
+      setLandingStatusHidden(shown !== 0);
       const classificationQuery = [
         arxivValue && `arXiv ${arxivValue}`,
         mscValue && `MSC2020 ${mscValue}`,
@@ -587,13 +532,12 @@ async function renderIndex() {
         mscInvalid && "MSC2020",
       ].filter(Boolean);
       status.textContent = shown
-        ? degradedMessage
+        ? ""
         : invalidClassifications.length
           ? `No registry entries match the current filters. Invalid classification code format: ${invalidClassifications.join(", ")}.`
           : classificationQuery.length
           ? `No registry entries match the current filters. Classification query: ${classificationQuery.join(", ")}.`
           : "No registry entries match those filters.";
-      if (!shown && degradedMessage) status.textContent += ` ${degradedMessage}`;
     };
     let updateTimer;
     const scheduleUpdate = () => {
@@ -1181,7 +1125,7 @@ function acceptanceCallout(entry, databaseBase) {
     );
   }
   copy.append(
-    el("strong", "", `Registered on ${displayDate(registrationDate(entry))}`),
+    el("strong", "", `Registered on ${displayDate(registrationDate(entry.registered_at))}`),
     assurance(
       "Mechanical assurance",
       "Comparator checked that the recorded Solution proves the recorded formal Challenge under the listed axiom and dependency rules, and both Lean's kernel and NanoDa accepted the exported proof.",

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -61,6 +61,16 @@ function string(value, field) {
   return value;
 }
 
+function boundedString(value, field, maximum) {
+  const text = string(value, field);
+  let length = 0;
+  for (const _character of text) {
+    length += 1;
+    if (length > maximum) fail(`${field} is longer than ${maximum} characters`);
+  }
+  return text;
+}
+
 function integer(value, field) {
   if (!Number.isSafeInteger(value) || value < 1) fail(`${field} must be a positive integer`);
   return value;
@@ -242,8 +252,8 @@ export function validateRecent(value) {
     const id = string(summary.id, `${field}.id`);
     if (!ID_RE.test(id)) fail(`recent.entries[${position}].id is malformed`);
     const version = integer(summary.version, `${field}.version`);
-    string(summary.title, `${field}.title`);
-    string(summary.abstract, `${field}.abstract`);
+    boundedString(summary.title, `${field}.title`, 300);
+    boundedString(summary.abstract, `${field}.abstract`, 10_000);
     if (summary.status !== "accepted") fail(`recent.entries[${position}].status is not accepted`);
     const expectedPath = `entries/${id}-v${version}.json`;
     if (summary.path !== expectedPath) {
@@ -287,8 +297,18 @@ export function validateRecent(value) {
       ["arxiv", "msc2020"],
       `${field}.classification`,
     );
-    distinctStringArray(classification.arxiv, `${field}.classification.arxiv`, ARXIV_RE);
-    distinctStringArray(classification.msc2020, `${field}.classification.msc2020`, MSC2020_RE);
+    const arxiv = distinctStringArray(
+      classification.arxiv,
+      `${field}.classification.arxiv`,
+      ARXIV_RE,
+    );
+    if (arxiv.length > 2) fail(`${field}.classification.arxiv has more than 2 codes`);
+    const msc2020 = distinctStringArray(
+      classification.msc2020,
+      `${field}.classification.msc2020`,
+      MSC2020_RE,
+    );
+    if (msc2020.length > 8) fail(`${field}.classification.msc2020 has more than 8 codes`);
     const formalization = exactObject(
       summary.formalization,
       ["theorem_names"],

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -71,11 +71,32 @@ function array(value, field) {
   return value;
 }
 
+function exactObject(value, keys, field) {
+  const item = object(value, field);
+  const actual = Object.keys(item).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length ||
+      actual.some((key, position) => key !== expected[position])) {
+    fail(`${field} has an invalid shape`);
+  }
+  return item;
+}
+
 function stringArray(value, field) {
   for (const [position, item] of array(value, field).entries()) {
     string(item, `${field}[${position}]`);
   }
   return value;
+}
+
+function distinctStringArray(value, field, pattern = null) {
+  const items = stringArray(value, field);
+  if (!items.length) fail(`${field} must be a non-empty array`);
+  if (new Set(items).size !== items.length) fail(`${field} must contain distinct values`);
+  if (pattern && items.some((item) => !pattern.test(item))) {
+    fail(`${field} contains a malformed value`);
+  }
+  return items;
 }
 
 function commit(value, field) {
@@ -185,15 +206,14 @@ export function recentUrl(databaseBase) {
 /**
  * What is new, from `recent.json`.
  *
- * The rows are the ones the index carried, so the row grammar and
- * `entryRecordUrl` apply unchanged. What is new is coverage and ordering: this
- * document claims to be the newest current versions and no more than the
- * publisher's bound of them. A page in some other order renders perfectly well,
- * and so does one carrying a result twice under two versions, which is why
- * neither would be noticed by anything else.
+ * Each row is the publisher's exact, self-contained landing-card projection of
+ * one validated canonical entry. The deliberately small nested objects carry
+ * every field a card renders and no record-only fields. Besides that complete
+ * shape, this document claims to be the newest current versions and no more
+ * than the publisher's bound of them, so coverage and ordering are checked too.
  */
 export function validateRecent(value) {
-  const document = object(value, "recent");
+  const document = exactObject(value, ["schema_version", "entries"], "recent");
   if (document.schema_version !== RECENT_SCHEMA_VERSION) {
     fail(`unsupported recent schema_version ${String(document.schema_version)}`);
   }
@@ -202,18 +222,35 @@ export function validateRecent(value) {
   const seen = new Set();
   let previous = null;
   for (const [position, value] of entries.entries()) {
-    const summary = object(value, `recent.entries[${position}]`);
-    const id = string(summary.id, `recent.entries[${position}].id`);
+    const field = `recent.entries[${position}]`;
+    const summary = exactObject(value, [
+      "abstract",
+      "authors",
+      "classification",
+      "formalization",
+      "id",
+      "path",
+      "preservation",
+      "published_at",
+      "source",
+      "status",
+      "title",
+      "trust",
+      "version",
+      "versions",
+    ], field);
+    const id = string(summary.id, `${field}.id`);
     if (!ID_RE.test(id)) fail(`recent.entries[${position}].id is malformed`);
-    const version = integer(summary.version, `recent.entries[${position}].version`);
-    string(summary.title, `recent.entries[${position}].title`);
+    const version = integer(summary.version, `${field}.version`);
+    string(summary.title, `${field}.title`);
+    string(summary.abstract, `${field}.abstract`);
     if (summary.status !== "accepted") fail(`recent.entries[${position}].status is not accepted`);
     const expectedPath = `entries/${id}-v${version}.json`;
     if (summary.path !== expectedPath) {
       fail(`recent.entries[${position}].path must be ${expectedPath}`);
     }
-    integer(summary.versions, `recent.entries[${position}].versions`);
-    const publishedAt = string(summary.published_at, `recent.entries[${position}].published_at`);
+    integer(summary.versions, `${field}.versions`);
+    const publishedAt = string(summary.published_at, `${field}.published_at`);
     // An instant, and only an instant. This is the record's `registered_at`,
     // which the schema requires of every version. A date was tolerated while a
     // row could fall back to `accepted_at`, and a date read as an instant is
@@ -223,13 +260,76 @@ export function validateRecent(value) {
       fail(`recent.entries[${position}].published_at is malformed`);
     }
     const moment = Date.parse(publishedAt);
-    if (Number.isNaN(moment)) fail(`recent.entries[${position}].published_at is malformed`);
-    if (previous !== null && moment > previous) fail("recent is not in newest-first order");
-    previous = moment;
+    if (Number.isNaN(moment) ||
+        new Date(moment).toISOString().replace(".000Z", "Z") !== publishedAt) {
+      fail(`recent.entries[${position}].published_at is malformed`);
+    }
+    if (previous !== null &&
+        (moment > previous.moment || (moment === previous.moment && id > previous.id))) {
+      fail("recent is not in newest-first order");
+    }
+    previous = { moment, id };
     // One row per result, because these are the current versions: the same
     // identifier twice means this is not the selection it says it is.
     if (seen.has(id)) fail(`recent names ${id} more than once`);
     seen.add(id);
+
+    const authors = array(summary.authors, `${field}.authors`);
+    if (!authors.length) fail(`${field}.authors must be a non-empty array`);
+    for (const [authorPosition, authorValue] of authors.entries()) {
+      const authorField = `${field}.authors[${authorPosition}]`;
+      const author = exactObject(authorValue, ["name"], authorField);
+      string(author.name, `${authorField}.name`);
+    }
+
+    const classification = exactObject(
+      summary.classification,
+      ["arxiv", "msc2020"],
+      `${field}.classification`,
+    );
+    distinctStringArray(classification.arxiv, `${field}.classification.arxiv`, ARXIV_RE);
+    distinctStringArray(classification.msc2020, `${field}.classification.msc2020`, MSC2020_RE);
+    const formalization = exactObject(
+      summary.formalization,
+      ["theorem_names"],
+      `${field}.formalization`,
+    );
+    distinctStringArray(formalization.theorem_names, `${field}.formalization.theorem_names`);
+    const trust = exactObject(summary.trust, ["level"], `${field}.trust`);
+    if (!["high", "qualified"].includes(trust.level)) fail(`${field}.trust.level is invalid`);
+
+    const source = exactObject(
+      summary.source,
+      ["repository", "commit", "project_path"],
+      `${field}.source`,
+    );
+    const repository = string(source.repository, `${field}.source.repository`);
+    if (!REPOSITORY_RE.test(repository)) fail(`${field}.source.repository is malformed`);
+    commit(string(source.commit, `${field}.source.commit`), `${field}.source.commit`);
+    if (source.project_path !== null) safeRepositoryPath(source.project_path, `${field}.source.project_path`);
+
+    if (summary.preservation !== null) {
+      const preservation = exactObject(
+        summary.preservation,
+        ["repositories"],
+        `${field}.preservation`,
+      );
+      const repositories = array(preservation.repositories, `${field}.preservation.repositories`);
+      if (repositories.length !== 1) fail(`${field}.preservation must contain one source mapping`);
+      const mapping = exactObject(repositories[0], [
+        "source_repository",
+        "commit",
+        "fork_repository",
+      ], `${field}.preservation.repositories[0]`);
+      if (typeof mapping.source_repository !== "string" ||
+          mapping.source_repository.toLowerCase() !== repository.toLowerCase() ||
+          mapping.commit !== source.commit ||
+          typeof mapping.fork_repository !== "string" ||
+          !REPOSITORY_RE.test(mapping.fork_repository) ||
+          !mapping.fork_repository.startsWith("PalomarArchive/")) {
+        fail(`${field}.preservation does not match source`);
+      }
+    }
   }
   return document;
 }

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -180,6 +180,45 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
     return record
 
 
+def recent_row(record: dict, versions: int) -> dict:
+    """Project exactly the landing-card contract emitted by PalomarDatabase."""
+    source = record["source"]
+    mapping = next(
+        item
+        for item in record["preservation"]["repositories"]
+        if item["source_repository"].casefold() == source["repository"].casefold()
+        and item["commit"] == source["commit"]
+    )
+    return {
+        "id": record["id"],
+        "version": record["version"],
+        "status": record["status"],
+        "title": record["title"],
+        "path": f"entries/{record['id']}-v{record['version']}.json",
+        "abstract": record["abstract"],
+        "authors": [{"name": author["name"]} for author in record["authors"]],
+        "classification": record["classification"],
+        "formalization": {
+            "theorem_names": record["formalization"]["theorem_names"],
+        },
+        "trust": {"level": record["trust"]["level"]},
+        "source": {
+            "repository": source["repository"],
+            "commit": source["commit"],
+            "project_path": source.get("project_path"),
+        },
+        "preservation": {
+            "repositories": [{
+                "source_repository": mapping["source_repository"],
+                "commit": mapping["commit"],
+                "fork_repository": mapping["fork_repository"],
+            }]
+        },
+        "published_at": record["registered_at"],
+        "versions": versions,
+    }
+
+
 ENTRIES = {
     ("PALOMAR-2026-07-29-000123", 1): entry(
         "PALOMAR-2026-07-29-000123", 100, 1
@@ -307,18 +346,7 @@ class Handler(SimpleHTTPRequestHandler):
                 if previous is None or item["version"] > previous["version"]:
                     current[item["id"]] = item
             versions = collections.Counter(item["id"] for item in ENTRIES.values())
-            rows = [
-                {
-                    "id": item["id"],
-                    "version": item["version"],
-                    "title": item["title"],
-                    "status": "accepted",
-                    "path": f"entries/{item['id']}-v{item['version']}.json",
-                    "published_at": item["registered_at"],
-                    "versions": versions[item["id"]],
-                }
-                for item in current.values()
-            ]
+            rows = [recent_row(item, versions[item["id"]]) for item in current.values()]
             # Newest first, ties broken by identifier descending, exactly as
             # `selection.latest_entries` orders them in the publisher.
             rows.sort(key=lambda row: (row["published_at"], row["id"]), reverse=True)

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -183,11 +183,20 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
 def recent_row(record: dict, versions: int) -> dict:
     """Project exactly the landing-card contract emitted by PalomarDatabase."""
     source = record["source"]
-    mapping = next(
-        item
-        for item in record["preservation"]["repositories"]
-        if item["source_repository"].casefold() == source["repository"].casefold()
-        and item["commit"] == source["commit"]
+    preservation = record.get("preservation")
+    mapping = (
+        next(
+            (
+                item
+                for item in preservation["repositories"]
+                if item["source_repository"].casefold()
+                == source["repository"].casefold()
+                and item["commit"] == source["commit"]
+            ),
+            None,
+        )
+        if preservation
+        else None
     )
     return {
         "id": record["id"],
@@ -213,7 +222,7 @@ def recent_row(record: dict, versions: int) -> dict:
                 "commit": mapping["commit"],
                 "fork_repository": mapping["fork_repository"],
             }]
-        },
+        } if mapping else None,
         "published_at": record["registered_at"],
         "versions": versions,
     }
@@ -281,7 +290,7 @@ ENTRIES[("PALOMAR-2026-07-29-000124", 1)]["trust"].update(
 # case the published stopword list exists for: a query containing "the" has to
 # find it anyway, and inferring stopwords from a missing head could not.
 ENTRIES[("PALOMAR-2026-07-29-000124", 1)]["abstract"] = (
-    "Quasicoherent sheaves, synthetically."
+    "Quasicoherent sheaves, synthetically. Cacheprobe."
 )
 SEARCH_INDEX = search_index(ENTRIES)
 
@@ -290,11 +299,16 @@ class Handler(SimpleHTTPRequestHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=str(ROOT), **kwargs)
 
-    def send_bytes(self, payload: bytes, content_type: str) -> None:
+    def send_bytes(
+        self,
+        payload: bytes,
+        content_type: str,
+        cache_control: str = "no-store",
+    ) -> None:
         self.send_response(200)
         self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(len(payload)))
-        self.send_header("Cache-Control", "no-store")
+        self.send_header("Cache-Control", cache_control)
         self.end_headers()
         self.wfile.write(payload)
 
@@ -429,7 +443,13 @@ class Handler(SimpleHTTPRequestHandler):
             else:
                 self.send_error(404)
                 return
-            self.send_bytes(json.dumps(payload).encode(), "application/json")
+            self.send_bytes(
+                json.dumps(payload).encode(),
+                "application/json",
+                cache_control=(
+                    "public, max-age=60" if term == "cacheprobe" else "no-store"
+                ),
+            )
             return
         tombstone = re.fullmatch(
             r"/database/tombstones/(PALOMAR-2026-07-29-000125)-v(1)\.json",

--- a/tests/registry-fixture.mjs
+++ b/tests/registry-fixture.mjs
@@ -24,7 +24,41 @@ export function secondVersion(overrides = {}) {
 }
 
 export function recentRow(overrides = {}) {
-  return { ...summary(), published_at: "2026-07-29T09:14:07Z", versions: 1, ...overrides };
+  const record = entry();
+  const sourceMapping = record.preservation?.repositories.find(
+    (mapping) =>
+      mapping.source_repository.toLowerCase() === record.source.repository.toLowerCase() &&
+      mapping.commit === record.source.commit,
+  );
+  return {
+    id: record.id,
+    version: record.version,
+    status: record.status,
+    title: record.title,
+    path: `entries/${record.id}-v${record.version}.json`,
+    abstract: record.abstract,
+    authors: record.authors.map(({ name }) => ({ name })),
+    classification: structuredClone(record.classification),
+    formalization: { theorem_names: [...record.formalization.theorem_names] },
+    trust: { level: record.trust.level },
+    source: {
+      repository: record.source.repository,
+      commit: record.source.commit,
+      project_path: record.source.project_path ?? null,
+    },
+    preservation: sourceMapping
+      ? {
+          repositories: [{
+            source_repository: sourceMapping.source_repository,
+            commit: sourceMapping.commit,
+            fork_repository: sourceMapping.fork_repository,
+          }],
+        }
+      : null,
+    published_at: record.registered_at,
+    versions: 1,
+    ...overrides,
+  };
 }
 
 export function recent(entries = [recentRow()], overrides = {}) {

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -176,7 +176,12 @@ test("recent validation accepts the Database-owned landing-card fixture", async 
   const fixture = JSON.parse(
     await readFile(new URL("tests/fixtures/recent.json", `file://${checkout}/`), "utf8"),
   );
+  assert.ok(fixture.entries.length > 0, "the external contract fixture must exercise a row");
   assert.equal(validateRecent(fixture), fixture);
+});
+
+test("an empty recent registry is valid", () => {
+  assert.deepEqual(validateRecent(recent([])).entries, []);
 });
 
 test("recent is one exact complete projection, not a legacy summary shape", () => {
@@ -211,6 +216,31 @@ test("recent validates every projected card field and source mapping", () => {
   const mismatchedPreservation = recent();
   mismatchedPreservation.entries[0].preservation.repositories[0].commit = "2".repeat(40);
   assert.throws(() => validateRecent(mismatchedPreservation), /does not match source/);
+});
+
+test("recent applies the canonical producer's cheap presentation bounds", () => {
+  for (const [field, maximum] of [["title", 300], ["abstract", 10_000]]) {
+    const atBound = recent();
+    atBound.entries[0][field] = "x".repeat(maximum);
+    assert.equal(validateRecent(atBound), atBound);
+
+    const overBound = recent();
+    overBound.entries[0][field] = "x".repeat(maximum + 1);
+    assert.throws(() => validateRecent(overBound), new RegExp(`longer than ${maximum}`));
+  }
+
+  const classifications = recent();
+  classifications.entries[0].classification.arxiv = ["math.CO", "math.NT"];
+  classifications.entries[0].classification.msc2020 = Array.from(
+    { length: 8 },
+    (_unused, position) => `10A${String(position + 1).padStart(2, "0")}`,
+  );
+  assert.equal(validateRecent(classifications), classifications);
+  classifications.entries[0].classification.arxiv.push("cs.DM");
+  assert.throws(() => validateRecent(classifications), /more than 2 codes/);
+  classifications.entries[0].classification.arxiv.pop();
+  classifications.entries[0].classification.msc2020.push("10A09");
+  assert.throws(() => validateRecent(classifications), /more than 8 codes/);
 });
 
 test("a record must say when the version was registered, and agree with its result date", () => {
@@ -283,6 +313,16 @@ test("what recent claims is coverage and ordering, so both are checked", () => {
     () => validateRecent(recent([recentRow(), recentRow({ version: 2, path: "entries/PALOMAR-2026-07-29-000123-v2.json" })])),
     /more than once/,
   );
+});
+
+test("recent breaks equal publication timestamps by descending identifier", () => {
+  const lower = recentRow();
+  const higher = recentRow({
+    id: "PALOMAR-2026-07-29-000124",
+    path: "entries/PALOMAR-2026-07-29-000124-v1.json",
+  });
+  assert.deepEqual(validateRecent(recent([higher, lower])).entries, [higher, lower]);
+  assert.throws(() => validateRecent(recent([lower, higher])), /newest-first/);
 });
 
 test("recent is bounded, because the document it replaced was the registry", () => {

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -167,6 +167,52 @@ test("recent validation rejects unsupported, rejected, and malformed rows", () =
   assert.equal(validateRecent(recent()).entries.length, 1);
 });
 
+test("recent validation accepts the Database-owned landing-card fixture", async () => {
+  // This is the same mandatory cross-repository contract mechanism used for
+  // canonical schemas below. Locally it reads PalomarDatabase's checked
+  // fixture; CI supplies the published producer output at the same path.
+  const checkout = process.env.PALOMAR_DATABASE_CHECKOUT
+    ?? new URL("../../PalomarDatabase/", import.meta.url).pathname;
+  const fixture = JSON.parse(
+    await readFile(new URL("tests/fixtures/recent.json", `file://${checkout}/`), "utf8"),
+  );
+  assert.equal(validateRecent(fixture), fixture);
+});
+
+test("recent is one exact complete projection, not a legacy summary shape", () => {
+  assert.throws(
+    () => validateRecent({ schema_version: 1, entries: [summary()] }),
+    /invalid shape/,
+  );
+
+  for (const mutate of [
+    (page) => { page.legacy_entries = []; },
+    (page) => { delete page.entries[0].abstract; },
+    (page) => { page.entries[0].registered_at = page.entries[0].published_at; },
+    (page) => { delete page.entries[0].source.project_path; },
+    (page) => { page.entries[0].authors[0].github = "somebody"; },
+    (page) => { page.entries[0].preservation.repositories = []; },
+  ]) {
+    const page = recent();
+    mutate(page);
+    assert.throws(() => validateRecent(page), /invalid shape|must contain one source mapping/);
+  }
+});
+
+test("recent validates every projected card field and source mapping", () => {
+  const duplicateClassifications = recent();
+  duplicateClassifications.entries[0].classification.arxiv.push("math.CO");
+  assert.throws(() => validateRecent(duplicateClassifications), /distinct values/);
+
+  const missingTheorems = recent();
+  missingTheorems.entries[0].formalization.theorem_names = [];
+  assert.throws(() => validateRecent(missingTheorems), /non-empty array/);
+
+  const mismatchedPreservation = recent();
+  mismatchedPreservation.entries[0].preservation.repositories[0].commit = "2".repeat(40);
+  assert.throws(() => validateRecent(mismatchedPreservation), /does not match source/);
+});
+
 test("a record must say when the version was registered, and agree with its result date", () => {
   // The two are one fact written twice, in two repositories. `accepted_at` is
   // the result's date: the identifier carries it, browsing pages by it, and

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -919,6 +919,33 @@ test("a search reads one postings sequence per word and confirms every hit", asy
     .toEqual(["/database/entries/PALOMAR-2026-07-29-000124-v1.json"]);
 });
 
+test("runtime data reads reuse a fresh HTTP response", async ({ page }) => {
+  const headUrl = "http://127.0.0.1:4173/database/search/t/cacheprobe/head.json";
+  const timings = () => page.evaluate((url) =>
+    performance.getEntriesByName(url).map((entry) => ({
+      decodedBodySize: entry.decodedBodySize,
+      transferSize: entry.transferSize,
+    })), headUrl);
+
+  await page.goto(`/?database=${database}`);
+  await page.evaluate(() => performance.clearResourceTimings());
+  await page.locator("#query").fill("cacheprobe");
+  await page.getByRole("button", { name: "Search" }).click();
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
+  await expect.poll(async () => (await timings()).length).toBe(1);
+
+  // The fixture gives this otherwise ordinary postings document max-age=60.
+  // Submitting the same search still calls fetch, but the browser should
+  // satisfy it from its HTTP cache rather than transferring it again.
+  await page.getByRole("button", { name: "Search" }).click();
+  await expect.poll(async () => (await timings()).length).toBe(2);
+  const [network, cached] = await timings();
+  expect(network.transferSize).toBeGreaterThan(0);
+  expect(network.decodedBodySize).toBeGreaterThan(0);
+  expect(cached.transferSize).toBe(0);
+  expect(cached.decodedBodySize).toBe(network.decodedBodySize);
+});
+
 test("an over-limit term count is an accessible warning and can be corrected", async ({ page }) => {
   const query = Array.from(
     { length: SEARCH_TERM_LIMIT + 1 },

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -97,7 +97,14 @@ test("every formalization.yaml mention on the About page links to its standard",
 });
 
 test("landing cards show the registration date and dated identifier", async ({ page }) => {
-  await page.route("**/entries/PALOMAR-2026-07-29-000123-v1.json", (route) => route.abort());
+  const dynamicRequests = [];
+  page.on("request", (request) => {
+    const path = new URL(request.url()).pathname;
+    if (path.startsWith("/database/")) dynamicRequests.push(path);
+  });
+  // A landing record read is a regression even if its result happens to be
+  // valid, so make one fail loudly instead of letting it hide in the fixture.
+  await page.route("**/database/entries/*.json", (route) => route.abort());
   await page.goto(`/?database=${database}`);
   const first = page.locator(".entry-card").first();
   await expect(first.locator(".entry-id")).toContainText("PALOMAR-2026-07-29-");
@@ -120,8 +127,29 @@ test("landing cards show the registration date and dated identifier", async ({ p
   await expect(first.locator(".card-subjects")).toContainText("MSC 05C10");
   await expect(first.locator(".card-project")).toContainText("Project directory");
   await expect(first.locator(".card-project")).toContainText("project");
+  await expect(first.locator("h3")).toContainText("version 2");
+  await expect(first.locator(".card-abstract")).toContainText("quasicoherent behaviour");
+  await expect(first.locator(".card-meta")).toContainText("Example");
+  await expect(first.locator(".card-meta")).toContainText("Example.theorem");
+  await expect(first.locator(".repo-link")).toHaveAttribute(
+    "href",
+    /github\.com\/example\/challenge\/tree\/1{40}$/,
+  );
+  await expect(first.locator(".archive-link")).toHaveAttribute(
+    "href",
+    /github\.com\/PalomarArchive\/example--challenge\/tree\/1{40}$/,
+  );
+  await expect(page.locator("#metric-results")).toHaveText("2");
+  await expect(page.locator("#metric-projects")).toHaveText("1");
   await expect(page.getByRole("button", { name: "Mathlib only" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Additional libraries" })).toBeVisible();
+  await expect.poll(() => [...dynamicRequests].sort()).toEqual([
+    "/database/recent.json",
+    "/database/source-availability.json",
+  ]);
+  await page.waitForTimeout(100);
+  expect(dynamicRequests.filter((path) => path.startsWith("/database/entries/"))).toEqual([]);
+  expect(dynamicRequests).toHaveLength(2);
 });
 
 test("landing cards preserve the publisher's newest-first order", async ({ page }) => {
@@ -140,13 +168,6 @@ test("landing cards preserve the publisher's newest-first order", async ({ page 
     }));
     await route.fulfill({ response, json: recent });
   });
-  await page.route("**/database/entries/*.json", async (route) => {
-    const response = await route.fetch();
-    const entry = await response.json();
-    entry.registered_at = registeredAt.get(entry.id);
-    await route.fulfill({ response, json: entry });
-  });
-
   await page.goto(`/?database=${database}`);
 
   // Recency and identifier order deliberately disagree. The DOM must follow
@@ -157,47 +178,52 @@ test("landing cards preserve the publisher's newest-first order", async ({ page 
   ]);
 });
 
-test("one malformed recent entry does not hide valid cards", async ({ page }) => {
-  await page.route("**/database/entries/PALOMAR-2026-07-29-000123-v2.json", async (route) => {
+test("old, partial, and malformed recent summaries fail closed before rendering", async ({ page }) => {
+  let variant = "old";
+  const entryRequests = [];
+  page.on("request", (request) => {
+    const path = new URL(request.url()).pathname;
+    if (path.startsWith("/database/entries/")) entryRequests.push(path);
+  });
+  await page.route("**/database/recent.json", async (route) => {
     const response = await route.fetch();
-    const malformed = await response.json();
-    malformed.title = "";
-    await route.fulfill({ response, json: malformed });
+    const document = await response.json();
+    if (variant === "old") {
+      document.entries = document.entries.map((row) => ({
+        id: row.id,
+        version: row.version,
+        title: row.title,
+        status: row.status,
+        path: row.path,
+        published_at: row.published_at,
+        versions: row.versions,
+      }));
+    } else if (variant === "partial") {
+      delete document.entries[0].abstract;
+    } else {
+      document.entries[0].preservation.repositories[0].commit = "2".repeat(40);
+    }
+    await route.fulfill({ response, json: document });
   });
 
-  await page.goto(`/?database=${database}`);
-
-  await expect(page.locator("#entry-grid .entry-card .entry-id")).toHaveText([
-    "PALOMAR-2026-07-29-000124 v1 · current",
-  ]);
-  await expect(page.locator("#status")).toHaveText(
-    "The recent listing is incomplete: 1 of 2 entries could not be loaded.",
-  );
-  await expect(page.locator("#status")).toHaveClass(/warning/);
-  await expect(page.locator("#metric-results")).toHaveText("2");
-
-  await page.locator("#arxiv-query").fill("math.NT");
-  await expect(page.locator(".entry-card:visible")).toHaveCount(1);
-  await expect(page.locator("#status")).toHaveText(
-    "The recent listing is incomplete: 1 of 2 entries could not be loaded.",
-  );
-
-  await page.locator("#arxiv-query").fill("math.CO");
-  await expect(page.locator(".entry-card:visible")).toHaveCount(0);
-  await expect(page.locator("#status")).toHaveText(
-    "No registry entries match the current filters. Classification query: arXiv math.CO. " +
-      "The recent listing is incomplete: 1 of 2 entries could not be loaded.",
-  );
+  for (const selected of ["old", "partial", "malformed"]) {
+    variant = selected;
+    await page.goto(`/?database=${database}&contract-case=${selected}`);
+    await expect(page.locator("#entry-grid .entry-card")).toHaveCount(0);
+    await expect(page.locator("#status")).toHaveClass(/error/);
+    await expect(page.locator("#status")).toContainText("The registry could not be loaded");
+  }
+  expect(entryRequests).toEqual([]);
 });
 
-test("an entirely unavailable recent selection reports failure instead of emptiness", async ({ page }) => {
-  await page.route("**/database/entries/*.json", (route) => route.abort());
+test("an unavailable recent summary reports failure instead of emptiness", async ({ page }) => {
+  await page.route("**/database/recent.json", (route) =>
+    route.fulfill({ status: 503, body: "temporarily unavailable" }),
+  );
 
   await page.goto(`/?database=${database}`);
 
-  await expect(page.locator("#status")).toHaveText(
-    "No recent registry entries could be loaded (2 of 2 failed). Try again later.",
-  );
+  await expect(page.locator("#status")).toContainText("The registry could not be loaded: 503");
   await expect(page.locator("#entry-grid .entry-card")).toHaveCount(0);
   await expect(page.locator("#status")).toHaveClass(/error/);
   await expect(page.locator("#status")).not.toContainText("No entries have been published");
@@ -393,12 +419,12 @@ test("a card for a result accepted before archiving does not call its original u
   // read that silence as a missing original and printed "Original unavailable"
   // beside somebody else's repository, which is a published claim about a
   // third party's work made on no evidence.
-  await page.route("**/entries/PALOMAR-2026-07-29-000123-v2.json", async (route) => {
+  await page.route("**/database/recent.json", async (route) => {
     const response = await route.fetch();
-    const legacy = await response.json();
-    legacy.schema_version = 1;
-    delete legacy.preservation;
-    await route.fulfill({ response, json: legacy });
+    const recent = await response.json();
+    const legacy = recent.entries.find((row) => row.id === "PALOMAR-2026-07-29-000123");
+    legacy.preservation = null;
+    await route.fulfill({ response, json: recent });
   });
   await page.goto(`/?database=${database}`);
 


### PR DESCRIPTION
## What changed

- validate the complete closed recent.json landing-card projection introduced by PalomarDatabase #96, including nested card, source, preservation, ordering, uniqueness, and bound invariants
- render landing cards directly from recent rows and delete the 200-record landing loader, its timeout, and its concurrency policy
- leave linked search isolated from landing work and preserve filters, metrics, progressive availability decoration, source/archive links, focus, recency, dates, current labels, and history counts
- let normal browser caching honor the data service's 60-second successful-response policy instead of forcing revalidation
- exercise the nonempty Database-owned recent fixture through the existing PALOMAR_DATABASE_CHECKOUT contract path and in exact browser fixtures
- match the producer's title, abstract, arXiv, and MSC2020 bounds and its equal-timestamp identifier ordering

## Why

The landing page already selected at most 200 rows, but then fetched one canonical entry for every row. Database #96 made recent.json the validated self-contained card projection, so retaining that fanout would preserve the dominant request and runtime term without adding correctness.

## Impact

A normal landing view falls from as many as 202 dynamic data requests (recent + availability + 200 entries) to exactly two (recent + availability), with zero landing entry reads. Old, partial, or malformed summary shapes now fail closed before rendering; there is no legacy or entry-fetch fallback. Search and entry pages keep their existing bounded/canonical reads.

This is deliberately an exact closed producer/consumer contract. Deployment order is producer first: PalomarDatabase #96 is merged and the published recent.json now validates against this consumer. Future shape changes require the same producer-first coordination.

## Checks

- PALOMAR_DATABASE_CHECKOUT=/tmp/palomar-database-contract.fl3MxX/PalomarDatabase npm test (86 passed)
- npm run build -- --version review-amendment --output .site
- PALOMAR_PREVIOUS_REF=origin/main npm run test:browser under Nix Chromium (49 passed, including deployment compatibility)
- behavioral HTTP-cache regression proves a second real UI fetch transfers zero bytes; check-published's deliberate no-store probe is unchanged
- published https://data.palomar-registry.org/recent.json validated locally with the new consumer
- git diff --check; Node syntax checks; Python fixture syntax check