### PR TITLE
Enforce per-endpoint source freshness

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,6 +40,9 @@ jobs:
           curl --fail --silent --show-error --retry 3 \
             "$PUBLIC_DATA_ORIGIN/recent.json" \
             --output palomar-database/tests/fixtures/recent.json
+          curl --fail --silent --show-error --retry 3 \
+            "$PUBLIC_DATA_ORIGIN/source-availability.json" \
+            --output palomar-database/tests/fixtures/source-availability.json
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.4.1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,9 @@ jobs:
           curl --fail --silent --show-error --retry 3 \
             "$PUBLIC_DATA_ORIGIN/recent.json" \
             --output palomar-database/tests/fixtures/recent.json
+          curl --fail --silent --show-error --retry 3 \
+            "$PUBLIC_DATA_ORIGIN/source-availability.json" \
+            --output palomar-database/tests/fixtures/source-availability.json
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.4.1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,9 @@
   in the future through eighteen hours old, inclusively; malformed or older
   observations become unknown without hiding valid siblings. Contract changes
   are deployed producer-first and the cross-repository unit test is mandatory.
+  With a canonical Database checkout the test invokes its executable contract;
+  CI cannot read that private checkout, so it downloads the deployed object and
+  requires the producer's declared freshness maximum to equal the consumer's.
 
 - The browser suite needs `python3` on `PATH`, for the fixture server. Two of
   its tests want `PALOMAR_PREVIOUS_REF` and skip silently without it, which only

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,13 @@
   the matching Web deployment. Do not add an old-shape or per-entry fallback;
   invalid projections are supposed to fail closed.
 
+- `source-availability.json` is normalized by PalomarDatabase's executable
+  source-availability contract and consumed under the same per-endpoint
+  freshness rules here. A known answer is authoritative only from five minutes
+  in the future through eighteen hours old, inclusively; malformed or older
+  observations become unknown without hiding valid siblings. Contract changes
+  are deployed producer-first and the cross-repository unit test is mandatory.
+
 - The browser suite needs `python3` on `PATH`, for the fixture server. Two of
   its tests want `PALOMAR_PREVIOUS_REF` and skip silently without it, which only
   CI sets.

--- a/README.md
+++ b/README.md
@@ -17,13 +17,17 @@ The landing page and entry pages also load the current source-availability
 manifest. When an original pinned commit has been confirmed missing and the
 recorded archive is not itself known to be missing, source links automatically
 switch to the `PalomarArchive` copy while still displaying the original
-location. Missing archives are shown as degraded. The manifest and every known
-endpoint observation independently have an inclusive eighteen-hour maximum age
-and five-minute future-clock allowance. An endpoint whose `checked_at` is
-missing, malformed, too far in the future, or one second older is treated as
-unknown without discarding fresh sibling rows; a stale or unavailable whole
-manifest is likewise never believed. `last_attempt_at` may be null when the
-bounded producer has never attempted that endpoint.
+location. Missing archives are shown as degraded; the notice says the original
+still works only when its own observation confirms that, and otherwise describes
+the recorded original neutrally. The manifest and every known endpoint
+observation independently have an inclusive eighteen-hour maximum age and
+five-minute future-clock allowance. The producer declares that maximum in
+`coverage.freshness_max_age_seconds`, and the browser rejects a document that
+disagrees. An endpoint whose `checked_at` is missing, malformed, too far in the
+future, or one second older is treated as unknown without discarding fresh
+sibling rows; a stale or unavailable whole manifest is likewise never believed.
+`last_attempt_at` may be null when the bounded producer has never attempted that
+endpoint.
 Registry cards display arXiv and MSC2020 classifications, and the toolbar can
 filter the rows the landing page holds by either taxonomy. The classification
 fields suggest codes represented by those rows but also accept any exact code,

--- a/README.md
+++ b/README.md
@@ -17,8 +17,13 @@ The landing page and entry pages also load the current source-availability
 manifest. When an original pinned commit has been confirmed missing and the
 recorded archive is not itself known to be missing, source links automatically
 switch to the `PalomarArchive` copy while still displaying the original
-location. Missing archives are shown as degraded, and a stale or unavailable
-manifest is discarded rather than believed.
+location. Missing archives are shown as degraded. The manifest and every known
+endpoint observation independently have an inclusive eighteen-hour maximum age
+and five-minute future-clock allowance. An endpoint whose `checked_at` is
+missing, malformed, too far in the future, or one second older is treated as
+unknown without discarding fresh sibling rows; a stale or unavailable whole
+manifest is likewise never believed. `last_attempt_at` may be null when the
+bounded producer has never attempted that endpoint.
 Registry cards display arXiv and MSC2020 classifications, and the toolbar can
 filter the rows the landing page holds by either taxonomy. The classification
 fields suggest codes represented by those rows but also accept any exact code,

--- a/assets/app.js
+++ b/assets/app.js
@@ -1217,10 +1217,18 @@ function sourceAvailabilityNotice(entry, availability) {
     );
   } else if (location.archiveStatus === "missing") {
     notice.classList.add("archive-missing");
+    const originalConfirmed = location.originalStatus === "available";
     notice.append(
       el("strong", "", "Source preservation degraded"),
-      el("p", "", "The original source still works, but Palomar's preserved copy is unavailable."),
-      externalLink("Original source", original),
+      el(
+        "p",
+        "",
+        originalConfirmed
+          ? "The original source still works, but Palomar's preserved copy is unavailable."
+          : "Palomar's preserved copy is unavailable. The recorded original location remains " +
+            "linked, but its current availability has not been confirmed.",
+      ),
+      externalLink(originalConfirmed ? "Original source" : "Recorded original location", original),
       " · ",
       externalLink("Recorded Palomar copy", archived),
     );

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -45,7 +45,8 @@ const ARXIV_RE = /^[a-z]+(?:-[a-z]+)*(?:\.[A-Za-z-]+)?$/;
 const MSC2020_RE = /^[0-9]{2}(?:[A-Z][0-9]{2}|-[0-9]{2})$/;
 const LICENSE_PATH_RE = /^(?:licen[cs]e|copying|unlicense|ofl)(?:\.(?:md|markdown|txt))?$/i;
 const TIMESTAMP_RE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/;
-const AVAILABILITY_MAX_AGE_MS = 18 * 60 * 60 * 1000;
+export const AVAILABILITY_MAX_AGE_MS = 18 * 60 * 60 * 1000;
+export const AVAILABILITY_MAX_CLOCK_SKEW_MS = 5 * 60 * 1000;
 
 function fail(message) {
   throw new Error(`invalid registry data: ${message}`);
@@ -354,17 +355,29 @@ export function validateRecent(value) {
   return document;
 }
 
+function availabilityTimestamp(value) {
+  if (typeof value !== "string" || !TIMESTAMP_RE.test(value)) return null;
+  const moment = Date.parse(value);
+  if (!Number.isFinite(moment) ||
+      new Date(moment).toISOString().replace(".000Z", "Z") !== value) {
+    return null;
+  }
+  return moment;
+}
+
 function availabilityEndpoint(value, field) {
   const endpoint = object(value, field);
   if (!["available", "missing", "unknown"].includes(endpoint.status)) {
     fail(`${field}.status is unsupported`);
   }
   if (endpoint.checked_at !== null && endpoint.checked_at !== undefined) {
-    if (!TIMESTAMP_RE.test(endpoint.checked_at) || Number.isNaN(Date.parse(endpoint.checked_at))) {
-      fail(`${field}.checked_at is malformed`);
-    }
+    // A malformed observation time is not evidence for a known answer. The
+    // producer normalizes it to null, and availabilityRecord independently
+    // demotes the endpoint so one bad observation cannot hide fresh siblings.
+    if (typeof endpoint.checked_at !== "string") fail(`${field}.checked_at is malformed`);
   }
-  if (!TIMESTAMP_RE.test(endpoint.last_attempt_at) || Number.isNaN(Date.parse(endpoint.last_attempt_at))) {
+  if (endpoint.last_attempt_at !== null && endpoint.last_attempt_at !== undefined &&
+      availabilityTimestamp(endpoint.last_attempt_at) === null) {
     fail(`${field}.last_attempt_at is malformed`);
   }
   if (!Number.isSafeInteger(endpoint.consecutive_missing) || endpoint.consecutive_missing < 0) {
@@ -411,15 +424,35 @@ export function validateAvailability(manifest) {
 
 export function availabilityRecord(manifest, repository, revision, now = Date.now()) {
   if (!manifest) return null;
-  const generated = Date.parse(manifest.generated_at);
-  if (!Number.isFinite(generated) || generated > now + 5 * 60 * 1000 ||
+  const generated = availabilityTimestamp(manifest.generated_at);
+  if (generated === null || generated > now + AVAILABILITY_MAX_CLOCK_SKEW_MS ||
       now - generated > AVAILABILITY_MAX_AGE_MS) {
     return null;
   }
-  return manifest.repositories.find(
+  const record = manifest.repositories.find(
     (row) => row.source_repository.toLowerCase() === repository.toLowerCase() &&
       row.commit === revision,
   ) || null;
+  if (record === null) return null;
+
+  // generated_at describes the publication, not the age of every observation
+  // carried in it. Apply the same inclusive freshness window to each known
+  // endpoint at the point all landing, search, and entry links consume it.
+  const authoritativeEndpoint = (endpoint) => {
+    if (!["available", "missing"].includes(endpoint.status)) return endpoint;
+    const checked = availabilityTimestamp(endpoint.checked_at);
+    const age = checked === null ? null : now - checked;
+    if (age !== null && age >= -AVAILABILITY_MAX_CLOCK_SKEW_MS &&
+        age <= AVAILABILITY_MAX_AGE_MS) {
+      return endpoint;
+    }
+    return { ...endpoint, status: "unknown", checked_at: checked === null ? null : endpoint.checked_at };
+  };
+  return {
+    ...record,
+    original: authoritativeEndpoint(record.original),
+    archive: authoritativeEndpoint(record.archive),
+  };
 }
 
 export function entryRecordUrl(summary, databaseBase) {

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -370,12 +370,6 @@ function availabilityEndpoint(value, field) {
   if (!["available", "missing", "unknown"].includes(endpoint.status)) {
     fail(`${field}.status is unsupported`);
   }
-  if (endpoint.checked_at !== null && endpoint.checked_at !== undefined) {
-    // A malformed observation time is not evidence for a known answer. The
-    // producer normalizes it to null, and availabilityRecord independently
-    // demotes the endpoint so one bad observation cannot hide fresh siblings.
-    if (typeof endpoint.checked_at !== "string") fail(`${field}.checked_at is malformed`);
-  }
   if (endpoint.last_attempt_at !== null && endpoint.last_attempt_at !== undefined &&
       availabilityTimestamp(endpoint.last_attempt_at) === null) {
     fail(`${field}.last_attempt_at is malformed`);
@@ -387,21 +381,34 @@ function availabilityEndpoint(value, field) {
       typeof endpoint.last_error !== "string") {
     fail(`${field}.last_error is malformed`);
   }
-  return endpoint;
+  // checked_at is evidence rather than structure. Whatever malformed value
+  // arrived, it says only that this endpoint has no trustworthy observation;
+  // do not let it invalidate fresh sibling endpoints or rows.
+  if (availabilityTimestamp(endpoint.checked_at) !== null) return endpoint;
+  return {
+    ...endpoint,
+    status: ["available", "missing"].includes(endpoint.status) ? "unknown" : endpoint.status,
+    checked_at: null,
+  };
 }
 
 export function validateAvailability(manifest) {
-  object(manifest, "availability");
-  if (manifest.schema_version !== 1) fail("availability schema_version is unsupported");
-  if (!TIMESTAMP_RE.test(manifest.generated_at) || Number.isNaN(Date.parse(manifest.generated_at))) {
+  const document = object(manifest, "availability");
+  if (document.schema_version !== 1) fail("availability schema_version is unsupported");
+  if (availabilityTimestamp(document.generated_at) === null) {
     fail("availability.generated_at is malformed");
   }
-  if (manifest.database_commit !== undefined) {
-    commit(manifest.database_commit, "availability.database_commit");
+  if (document.database_commit !== undefined) {
+    commit(document.database_commit, "availability.database_commit");
+  }
+  const coverage = object(document.coverage, "availability.coverage");
+  if (coverage.freshness_max_age_seconds !== AVAILABILITY_MAX_AGE_MS / 1_000) {
+    fail("availability.coverage.freshness_max_age_seconds disagrees with the consumer");
   }
   const seen = new Set();
+  const repositories = [];
   for (const [position, value] of array(
-    manifest.repositories,
+    document.repositories,
     "availability.repositories",
   ).entries()) {
     const row = object(value, `availability.repositories[${position}]`);
@@ -416,10 +423,19 @@ export function validateAvailability(manifest) {
     const key = `${row.source_repository.toLowerCase()}\0${row.commit}`;
     if (seen.has(key)) fail(`availability.repositories[${position}] is duplicated`);
     seen.add(key);
-    availabilityEndpoint(row.original, `availability.repositories[${position}].original`);
-    availabilityEndpoint(row.archive, `availability.repositories[${position}].archive`);
+    repositories.push({
+      ...row,
+      original: availabilityEndpoint(
+        row.original,
+        `availability.repositories[${position}].original`,
+      ),
+      archive: availabilityEndpoint(
+        row.archive,
+        `availability.repositories[${position}].archive`,
+      ),
+    });
   }
-  return manifest;
+  return { ...document, repositories };
 }
 
 export function availabilityRecord(manifest, repository, revision, now = Date.now()) {
@@ -439,14 +455,17 @@ export function availabilityRecord(manifest, repository, revision, now = Date.no
   // carried in it. Apply the same inclusive freshness window to each known
   // endpoint at the point all landing, search, and entry links consume it.
   const authoritativeEndpoint = (endpoint) => {
-    if (!["available", "missing"].includes(endpoint.status)) return endpoint;
     const checked = availabilityTimestamp(endpoint.checked_at);
+    const normalized = checked === null && endpoint.checked_at !== null
+      ? { ...endpoint, checked_at: null }
+      : endpoint;
+    if (!["available", "missing"].includes(endpoint.status)) return normalized;
     const age = checked === null ? null : now - checked;
     if (age !== null && age >= -AVAILABILITY_MAX_CLOCK_SKEW_MS &&
         age <= AVAILABILITY_MAX_AGE_MS) {
-      return endpoint;
+      return normalized;
     }
-    return { ...endpoint, status: "unknown", checked_at: checked === null ? null : endpoint.checked_at };
+    return { ...normalized, status: "unknown" };
   };
   return {
     ...record,

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -337,6 +337,7 @@ class Handler(SimpleHTTPRequestHandler):
             payload = {
                 "schema_version": 1,
                 "generated_at": checked_at,
+                "coverage": {"freshness_max_age_seconds": 18 * 60 * 60},
                 "repositories": [
                     {
                         "source_repository": row["source_repository"],

--- a/tests/registry-fixture.mjs
+++ b/tests/registry-fixture.mjs
@@ -65,6 +65,38 @@ export function recent(entries = [recentRow()], overrides = {}) {
   return { schema_version: 1, entries, ...overrides };
 }
 
+export function availabilityEndpoint(overrides = {}) {
+  return {
+    status: "available",
+    checked_at: "2026-08-08T12:00:00Z",
+    last_attempt_at: "2026-08-08T12:00:00Z",
+    consecutive_missing: 0,
+    last_error: null,
+    ...overrides,
+  };
+}
+
+export function availabilityManifest(repositories = [], overrides = {}) {
+  return {
+    schema_version: 1,
+    generated_at: "2026-08-08T12:00:00Z",
+    database_commit: "d".repeat(40),
+    repositories,
+    ...overrides,
+  };
+}
+
+export function availabilityRow(overrides = {}) {
+  return {
+    source_repository: "example/challenge",
+    commit: COMMIT,
+    fork_repository: "PalomarArchive/example--challenge--fixture",
+    original: availabilityEndpoint(),
+    archive: availabilityEndpoint(),
+    ...overrides,
+  };
+}
+
 export function entry(overrides = {}) {
   const evidenceTree = "c".repeat(64);
   const value = {

--- a/tests/registry-fixture.mjs
+++ b/tests/registry-fixture.mjs
@@ -81,6 +81,7 @@ export function availabilityManifest(repositories = [], overrides = {}) {
     schema_version: 1,
     generated_at: "2026-08-08T12:00:00Z",
     database_commit: "d".repeat(40),
+    coverage: { freshness_max_age_seconds: 18 * 60 * 60 },
     repositories,
     ...overrides,
   };

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
@@ -6,6 +7,9 @@ import { htmlFiles } from "../scripts/build-site.mjs";
 import {
   COMMIT,
   DIGEST,
+  availabilityEndpoint,
+  availabilityManifest,
+  availabilityRow,
   entry,
   recent,
   recentRow,
@@ -14,6 +18,8 @@ import {
 } from "./registry-fixture.mjs";
 
 import {
+  AVAILABILITY_MAX_AGE_MS,
+  AVAILABILITY_MAX_CLOCK_SKEW_MS,
   DEFAULT_DATABASE,
   DEFAULT_AVAILABILITY,
   ENTRY_SCHEMA_VERSION,
@@ -410,41 +416,128 @@ test("legacy schema v1 records remain readable without an archive mapping", () =
   assert.equal(validateEntry(legacy, summary()).schema_version, 1);
 });
 
-test("availability is validated and stale state becomes unknown", () => {
-  const manifest = validateAvailability({
-    schema_version: 1,
-    generated_at: "2026-08-06T00:00:00Z",
-    repositories: [
-      {
-        source_repository: "example/challenge",
-        commit: COMMIT,
-        fork_repository: "PalomarArchive/example--challenge--fixture",
-        original: {
-          status: "missing",
-          checked_at: "2026-08-06T00:00:00Z",
-          last_attempt_at: "2026-08-06T00:00:00Z",
-          consecutive_missing: 2,
-          last_error: null,
-        },
-        archive: {
-          status: "available",
-          checked_at: "2026-08-06T00:00:00Z",
-          last_attempt_at: "2026-08-06T00:00:00Z",
-          consecutive_missing: 0,
-          last_error: null,
-        },
-      },
+test("availability applies the inclusive freshness boundaries to each endpoint", () => {
+  const now = Date.parse("2026-08-08T12:00:00Z");
+  const stamp = (offset) => new Date(now + offset).toISOString().replace(".000Z", "Z");
+  const statusAt = (checkedAt) => availabilityRecord(validateAvailability(availabilityManifest([
+    availabilityRow({
+      original: availabilityEndpoint({ status: "missing", checked_at: checkedAt }),
+    }),
+  ])), "example/challenge", COMMIT, now).original.status;
+
+  assert.equal(statusAt(stamp(-AVAILABILITY_MAX_AGE_MS)), "missing");
+  assert.equal(statusAt(stamp(-AVAILABILITY_MAX_AGE_MS - 1_000)), "unknown");
+  assert.equal(statusAt(stamp(AVAILABILITY_MAX_CLOCK_SKEW_MS)), "missing");
+  assert.equal(statusAt(stamp(AVAILABILITY_MAX_CLOCK_SKEW_MS + 1_000)), "unknown");
+});
+
+test("one malformed or stale endpoint cannot hide unrelated fresh observations", () => {
+  const now = Date.parse("2026-08-08T12:00:00Z");
+  const manifest = validateAvailability(availabilityManifest([
+    availabilityRow({
+      original: availabilityEndpoint({ status: "missing", checked_at: "not-a-timestamp" }),
+      archive: availabilityEndpoint({
+        status: "available",
+        checked_at: "2026-08-07T17:59:59Z",
+        last_attempt_at: null,
+      }),
+    }),
+    availabilityRow({
+      source_repository: "example/fresh",
+      original: availabilityEndpoint({ status: "missing" }),
+      archive: availabilityEndpoint({ status: "available" }),
+    }),
+  ]));
+
+  const mixed = availabilityRecord(manifest, "EXAMPLE/challenge", COMMIT, now);
+  assert.equal(mixed.original.status, "unknown", "malformed checked_at is not evidence");
+  assert.equal(mixed.original.checked_at, null);
+  assert.equal(mixed.archive.status, "unknown", "one second beyond 18 hours is stale");
+  assert.equal(mixed.archive.last_attempt_at, null, "never-attempted endpoints are valid");
+  assert.deepEqual(
+    [
+      availabilityRecord(manifest, "example/fresh", COMMIT, now).original.status,
+      availabilityRecord(manifest, "example/fresh", COMMIT, now).archive.status,
     ],
-  });
-  assert.equal(
-    availabilityRecord(manifest, "EXAMPLE/challenge", COMMIT, Date.parse("2026-08-06T12:00:00Z"))
-      .original.status,
-    "missing",
+    ["missing", "available"],
   );
-  assert.equal(
-    availabilityRecord(manifest, "example/challenge", COMMIT, Date.parse("2026-08-07T00:00:00Z")),
-    null,
+});
+
+test("availability keeps whole-document freshness inclusive and fail-closed", () => {
+  const now = Date.parse("2026-08-08T12:00:00Z");
+  const recordAt = (generatedAt) => availabilityRecord(
+    validateAvailability(availabilityManifest([availabilityRow()], { generated_at: generatedAt })),
+    "example/challenge",
+    COMMIT,
+    now,
   );
+  assert.ok(recordAt("2026-08-07T18:00:00Z"));
+  assert.equal(recordAt("2026-08-07T17:59:59Z"), null);
+  assert.ok(recordAt("2026-08-08T12:05:00Z"));
+  assert.equal(recordAt("2026-08-08T12:05:01Z"), null);
+  assert.throws(
+    () => validateAvailability(availabilityManifest([
+      availabilityRow({ original: availabilityEndpoint({ last_attempt_at: "never" }) }),
+    ])),
+    /last_attempt_at is malformed/,
+  );
+});
+
+test("availability agrees with the Database producer contract", async () => {
+  const checkout = process.env.PALOMAR_DATABASE_CHECKOUT
+    ?? new URL("../../PalomarDatabase/", import.meta.url).pathname;
+  const executable = new URL("tools/source_availability_contract.py", `file://${checkout}/`);
+  try {
+    await readFile(executable, "utf8");
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+    // CI cannot read the private canonical repository, so the existing
+    // cross-repository mechanism supplies the producer's published object at
+    // the same checkout root. This remains a mandatory exercised contract,
+    // not a skip; local development invokes the exact executable below.
+    const fixture = JSON.parse(await readFile(
+      new URL("tests/fixtures/source-availability.json", `file://${checkout}/`),
+      "utf8",
+    ));
+    assert.ok(fixture.repositories.length > 0, "the published contract must exercise a row");
+    assert.equal(validateAvailability(fixture), fixture);
+    return;
+  }
+  const raw = availabilityManifest([
+    availabilityRow({
+      original: availabilityEndpoint({
+        status: "missing",
+        checked_at: "2026-08-07T17:59:59Z",
+      }),
+      archive: availabilityEndpoint({
+        checked_at: "2026-08-08T12:05:00Z",
+        last_attempt_at: null,
+      }),
+    }),
+  ]);
+  const script = [
+    "import datetime as dt, json, pathlib, sys",
+    `sys.path.insert(0, str(pathlib.Path(${JSON.stringify(checkout)}) / 'tools'))`,
+    "from source_availability_contract import normalize_manifest",
+    "value = normalize_manifest(json.load(sys.stdin), as_of=dt.datetime(2026, 8, 8, 12, tzinfo=dt.UTC))",
+    "json.dump(value, sys.stdout, sort_keys=True)",
+  ].join("; ");
+  const produced = JSON.parse(execFileSync("python3", ["-c", script], {
+    encoding: "utf8",
+    input: JSON.stringify(raw),
+  }));
+
+  const consumed = validateAvailability(produced);
+  const row = availabilityRecord(
+    consumed,
+    "example/challenge",
+    COMMIT,
+    Date.parse("2026-08-08T12:00:00Z"),
+  );
+  assert.equal(row.original.status, "unknown");
+  assert.equal(row.archive.status, "available");
+  assert.equal(row.archive.last_attempt_at, null);
+  assert.equal(produced.coverage.freshness_max_age_seconds, AVAILABILITY_MAX_AGE_MS / 1_000);
 });
 
 test("withdrawn palomar-indexed provenance is rejected", () => {

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -58,6 +58,7 @@ import {
 
 // The website's own origin, for the cross-origin assertion below.
 const CANONICAL_WEB_BASE_FOR_TEST = "https://palomar-registry.org/";
+const AVAILABILITY_PRODUCER_COMMIT = "5288deae2cf6c537bdf56e9a54faf00393937119";
 
 test("production ignores every database query override", () => {
   for (const override of [
@@ -503,6 +504,10 @@ test("availability agrees with the Database producer contract", async () => {
     assert.equal(validateAvailability(fixture), fixture);
     return;
   }
+  assert.doesNotThrow(() => execFileSync(
+    "git",
+    ["-C", checkout, "merge-base", "--is-ancestor", AVAILABILITY_PRODUCER_COMMIT, "HEAD"],
+  ), "the Database checkout must include the reviewed source-availability contract");
   const raw = availabilityManifest([
     availabilityRow({
       original: availabilityEndpoint({

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -58,7 +58,7 @@ import {
 
 // The website's own origin, for the cross-origin assertion below.
 const CANONICAL_WEB_BASE_FOR_TEST = "https://palomar-registry.org/";
-const AVAILABILITY_PRODUCER_COMMIT = "5288deae2cf6c537bdf56e9a54faf00393937119";
+const AVAILABILITY_PRODUCER_COMMIT = "7e446fda08d26b5c1290a9e3ec0947ece0c4994e";
 
 test("production ignores every database query override", () => {
   for (const override of [
@@ -461,6 +461,26 @@ test("one malformed or stale endpoint cannot hide unrelated fresh observations",
       availabilityRecord(manifest, "example/fresh", COMMIT, now).archive.status,
     ],
     ["missing", "available"],
+  );
+});
+
+test("availability demotes malformed timestamp strings but rejects non-string values", () => {
+  const now = Date.parse("2026-08-08T12:00:00Z");
+  const malformedString = validateAvailability(availabilityManifest([
+    availabilityRow({
+      original: availabilityEndpoint({ status: "missing", checked_at: "not-a-timestamp" }),
+    }),
+  ]));
+  assert.equal(
+    availabilityRecord(malformedString, "example/challenge", COMMIT, now).original.status,
+    "unknown",
+  );
+
+  assert.throws(
+    () => validateAvailability(availabilityManifest([
+      availabilityRow({ original: availabilityEndpoint({ checked_at: 123 }) }),
+    ])),
+    /checked_at is malformed/,
   );
 });
 

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -420,26 +420,32 @@ test("legacy schema v1 records remain readable without an archive mapping", () =
 test("availability applies the inclusive freshness boundaries to each endpoint", () => {
   const now = Date.parse("2026-08-08T12:00:00Z");
   const stamp = (offset) => new Date(now + offset).toISOString().replace(".000Z", "Z");
-  const statusAt = (checkedAt) => availabilityRecord(validateAvailability(availabilityManifest([
+  const recordAt = (checkedAt) => availabilityRecord(validateAvailability(availabilityManifest([
     availabilityRow({
       original: availabilityEndpoint({ status: "missing", checked_at: checkedAt }),
     }),
-  ])), "example/challenge", COMMIT, now).original.status;
+  ])), "example/challenge", COMMIT, now).original;
 
-  assert.equal(statusAt(stamp(-AVAILABILITY_MAX_AGE_MS)), "missing");
-  assert.equal(statusAt(stamp(-AVAILABILITY_MAX_AGE_MS - 1_000)), "unknown");
-  assert.equal(statusAt(stamp(AVAILABILITY_MAX_CLOCK_SKEW_MS)), "missing");
-  assert.equal(statusAt(stamp(AVAILABILITY_MAX_CLOCK_SKEW_MS + 1_000)), "unknown");
+  assert.equal(recordAt(stamp(-AVAILABILITY_MAX_AGE_MS)).status, "missing");
+  const stale = recordAt(stamp(-AVAILABILITY_MAX_AGE_MS - 1_000));
+  assert.equal(stale.status, "unknown");
+  assert.equal(
+    stale.checked_at,
+    stamp(-AVAILABILITY_MAX_AGE_MS - 1_000),
+    "valid stale evidence is retained after its answer loses authority",
+  );
+  assert.equal(recordAt(stamp(AVAILABILITY_MAX_CLOCK_SKEW_MS)).status, "missing");
+  assert.equal(recordAt(stamp(AVAILABILITY_MAX_CLOCK_SKEW_MS + 1_000)).status, "unknown");
 });
 
-test("one malformed or stale endpoint cannot hide unrelated fresh observations", () => {
+test("one malformed endpoint cannot hide its fresh sibling or unrelated rows", () => {
   const now = Date.parse("2026-08-08T12:00:00Z");
   const manifest = validateAvailability(availabilityManifest([
     availabilityRow({
-      original: availabilityEndpoint({ status: "missing", checked_at: "not-a-timestamp" }),
+      original: availabilityEndpoint({ status: "missing", checked_at: 123 }),
       archive: availabilityEndpoint({
         status: "available",
-        checked_at: "2026-08-07T17:59:59Z",
+        checked_at: "2026-08-08T12:00:00Z",
         last_attempt_at: null,
       }),
     }),
@@ -453,7 +459,7 @@ test("one malformed or stale endpoint cannot hide unrelated fresh observations",
   const mixed = availabilityRecord(manifest, "EXAMPLE/challenge", COMMIT, now);
   assert.equal(mixed.original.status, "unknown", "malformed checked_at is not evidence");
   assert.equal(mixed.original.checked_at, null);
-  assert.equal(mixed.archive.status, "unknown", "one second beyond 18 hours is stale");
+  assert.equal(mixed.archive.status, "available", "the fresh sibling remains authoritative");
   assert.equal(mixed.archive.last_attempt_at, null, "never-attempted endpoints are valid");
   assert.deepEqual(
     [
@@ -464,24 +470,21 @@ test("one malformed or stale endpoint cannot hide unrelated fresh observations",
   );
 });
 
-test("availability demotes malformed timestamp strings but rejects non-string values", () => {
+test("availability normalizes every malformed endpoint timestamp without rejecting the document", () => {
   const now = Date.parse("2026-08-08T12:00:00Z");
-  const malformedString = validateAvailability(availabilityManifest([
-    availabilityRow({
-      original: availabilityEndpoint({ status: "missing", checked_at: "not-a-timestamp" }),
-    }),
-  ]));
-  assert.equal(
-    availabilityRecord(malformedString, "example/challenge", COMMIT, now).original.status,
-    "unknown",
-  );
-
-  assert.throws(
-    () => validateAvailability(availabilityManifest([
-      availabilityRow({ original: availabilityEndpoint({ checked_at: 123 }) }),
-    ])),
-    /checked_at is malformed/,
-  );
+  for (const checkedAt of ["not-a-timestamp", 123, {}, []]) {
+    const malformed = validateAvailability(availabilityManifest([
+      availabilityRow({
+        original: availabilityEndpoint({ status: "missing", checked_at: checkedAt }),
+        archive: availabilityEndpoint({ status: "unknown", checked_at: checkedAt }),
+      }),
+    ]));
+    const row = availabilityRecord(malformed, "example/challenge", COMMIT, now);
+    assert.deepEqual(
+      [row.original.status, row.original.checked_at, row.archive.status, row.archive.checked_at],
+      ["unknown", null, "unknown", null],
+    );
+  }
 });
 
 test("availability keeps whole-document freshness inclusive and fail-closed", () => {
@@ -496,6 +499,19 @@ test("availability keeps whole-document freshness inclusive and fail-closed", ()
   assert.equal(recordAt("2026-08-07T17:59:59Z"), null);
   assert.ok(recordAt("2026-08-08T12:05:00Z"));
   assert.equal(recordAt("2026-08-08T12:05:01Z"), null);
+  assert.throws(
+    () => validateAvailability(availabilityManifest([], { generated_at: "2026-02-30T00:00:00Z" })),
+    /generated_at is malformed/,
+  );
+  assert.throws(
+    () => validateAvailability(availabilityManifest([], {
+      coverage: { freshness_max_age_seconds: 86_400 },
+    })),
+    /freshness_max_age_seconds disagrees/,
+  );
+  const noCoverage = availabilityManifest([]);
+  delete noCoverage.coverage;
+  assert.throws(() => validateAvailability(noCoverage), /availability.coverage must be an object/);
   assert.throws(
     () => validateAvailability(availabilityManifest([
       availabilityRow({ original: availabilityEndpoint({ last_attempt_at: "never" }) }),
@@ -520,14 +536,26 @@ test("availability agrees with the Database producer contract", async () => {
       new URL("tests/fixtures/source-availability.json", `file://${checkout}/`),
       "utf8",
     ));
-    assert.ok(fixture.repositories.length > 0, "the published contract must exercise a row");
-    assert.equal(validateAvailability(fixture), fixture);
+    assert.ok(fixture.repositories.length > 0, "the deployed contract must exercise a row");
+    assert.equal(
+      fixture.coverage?.freshness_max_age_seconds,
+      AVAILABILITY_MAX_AGE_MS / 1_000,
+      "the deployed producer and consumer must share the freshness policy",
+    );
+    assert.deepEqual(validateAvailability(fixture), fixture);
     return;
   }
-  assert.doesNotThrow(() => execFileSync(
-    "git",
-    ["-C", checkout, "merge-base", "--is-ancestor", AVAILABILITY_PRODUCER_COMMIT, "HEAD"],
-  ), "the Database checkout must include the reviewed source-availability contract");
+  try {
+    execFileSync(
+      "git",
+      ["-C", checkout, "merge-base", "--is-ancestor", AVAILABILITY_PRODUCER_COMMIT, "HEAD"],
+    );
+  } catch {
+    assert.fail(
+      `PalomarDatabase checkout ${checkout} is older than the required ` +
+        `source-availability contract ${AVAILABILITY_PRODUCER_COMMIT}; fetch current main`,
+    );
+  }
   const raw = availabilityManifest([
     availabilityRow({
       original: availabilityEndpoint({
@@ -562,7 +590,7 @@ test("availability agrees with the Database producer contract", async () => {
   assert.equal(row.original.status, "unknown");
   assert.equal(row.archive.status, "available");
   assert.equal(row.archive.last_attempt_at, null);
-  assert.equal(produced.coverage.freshness_max_age_seconds, AVAILABILITY_MAX_AGE_MS / 1_000);
+  assert.equal(consumed.coverage.freshness_max_age_seconds, AVAILABILITY_MAX_AGE_MS / 1_000);
 });
 
 test("withdrawn palomar-indexed provenance is rejected", () => {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -389,6 +389,42 @@ test("a missing original automatically switches source links to the Palomar copy
   );
 });
 
+test("entry rendering demotes a stale original without discarding a fresh archive result", async ({ page }) => {
+  await page.route("**/database/source-availability-missing.json", async (route) => {
+    const response = await route.fetch();
+    const availability = await response.json();
+    const now = new Date();
+    now.setMilliseconds(0);
+    const stale = new Date(now.getTime() - 18 * 60 * 60 * 1000 - 1_000)
+      .toISOString().replace(".000Z", "Z");
+    const fresh = now.toISOString().replace(".000Z", "Z");
+    availability.generated_at = fresh;
+    for (const row of availability.repositories) {
+      row.original.status = "missing";
+      row.original.checked_at = stale;
+      row.original.last_attempt_at = null;
+      row.archive.status = "missing";
+      row.archive.checked_at = fresh;
+      row.archive.last_attempt_at = fresh;
+    }
+    await route.fulfill({ response, json: availability });
+  });
+
+  await page.goto(
+    `/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}` +
+      `&availability=${missingAvailability}`,
+  );
+
+  await expect(page.locator(".source-availability.archive-missing")).toContainText(
+    "Source preservation degraded",
+  );
+  await expect(page.locator(".source-availability.original-missing")).toHaveCount(0);
+  await expect(page.getByRole("link", { name: /View full pinned statement file/ })).toHaveAttribute(
+    "href",
+    /github\.com\/example\/challenge\/blob\/1{40}\/project\/Comparator\/Task\.lean$/,
+  );
+});
+
 test("an entry accepted before source archiving explains the limitation as a warning", async ({ page }) => {
   await page.route("**/entries/PALOMAR-2026-07-29-000123-v1.json", async (route) => {
     const response = await route.fetch();
@@ -467,6 +503,42 @@ test("a card says the original is unavailable exactly when the manifest says so"
 
   await page.goto(`/?database=${database}`);
   await expect(page.locator(".entry-card .source-status")).toHaveCount(0);
+});
+
+test("progressive cards never apply a stale missing claim", async ({ page }) => {
+  let releaseAvailability;
+  let noteAvailabilityRequest;
+  const availabilityRequested = new Promise((resolve) => { noteAvailabilityRequest = resolve; });
+  await page.route("**/database/source-availability-missing.json", async (route) => {
+    noteAvailabilityRequest();
+    const response = await route.fetch();
+    const availability = await response.json();
+    const now = new Date();
+    now.setMilliseconds(0);
+    availability.generated_at = now.toISOString().replace(".000Z", "Z");
+    const stale = new Date(now.getTime() - 18 * 60 * 60 * 1000 - 1_000)
+      .toISOString().replace(".000Z", "Z");
+    for (const row of availability.repositories) {
+      row.original.checked_at = stale;
+      row.original.last_attempt_at = null;
+    }
+    await new Promise((resolve) => { releaseAvailability = resolve; });
+    await route.fulfill({ response, json: availability });
+  });
+
+  await page.goto(`/?database=${database}&availability=${missingAvailability}`);
+  const card = page.locator(".entry-card").first();
+  await expect(card).toHaveCount(1);
+  await availabilityRequested;
+  await card.evaluate((node) => { node.dataset.progressiveFixture = "same-card"; });
+  await card.locator(".repo-link").focus();
+  releaseAvailability();
+
+  await expect(card.locator(".repo-link")).toHaveText("example/challenge");
+  await expect(card.locator(".source-status.missing")).toHaveCount(0);
+  await expect(card.locator(".archive-link")).toBeVisible();
+  await expect(card).toHaveAttribute("data-progressive-fixture", "same-card");
+  await expect(card.locator(".repo-link")).toBeFocused();
 });
 
 test("entry pages list immutable versions and flag superseded snapshots", async ({ page }) => {
@@ -1097,6 +1169,28 @@ test("search availability decorates the existing focused card in place", async (
   await expect(card.locator(".source-status.missing")).toHaveText("Original unavailable");
   await expect(card).toHaveAttribute("data-progressive-fixture", "same-card");
   await expect(card.locator(".repo-link")).toBeFocused();
+});
+
+test("search cards do not publish a stale source-unavailable claim", async ({ page }) => {
+  await page.route("**/database/source-availability-missing.json", async (route) => {
+    const response = await route.fetch();
+    const availability = await response.json();
+    const now = new Date();
+    now.setMilliseconds(0);
+    availability.generated_at = now.toISOString().replace(".000Z", "Z");
+    const stale = new Date(now.getTime() - 18 * 60 * 60 * 1000 - 1_000)
+      .toISOString().replace(".000Z", "Z");
+    for (const row of availability.repositories) row.original.checked_at = stale;
+    await route.fulfill({ response, json: availability });
+  });
+
+  await page.goto(
+    `/?database=${database}&availability=${missingAvailability}&q=synthetically`,
+  );
+  const card = page.locator("#search-results .entry-card");
+  await expect(card.locator(".repo-link")).toHaveText("example/challenge");
+  await expect(card.locator(".source-status.missing")).toHaveCount(0);
+  await expect(card.locator(".archive-link")).toBeVisible();
 });
 
 test("transient and invalid availability responses are both retried", async ({ page }) => {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -415,14 +415,41 @@ test("entry rendering demotes a stale original without discarding a fresh archiv
       `&availability=${missingAvailability}`,
   );
 
-  await expect(page.locator(".source-availability.archive-missing")).toContainText(
+  const notice = page.locator(".source-availability.archive-missing");
+  await expect(notice).toContainText(
     "Source preservation degraded",
   );
+  await expect(notice).toContainText("its current availability has not been confirmed");
+  await expect(notice).not.toContainText("still works");
+  await expect(notice.getByRole("link", { name: "Recorded original location" })).toBeVisible();
   await expect(page.locator(".source-availability.original-missing")).toHaveCount(0);
   await expect(page.getByRole("link", { name: /View full pinned statement file/ })).toHaveAttribute(
     "href",
     /github\.com\/example\/challenge\/blob\/1{40}\/project\/Comparator\/Task\.lean$/,
   );
+});
+
+test("an archive warning says the original works only after a fresh confirmation", async ({ page }) => {
+  await page.route("**/database/source-availability.json", async (route) => {
+    const response = await route.fetch();
+    const availability = await response.json();
+    const fresh = new Date().toISOString().replace(/\.[0-9]{3}Z$/, "Z");
+    availability.generated_at = fresh;
+    for (const row of availability.repositories) {
+      row.original.status = "available";
+      row.original.checked_at = fresh;
+      row.archive.status = "missing";
+      row.archive.checked_at = fresh;
+    }
+    await route.fulfill({ response, json: availability });
+  });
+
+  await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}`);
+
+  const notice = page.locator(".source-availability.archive-missing");
+  await expect(notice).toContainText("The original source still works");
+  await expect(notice).not.toContainText("has not been confirmed");
+  await expect(notice.getByRole("link", { name: "Original source" })).toBeVisible();
 });
 
 test("an entry accepted before source archiving explains the limitation as a warning", async ({ page }) => {


### PR DESCRIPTION
## What changed

- apply the existing eighteen-hour maximum age and five-minute future-skew allowance to each original/archive observation, not only the top-level source-availability document
- normalize every malformed endpoint checked_at to null and demote only that endpoint to unknown, preserving fresh sibling rows/endpoints and retaining valid stale timestamps as non-authoritative evidence
- keep generated_at strict and require coverage.freshness_max_age_seconds to equal the Web policy, so both local executable conformance and CI validation of the deployed producer object enforce the shared bound
- accept nullable last_attempt_at for producer-budget-skipped endpoints that have never been attempted
- use neutral archive-degradation wording when original availability is unknown; say the original still works only after a fresh available observation
- add unit and browser coverage for inclusive boundary seconds, same-row isolation, malformed values of every JSON type, landing/search/entry rendering, progressive cards, and both archive-warning states
- document the present producer/consumer freshness contract and local-versus-CI conformance paths

## Why

A newly generated manifest could carry an old per-endpoint available or missing answer. The browser trusted that answer because it checked only generated_at, allowing an old missing claim to switch source links and publish an inaccurate unavailable notice. It also described an original as working merely because the archive was missing, even when the original observation was unknown.

This is the Web consumer half of F-04. PalomarDatabase #97 is merged as 7e446fda08d26b5c1290a9e3ec0947ece0c4994e and its source-availability publication run 31266053029 completed successfully before this consumer. There is no old-shape fallback.

## Impact

Landing, search, and entry pages continue to use one optional manifest. Only known endpoint answers with a trustworthy checked_at are authoritative; unknown state retains the durable recorded source and preservation links. No new data reads are introduced. Archive warnings distinguish a confirmed working original from an original whose current state is unknown.

## Validation

- PALOMAR_DATABASE_CHECKOUT=/tmp/palomar-database-availability.P5bOHr/PalomarDatabase npm test (90 passed, exact merged producer main 7e446fda)
- published-object fallback npm test against live source-availability revision 6 (90 passed)
- npm run build -- --version f04-opus-amendment --output .site
- PALOMAR_PREVIOUS_REF=origin/main npm run test:browser with Nixpkgs Chromium (53 passed)
- node --check for changed JavaScript modules; Python fixture compile; git diff --check
