### PR TITLE
Extract source preservation module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,20 @@
   CI cannot read that private checkout, so it downloads the deployed object and
   requires the producer's declared freshness maximum to equal the consumer's.
 
+- Keep availability parsing and endpoint-freshness authority in
+  `assets/security.mjs`. `assets/source-preservation.mjs` consumes that
+  validated contract, matches manifest observations to preservation-receipt
+  mappings, and owns repository resolution plus in-place card decoration;
+  `assets/app.js` owns page composition. Do not duplicate validation across
+  those modules.
+
 - The browser suite needs `python3` on `PATH`, for the fixture server. Two of
   its tests want `PALOMAR_PREVIOUS_REF` and skip silently without it, which only
   CI sets.
+
+- The hourly published-site health job imports `shippedFiles` from
+  `scripts/build-site.mjs` without running `npm ci`. Keep build-only packages,
+  including the module lexer, behind lazy imports so this metadata-only path
+  remains dependency-free. The subprocess regression deliberately rejects npm
+  package resolution while importing that module; do not weaken it by adding
+  an install step to the health job.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ manifest; if it arrives, their existing source controls are decorated in place.
 A linked `?q=` search does not also load the hidden recent listing; clearing the
 search starts one landing attempt, and a failed attempt can be retried.
 
+The browser code keeps the data boundary separate from presentation:
+`security.mjs` validates registry and availability documents and owns endpoint
+freshness, `source-preservation.mjs` matches validated manifest observations to
+the preservation receipt before resolving repository locations and decorating
+existing cards, and `app.js` composes the page-level views.
+
 Runtime reads use the browser's normal HTTP cache behavior. The public data
 service gives successful documents a 60-second browser/shared-cache lifetime,
 so repeat reads can be reused for that interval; missing and error responses are

--- a/assets/app.js
+++ b/assets/app.js
@@ -6,13 +6,11 @@ import {
 } from "./rendering.js";
 import {
   databaseBaseFor,
-  availabilityRecord,
   RESULT_ORIGIN_LABELS,
   REPOSITORY_ROLE_LABELS,
   entryRecordUrl,
   isLoopbackHostname,
   pinnedRepositoryDirectoryUrl,
-  pinnedRepositoryFileUrl,
   safeDataUrl,
   safeExternalUrl,
   safeInternalUrl,
@@ -31,6 +29,13 @@ import {
 } from "./security.mjs";
 import { loadSettledBounded } from "./loading.mjs";
 import { createRegistrySearch, validateSearchQuery } from "./searching.mjs";
+import {
+  decorateCardSet,
+  sourceDirectoryUrl,
+  sourceFileUrl,
+  sourceLocation,
+  topSourceLocation,
+} from "./source-preservation.mjs";
 
 const CANONICAL_WEB_BASE = "https://palomar-registry.org/";
 
@@ -140,58 +145,6 @@ function loadAvailabilityBounded(url) {
   return availabilityLoads.get(key);
 }
 
-function sourceLocation(entry, availability, repository, commit) {
-  if (!entry.preservation) {
-    return {
-      repository,
-      originalRepository: repository,
-      archiveRepository: null,
-      commit,
-      originalStatus: "unknown",
-      archiveStatus: "unknown",
-      checkedAt: null,
-      useArchive: false,
-    };
-  }
-  const mapping = entry.preservation.repositories.find(
-    (row) => row.source_repository.toLowerCase() === repository.toLowerCase() &&
-      row.commit === commit,
-  );
-  if (!mapping) throw new Error(`entry has no preserved copy of ${repository}@${commit}`);
-  const observed = availabilityRecord(availability, repository, commit);
-  const status = observed &&
-      observed.fork_repository.toLowerCase() === mapping.fork_repository.toLowerCase()
-    ? observed
-    : null;
-  const originalStatus = status?.original.status || "unknown";
-  const archiveStatus = status?.archive.status || "unknown";
-  const useArchive = originalStatus === "missing" && archiveStatus !== "missing";
-  return {
-    repository: useArchive ? mapping.fork_repository : repository,
-    originalRepository: repository,
-    archiveRepository: mapping.fork_repository,
-    commit,
-    originalStatus,
-    archiveStatus,
-    checkedAt: status?.original.checked_at || null,
-    useArchive,
-  };
-}
-
-function topSourceLocation(entry, availability) {
-  return sourceLocation(entry, availability, entry.source.repository, entry.source.commit);
-}
-
-function sourceFileUrl(entry, path, availability) {
-  const location = topSourceLocation(entry, availability);
-  return pinnedRepositoryFileUrl(location.repository, entry.source.commit, path);
-}
-
-function sourceDirectoryUrl(entry, path, availability) {
-  const location = topSourceLocation(entry, availability);
-  return pinnedRepositoryDirectoryUrl(location.repository, entry.source.commit, path);
-}
-
 function authorNames(entry) {
   return entry.authors.map((author) => author.name).join(", ");
 }
@@ -276,50 +229,6 @@ function trustBadge(entry) {
     ? "Statement dependencies: Mathlib only"
     : "Statement dependencies: additional libraries";
   return badge;
-}
-
-function decorateCardAvailability(card, entry, availability) {
-  const location = topSourceLocation(entry, availability);
-  const repositoryLink = card.querySelector(".repo-link");
-  if (!repositoryLink) throw new Error("card has no repository link");
-  repositoryLink.textContent = location.useArchive
-    ? "Palomar preserved copy"
-    : entry.source.repository;
-  repositoryLink.href = pinnedRepositoryDirectoryUrl(
-    location.repository,
-    entry.source.commit,
-  ).href;
-
-  const archiveLink = card.querySelector(".archive-link");
-  if (archiveLink) {
-    const archiveWasFocused = document.activeElement === archiveLink;
-    archiveLink.href = pinnedRepositoryDirectoryUrl(
-      location.archiveRepository,
-      entry.source.commit,
-    ).href;
-    archiveLink.hidden = location.useArchive;
-    let missing = card.querySelector(".source-status.missing");
-    if (location.useArchive && !missing) {
-      missing = el("span", "source-status missing", "Original unavailable");
-      archiveLink.insertAdjacentElement("afterend", missing);
-    }
-    if (!location.useArchive) missing?.remove();
-    if (archiveWasFocused && location.useArchive) repositoryLink.focus();
-  }
-}
-
-function decorateCardSet(cards, entries, availability, context) {
-  if (availability === null) return;
-  for (const [position, card] of cards.entries()) {
-    try {
-      decorateCardAvailability(card, entries[position], availability);
-    } catch (error) {
-      console.warn(
-        `${context} source availability could not be applied to ` +
-          `${entries[position].id} v${entries[position].version}: ${error.message}`,
-      );
-    }
-  }
 }
 
 function entryCard(

--- a/assets/source-preservation.mjs
+++ b/assets/source-preservation.mjs
@@ -1,0 +1,115 @@
+import {
+  availabilityRecord,
+  pinnedRepositoryDirectoryUrl,
+  pinnedRepositoryFileUrl,
+} from "./security.mjs";
+
+/** Resolve one immutable repository revision to its recorded or preserved copy. */
+export function sourceLocation(entry, availability, repository, commit) {
+  if (!entry.preservation) {
+    return {
+      repository,
+      originalRepository: repository,
+      archiveRepository: null,
+      commit,
+      originalStatus: "unknown",
+      archiveStatus: "unknown",
+      checkedAt: null,
+      useArchive: false,
+    };
+  }
+  const mapping = entry.preservation.repositories.find(
+    (row) => row.source_repository.toLowerCase() === repository.toLowerCase() &&
+      row.commit === commit,
+  );
+  if (!mapping) throw new Error(`entry has no preserved copy of ${repository}@${commit}`);
+  const observed = availabilityRecord(availability, repository, commit);
+  const status = observed &&
+      observed.fork_repository.toLowerCase() === mapping.fork_repository.toLowerCase()
+    ? observed
+    : null;
+  const originalStatus = status?.original.status || "unknown";
+  const archiveStatus = status?.archive.status || "unknown";
+  const useArchive = originalStatus === "missing" && archiveStatus !== "missing";
+  return {
+    repository: useArchive ? mapping.fork_repository : repository,
+    originalRepository: repository,
+    archiveRepository: mapping.fork_repository,
+    commit,
+    originalStatus,
+    archiveStatus,
+    checkedAt: status?.original.checked_at || null,
+    useArchive,
+  };
+}
+
+export function topSourceLocation(entry, availability) {
+  return sourceLocation(entry, availability, entry.source.repository, entry.source.commit);
+}
+
+export function sourceFileUrl(entry, path, availability) {
+  const location = topSourceLocation(entry, availability);
+  return pinnedRepositoryFileUrl(location.repository, entry.source.commit, path);
+}
+
+export function sourceDirectoryUrl(entry, path, availability) {
+  const location = topSourceLocation(entry, availability);
+  return pinnedRepositoryDirectoryUrl(location.repository, entry.source.commit, path);
+}
+
+function decorateCardAvailability(card, entry, availability) {
+  const location = topSourceLocation(entry, availability);
+  const repositoryLink = card.querySelector(".repo-link");
+  if (!repositoryLink) throw new Error("card has no repository link");
+  repositoryLink.textContent = location.useArchive
+    ? "Palomar preserved copy"
+    : entry.source.repository;
+  repositoryLink.href = pinnedRepositoryDirectoryUrl(
+    location.repository,
+    entry.source.commit,
+  ).href;
+
+  const archiveLink = card.querySelector(".archive-link");
+  if (!archiveLink) return;
+  const archiveWasFocused = document.activeElement === archiveLink;
+  archiveLink.href = pinnedRepositoryDirectoryUrl(
+    location.archiveRepository,
+    entry.source.commit,
+  ).href;
+  archiveLink.hidden = location.useArchive;
+  let missing = card.querySelector(".source-status.missing");
+  if (location.useArchive && !missing) {
+    missing = document.createElement("span");
+    missing.className = "source-status missing";
+    missing.textContent = "Original unavailable";
+    archiveLink.insertAdjacentElement("afterend", missing);
+  }
+  if (!location.useArchive) missing?.remove();
+  if (archiveWasFocused && location.useArchive) repositoryLink.focus();
+}
+
+/** Decorate existing cards in place without making one malformed card abort its peers. */
+export function decorateCardSet(cards, entries, availability, context) {
+  if (availability === null) return;
+  if (cards.length !== entries.length) {
+    console.warn(
+      `${context} source availability received ${cards.length} cards for ` +
+        `${entries.length} entries`,
+    );
+  }
+  for (const [position, card] of cards.entries()) {
+    const entry = entries[position];
+    try {
+      decorateCardAvailability(card, entry, availability);
+    } catch (error) {
+      const identity = entry?.id && entry?.version
+        ? `${entry.id} v${entry.version}`
+        : `card ${position + 1}`;
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(
+        `${context} source availability could not be applied to ` +
+          `${identity}: ${message}`,
+      );
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "name": "palomar-web",
       "devDependencies": {
-        "@playwright/test": "1.62.1"
+        "@playwright/test": "1.62.1",
+        "es-module-lexer": "2.3.1"
       }
     },
     "node_modules/@playwright/test": {
@@ -24,6 +25,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:browser": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "1.62.1"
+    "@playwright/test": "1.62.1",
+    "es-module-lexer": "2.3.1"
   }
 }

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -5,11 +5,18 @@ import { fileURLToPath } from "node:url";
 const root = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 export const htmlFiles = ["404.html", "about.html", "entry.html", "index.html", "render.html"];
 const publicFiles = [...htmlFiles, "site.webmanifest", "favicon.svg"];
-const appModules = ["loading.mjs", "rendering.js", "searching.mjs", "security.mjs"];
-const assetFiles = [
+const browserModuleFiles = [
   "about.js",
   "app.js",
-  ...appModules,
+  "loading.mjs",
+  "rendering.js",
+  "searching.mjs",
+  "security.mjs",
+  "source-preservation.mjs",
+];
+const browserModulePaths = new Set(browserModuleFiles.map((file) => `/assets/${file}`));
+const assetFiles = [
+  ...browserModuleFiles,
   "style.css",
 ];
 // Copied verbatim into assets/, keeping their subdirectory. Listed separately
@@ -45,6 +52,60 @@ function options(args) {
     }
   }
   return result;
+}
+
+let browserModuleParser = null;
+
+async function parseBrowserModule(source, filename) {
+  browserModuleParser ||= import("es-module-lexer").then(async ({ init, parse }) => {
+    await init;
+    return parse;
+  });
+  return (await browserModuleParser)(source, filename)[0];
+}
+
+/** Add the deployment version to every relative edge in the shipped module graph. */
+export async function versionBrowserImports(source, filename, version) {
+  const imports = await parseBrowserModule(source, filename);
+  const replacements = [];
+  for (const imported of imports) {
+    const specifier = imported.n;
+    if (typeof specifier !== "string") {
+      continue;
+    }
+    const pathLike = specifier.startsWith("./") || specifier.startsWith("../") ||
+      specifier.startsWith("/");
+    if (!pathLike) continue;
+    const resolved = new URL(
+      specifier,
+      new URL(`/assets/${filename}`, "https://browser.invalid/"),
+    );
+    // Absolute and protocol-relative URLs are external dependencies, not
+    // deployment assets. Bare package imports are likewise left to the browser.
+    if (resolved.origin !== "https://browser.invalid") continue;
+    if (resolved.search || resolved.hash) {
+      throw new Error(`${filename} has an already-qualified local import: ${specifier}`);
+    }
+    if (!browserModulePaths.has(resolved.pathname)) {
+      throw new Error(
+        `${filename} imports a local browser module that is not shipped: ` +
+          `${specifier} resolves to ${resolved.pathname}`,
+      );
+    }
+    const versioned = `${specifier}?v=${version}`;
+    replacements.push({
+      start: imported.s,
+      end: imported.e,
+      value: imported.d === -1 ? versioned : JSON.stringify(versioned),
+    });
+  }
+
+  let output = source;
+  for (const replacement of replacements.reverse()) {
+    output = output.slice(0, replacement.start) + replacement.value +
+      output.slice(replacement.end);
+  }
+  return output;
 }
 
 export async function buildSite({ output, version }) {
@@ -83,20 +144,11 @@ export async function buildSite({ output, version }) {
     await writeFile(target, versioned);
   }
 
-  const appTarget = path.join(destination, "assets", "app.js");
-  const app = await readFile(appTarget, "utf8");
-  let versionedImport = app;
-  for (const module of appModules) {
-    const source = `from "./${module}";`;
-    if (!versionedImport.includes(source)) {
-      throw new Error(`could not find coupled browser import ${module}`);
-    }
-    versionedImport = versionedImport.replace(
-      source,
-      `from "./${module}?v=${version}";`,
-    );
+  for (const file of browserModuleFiles) {
+    const target = path.join(destination, "assets", file);
+    const source = await readFile(target, "utf8");
+    await writeFile(target, await versionBrowserImports(source, file, version));
   }
-  await writeFile(appTarget, versionedImport);
   await writeFile(path.join(destination, ".nojekyll"), "");
 }
 

--- a/tests/build-site.test.js
+++ b/tests/build-site.test.js
@@ -1,10 +1,16 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { readFile, rm } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { init, parse } from "es-module-lexer";
 
-import { buildSite } from "../scripts/build-site.mjs";
+import {
+  buildSite,
+  shippedFiles,
+  versionBrowserImports,
+} from "../scripts/build-site.mjs";
 
 const root = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 
@@ -16,6 +22,18 @@ test("deployment build versions coupled browser assets", async () => {
     const index = await readFile(path.join(destination, "index.html"), "utf8");
     const about = await readFile(path.join(destination, "about.html"), "utf8");
     const app = await readFile(path.join(destination, "assets", "app.js"), "utf8");
+    const preservation = await readFile(
+      path.join(destination, "assets", "source-preservation.mjs"),
+      "utf8",
+    );
+    const rendering = await readFile(
+      path.join(destination, "assets", "rendering.js"),
+      "utf8",
+    );
+    const searching = await readFile(
+      path.join(destination, "assets", "searching.mjs"),
+      "utf8",
+    );
     assert.match(index, /assets\/style\.css\?v=0123456789abcdef/);
     assert.match(index, /assets\/app\.js\?v=0123456789abcdef/);
     assert.match(about, /assets\/style\.css\?v=0123456789abcdef/);
@@ -25,12 +43,92 @@ test("deployment build versions coupled browser assets", async () => {
     assert.match(app, /\.\/security\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/loading\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/searching\.mjs\?v=0123456789abcdef/);
+    assert.match(app, /\.\/source-preservation\.mjs\?v=0123456789abcdef/);
+    assert.match(preservation, /\.\/security\.mjs\?v=0123456789abcdef/);
+    assert.match(rendering, /\.\/security\.mjs\?v=0123456789abcdef/);
+    assert.match(searching, /\.\/loading\.mjs\?v=0123456789abcdef/);
+    assert.match(searching, /\.\/security\.mjs\?v=0123456789abcdef/);
     await readFile(path.join(destination, "assets", "loading.mjs"), "utf8");
-    await readFile(path.join(destination, "assets", "searching.mjs"), "utf8");
     await readFile(path.join(destination, "assets", "security.mjs"), "utf8");
+
+    await init;
+    const browserModules = shippedFiles.filter(
+      (file) => file.startsWith("assets/") && /\.(?:js|mjs)$/.test(file),
+    );
+    const browserModulePaths = new Set(browserModules.map((file) => `/${file}`));
+    const intentionalExternalImports = new Set();
+    for (const file of browserModules) {
+      const source = await readFile(path.join(destination, file), "utf8");
+      for (const imported of parse(source, file)[0]) {
+        if (typeof imported.n === "string") {
+          const resolved = new URL(
+            imported.n,
+            new URL(`/${file}`, "https://browser.invalid/"),
+          );
+          if (resolved.origin !== "https://browser.invalid" ||
+              !browserModulePaths.has(resolved.pathname)) {
+            assert.ok(
+              intentionalExternalImports.has(imported.n),
+              `${file} has an undeclared external or package import: ${imported.n}`,
+            );
+            continue;
+          }
+          assert.equal(
+            resolved.searchParams.get("v"),
+            "0123456789abcdef",
+            `${file} retains an unversioned shipped-module import: ${imported.n}`,
+          );
+        }
+      }
+    }
   } finally {
     await rm(destination, { recursive: true, force: true });
   }
+});
+
+test("module versioning changes imports rather than lookalike strings or packages", async () => {
+  const source = [
+    'import helpers from "./security.mjs";',
+    'import rootHelpers from "/assets/rendering.js";',
+    'import parentHelpers from "../assets/searching.mjs";',
+    'const description = \'from "./loading.mjs";\';',
+    'import packageValue from "package-name";',
+    'const lazy = import("./loading.mjs");',
+  ].join("\n");
+  const versioned = await versionBrowserImports(source, "app.js", "release-1");
+
+  assert.match(versioned, /from "\.\/security\.mjs\?v=release-1"/);
+  assert.match(versioned, /from "\/assets\/rendering\.js\?v=release-1"/);
+  assert.match(versioned, /from "\.\.\/assets\/searching\.mjs\?v=release-1"/);
+  assert.match(versioned, /import\("\.\/loading\.mjs\?v=release-1"\)/);
+  assert.match(versioned, /const description = 'from "\.\/loading\.mjs";'/);
+  assert.match(versioned, /from "package-name"/);
+  await assert.rejects(
+    versionBrowserImports('import "/assets/not-shipped.mjs";', "app.js", "release-1"),
+    /not-shipped\.mjs resolves to \/assets\/not-shipped\.mjs/,
+  );
+});
+
+test("published-health metadata import does not resolve npm dependencies", () => {
+  const build = new URL("../scripts/build-site.mjs?dependency-free-health-test", import.meta.url);
+  const program = [
+    'import { registerHooks } from "node:module";',
+    'registerHooks({ resolve(specifier, context, nextResolve) {',
+    '  if (!specifier.startsWith("node:") && !specifier.startsWith("file:") &&',
+    '      !specifier.startsWith(".") && !specifier.startsWith("/")) {',
+    '    throw new Error(`unexpected package resolution: ${specifier}`);',
+    '  }',
+    '  return nextResolve(specifier, context);',
+    '} });',
+    `const module = await import(${JSON.stringify(build.href)});`,
+    'if (!module.shippedFiles.includes("assets/app.js")) process.exitCode = 2;',
+  ].join("\n");
+  const child = spawnSync(
+    process.execPath,
+    ["--input-type=module", "--eval", program],
+    { cwd: root, encoding: "utf8" },
+  );
+  assert.equal(child.status, 0, child.stderr || child.stdout);
 });
 
 test("deployment build refuses to remove a directory outside the repository", async () => {

--- a/tests/source-preservation.test.mjs
+++ b/tests/source-preservation.test.mjs
@@ -1,0 +1,234 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  decorateCardSet,
+  sourceDirectoryUrl,
+  sourceFileUrl,
+  sourceLocation,
+  topSourceLocation,
+} from "../assets/source-preservation.mjs";
+import { validateAvailability } from "../assets/security.mjs";
+import {
+  COMMIT,
+  availabilityEndpoint,
+  availabilityManifest,
+  availabilityRow,
+  entry,
+} from "./registry-fixture.mjs";
+
+const CHECKED_AT = new Date(Math.floor(Date.now() / 1_000) * 1_000)
+  .toISOString()
+  .replace(".000Z", "Z");
+
+function manifest({
+  original = "available",
+  archive = "available",
+  forkRepository = "PalomarArchive/example--challenge--fixture",
+} = {}) {
+  return validateAvailability(availabilityManifest([
+    availabilityRow({
+      fork_repository: forkRepository,
+      original: availabilityEndpoint({ status: original, checked_at: CHECKED_AT }),
+      archive: availabilityEndpoint({ status: archive, checked_at: CHECKED_AT }),
+    }),
+  ], { generated_at: CHECKED_AT }));
+}
+
+function fakeCard() {
+  let missing = null;
+  const repositoryLink = {
+    href: "",
+    textContent: "Recorded repository",
+    focus() {
+      document.activeElement = this;
+    },
+  };
+  const archiveLink = {
+    hidden: false,
+    href: "",
+    insertAdjacentElement(position, element) {
+      assert.equal(position, "afterend");
+      missing = element;
+      element.remove = () => {
+        missing = null;
+      };
+    },
+  };
+  return {
+    archiveLink,
+    element: {
+      querySelector(selector) {
+        if (selector === ".repo-link") return repositoryLink;
+        if (selector === ".archive-link") return archiveLink;
+        if (selector === ".source-status.missing") return missing;
+        return null;
+      },
+    },
+    get missing() {
+      return missing;
+    },
+    repositoryLink,
+  };
+}
+
+function withFakeDocument(run) {
+  const previousDocument = globalThis.document;
+  const previousWarn = console.warn;
+  const warnings = [];
+  globalThis.document = {
+    activeElement: null,
+    createElement(tag) {
+      assert.equal(tag, "span");
+      return { className: "", textContent: "" };
+    },
+  };
+  console.warn = (message) => warnings.push(message);
+  try {
+    run(warnings);
+  } finally {
+    console.warn = previousWarn;
+    if (previousDocument === undefined) delete globalThis.document;
+    else globalThis.document = previousDocument;
+  }
+}
+
+test("source location stays on the recorded repository without preservation evidence", () => {
+  const record = entry({ preservation: null });
+  assert.deepEqual(
+    sourceLocation(record, manifest({ original: "missing" }), record.source.repository, COMMIT),
+    {
+      repository: "example/challenge",
+      originalRepository: "example/challenge",
+      archiveRepository: null,
+      commit: COMMIT,
+      originalStatus: "unknown",
+      archiveStatus: "unknown",
+      checkedAt: null,
+      useArchive: false,
+    },
+  );
+});
+
+test("source location switches only from a confirmed missing original to its recorded archive", () => {
+  const record = entry();
+  const availability = manifest({ original: "missing", archive: "available" });
+  const location = sourceLocation(
+    record,
+    availability,
+    record.source.repository,
+    record.source.commit,
+  );
+
+  assert.deepEqual(location, {
+    repository: "PalomarArchive/example--challenge--fixture",
+    originalRepository: "example/challenge",
+    archiveRepository: "PalomarArchive/example--challenge--fixture",
+    commit: COMMIT,
+    originalStatus: "missing",
+    archiveStatus: "available",
+    checkedAt: CHECKED_AT,
+    useArchive: true,
+  });
+  assert.equal(
+    sourceFileUrl(record, "Challenge.lean", availability).href,
+    `https://github.com/PalomarArchive/example--challenge--fixture/blob/${COMMIT}/Challenge.lean`,
+  );
+  assert.equal(
+    sourceDirectoryUrl(record, "Palomar", availability).href,
+    `https://github.com/PalomarArchive/example--challenge--fixture/tree/${COMMIT}/Palomar`,
+  );
+});
+
+test("source location does not switch when both original and archive are missing", () => {
+  const location = topSourceLocation(
+    entry(),
+    manifest({ original: "missing", archive: "missing" }),
+  );
+  assert.equal(location.repository, "example/challenge");
+  assert.equal(location.originalStatus, "missing");
+  assert.equal(location.archiveStatus, "missing");
+  assert.equal(location.useArchive, false);
+});
+
+test("source location ignores availability for a different preserved fork", () => {
+  const location = topSourceLocation(
+    entry(),
+    manifest({
+      original: "missing",
+      forkRepository: "PalomarArchive/example--challenge--other",
+    }),
+  );
+  assert.equal(location.repository, "example/challenge");
+  assert.equal(location.originalStatus, "unknown");
+  assert.equal(location.archiveStatus, "unknown");
+  assert.equal(location.checkedAt, null);
+});
+
+test("source location rejects a repository revision absent from the preservation receipt", () => {
+  assert.throws(
+    () => sourceLocation(entry(), null, "example/other", COMMIT),
+    /entry has no preserved copy of example\/other@/,
+  );
+});
+
+test("card decoration isolates a malformed entry and still decorates its peer", () => {
+  withFakeDocument((warnings) => {
+    const bad = entry();
+    bad.source = {
+      ...bad.source,
+      repository: "example/unpreserved",
+      repository_url: "https://github.com/example/unpreserved",
+    };
+    const cards = [fakeCard(), fakeCard()];
+
+    decorateCardSet(
+      cards.map((card) => card.element),
+      [bad, entry()],
+      manifest({ original: "missing", archive: "available" }),
+      "Fixture card",
+    );
+
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /entry has no preserved copy of example\/unpreserved@/);
+    assert.equal(cards[0].repositoryLink.textContent, "Recorded repository");
+    assert.equal(cards[1].repositoryLink.textContent, "Palomar preserved copy");
+    assert.equal(cards[1].archiveLink.hidden, true);
+    assert.equal(cards[1].missing.textContent, "Original unavailable");
+  });
+});
+
+test("card decoration reports length mismatches without throwing in its error handler", () => {
+  withFakeDocument((warnings) => {
+    const cards = [fakeCard(), fakeCard()];
+    assert.doesNotThrow(() => decorateCardSet(
+      cards.map((card) => card.element),
+      [entry()],
+      manifest({ original: "missing", archive: "available" }),
+      "Fixture card",
+    ));
+
+    assert.equal(warnings.length, 2);
+    assert.match(warnings[0], /received 2 cards for 1 entries/);
+    assert.match(warnings[1], /Fixture card source availability could not be applied to card 2:/);
+    assert.equal(cards[0].repositoryLink.textContent, "Palomar preserved copy");
+  });
+});
+
+test("card decoration transfers focus before hiding the archive link", () => {
+  withFakeDocument((warnings) => {
+    const card = fakeCard();
+    document.activeElement = card.archiveLink;
+
+    decorateCardSet(
+      [card.element],
+      [entry()],
+      manifest({ original: "missing", archive: "available" }),
+      "Fixture card",
+    );
+
+    assert.deepEqual(warnings, []);
+    assert.equal(card.archiveLink.hidden, true);
+    assert.equal(document.activeElement, card.repositoryLink);
+  });
+});


### PR DESCRIPTION
## What

- move repository/archive resolution and stable card availability decoration from assets/app.js into assets/source-preservation.mjs
- keep security.mjs as the single owner of validation and endpoint freshness while the new module owns preservation-receipt versus manifest matching
- version every local edge across the complete shipped browser-module graph using an ECMAScript-aware lexer and real /assets module URLs
- fail the build when a same-origin local import is already qualified or points outside the shipped browser-module set
- independently parse the emitted graph so root-relative, dot-relative, and parent-relative imports cannot retain stale versions; undeclared external/package imports fail the test
- keep build-only parsing dependencies lazy so the no-install hourly health metadata import remains dependency-free
- harden per-card decoration isolation, length-mismatch diagnostics, and focus transfer
- add direct policy/fake-DOM/build-graph tests and document the module ownership boundary

## Why

This is a bounded first decomposition of the page controller. Source preservation is used by landing, search, and entry views, but its resolution rules and card mutation do not need to live among page orchestration. Entry-page section composition remains in app.js so the extracted API stays narrow.

The complete module-graph transformation is required because versioning only app.js imports leaves nested modules able to load a stale validator from a previous deployment. Parsing actual ECMAScript imports avoids rewriting lookalike strings or package specifiers.

## Impact

No data contract, request pattern, or reader-visible behavior changes. Existing progressive card decoration, archive/source links, per-card error isolation, and focus transfer are preserved. Existing top-level deployment versioning remains in place and now reaches every nested local import.

## Checks

- PALOMAR_DATABASE_CHECKOUT=/tmp/palomar-database-availability.P5bOHr/PalomarDatabase npm test (100 passed)
- npm run build -- --version root-module-local --output .site
- emitted-module graph assertion: every shipped-module import carries the build version and external imports require explicit declaration
- dependency-free subprocess import of build metadata with npm package resolution rejected
- Playwright with Nixpkgs Chromium and PALOMAR_PREVIOUS_REF=origin/main (53 passed)
- git diff --check and node --check for changed JavaScript modules