### PR TITLE
Require entry schema v2 only

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,9 +32,6 @@ jobs:
         run: |
           mkdir -p palomar-database/tests/fixtures
           curl --fail --silent --show-error --retry 3 \
-            "$PUBLIC_DATA_ORIGIN/schema-v1.json" \
-            --output palomar-database/schema-v1.json
-          curl --fail --silent --show-error --retry 3 \
             "$PUBLIC_DATA_ORIGIN/schema-v2.json" \
             --output palomar-database/schema-v2.json
           curl --fail --silent --show-error --retry 3 \

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,6 +48,13 @@ jobs:
       - run: npm test
         env:
           PALOMAR_DATABASE_CHECKOUT: ${{ github.workspace }}/palomar-database
+      # A consumer-first schema deletion is safe only if every currently served
+      # version already satisfies the new consumer. Keep this before the Pages
+      # artifact is built or uploaded.
+      - name: Can Web read every currently published entry version
+        run: node scripts/check-published.mjs --data "$PUBLIC_DATA_ORIGIN"
+        env:
+          PUBLIC_DATA_ORIGIN: https://data.palomar-registry.org
       - name: Resolve previous deployment revision
         env:
           BEFORE: ${{ github.event.before }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,6 +40,18 @@ jobs:
           curl --fail --silent --show-error --retry 3 \
             "$PUBLIC_DATA_ORIGIN/source-availability.json" \
             --output palomar-database/tests/fixtures/source-availability.json
+          curl --fail --silent --show-error --retry 3 \
+            "$PUBLIC_DATA_ORIGIN/browse/index.json" \
+            --output tests/fixtures/public-browse/index.json
+          browse_year=$(jq -er '.years[-1].year' tests/fixtures/public-browse/index.json)
+          curl --fail --silent --show-error --retry 3 \
+            "$PUBLIC_DATA_ORIGIN/browse/$browse_year.json" \
+            --output tests/fixtures/public-browse/year.json
+          browse_day=$(jq -er '.days[-1].day' tests/fixtures/public-browse/year.json)
+          browse_page=$(jq -er '.days[-1].first_page' tests/fixtures/public-browse/year.json)
+          curl --fail --silent --show-error --retry 3 \
+            "$PUBLIC_DATA_ORIGIN/browse/$browse_day/$browse_page.json" \
+            --output tests/fixtures/public-browse/page.json
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.4.1"

--- a/.github/workflows/publish-health.yml
+++ b/.github/workflows/publish-health.yml
@@ -20,11 +20,14 @@ permissions:
 
 concurrency:
   group: publish-health
-  cancel-in-progress: false
+  # A new hourly observation supersedes one still queued or stuck. Without
+  # this, concurrency can leave the current check silently waiting for hours.
+  cancel-in-progress: true
 
 jobs:
   published:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,18 @@ jobs:
           curl --fail --silent --show-error --retry 3 \
             "$PUBLIC_DATA_ORIGIN/source-availability.json" \
             --output palomar-database/tests/fixtures/source-availability.json
+          curl --fail --silent --show-error --retry 3 \
+            "$PUBLIC_DATA_ORIGIN/browse/index.json" \
+            --output tests/fixtures/public-browse/index.json
+          browse_year=$(jq -er '.years[-1].year' tests/fixtures/public-browse/index.json)
+          curl --fail --silent --show-error --retry 3 \
+            "$PUBLIC_DATA_ORIGIN/browse/$browse_year.json" \
+            --output tests/fixtures/public-browse/year.json
+          browse_day=$(jq -er '.days[-1].day' tests/fixtures/public-browse/year.json)
+          browse_page=$(jq -er '.days[-1].first_page' tests/fixtures/public-browse/year.json)
+          curl --fail --silent --show-error --retry 3 \
+            "$PUBLIC_DATA_ORIGIN/browse/$browse_day/$browse_page.json" \
+            --output tests/fixtures/public-browse/page.json
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24.4.1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,12 @@ jobs:
       - run: npm test
         env:
           PALOMAR_DATABASE_CHECKOUT: ${{ github.workspace }}/palomar-database
+      # This is intentionally broader than a page load: traverse browse and
+      # every per-ID history, then validate every active public permalink.
+      - name: Can Web read every currently published entry version
+        run: node scripts/check-published.mjs --data "$PUBLIC_DATA_ORIGIN"
+        env:
+          PUBLIC_DATA_ORIGIN: https://data.palomar-registry.org
       # Against the live service, because the grammar of what it serves lives
       # in the canonical database and this repository cannot see it. A link to
       # a document the service has removed answers 404 to a reader, which is

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,6 @@ jobs:
         run: |
           mkdir -p palomar-database/tests/fixtures
           curl --fail --silent --show-error --retry 3 \
-            "$PUBLIC_DATA_ORIGIN/schema-v1.json" \
-            --output palomar-database/schema-v1.json
-          curl --fail --silent --show-error --retry 3 \
             "$PUBLIC_DATA_ORIGIN/schema-v2.json" \
             --output palomar-database/schema-v2.json
           curl --fail --silent --show-error --retry 3 \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,12 @@
   as soon as Database publication removed it. This consumer-first ordering is
   specific to deleting an artifact an old consumer still requests; shape
   changes to documents the browser reads remain producer-first as above.
+  The consumer-first claim must be proved by `check-published.mjs --data`, which
+  traverses every browse page and per-ID version index and validates every
+  active entry before Pages artifact upload. A recent-only sample is not enough.
+  `recent.json`, versions, browse/search, source availability, and independent
+  render/evidence metadata intentionally retain their schema-v1 protocols;
+  entry-schema cleanup must not rewrite them.
 
 - `source-availability.json` is normalized by PalomarDatabase's executable
   source-availability contract and consumed under the same per-endpoint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,10 @@
   the matching Web deployment. Do not add an old-shape or per-entry fallback;
   invalid projections are supposed to fail closed.
 
+- Entry records have one contract: `schema_version: 2` in `schema-v2.json`.
+  Version 1 was an unused pre-launch draft; do not restore its validator,
+  preservation fallback, public schema download, or legacy presentation.
+
 - `source-availability.json` is normalized by PalomarDatabase's executable
   source-availability contract and consumed under the same per-endpoint
   freshness rules here. A known answer is authoritative only from five minutes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,12 @@
 - Entry records have one contract: `schema_version: 2` in `schema-v2.json`.
   Version 1 was an unused pre-launch draft; do not restore its validator,
   preservation fallback, public schema download, or legacy presentation.
+  Deploy this consumer cleanup before the matching Database deletion: the live
+  data already contains only v2 entries and preservation-backed recent rows,
+  while the previous Web workflows still fetch `schema-v1.json` and would fail
+  as soon as Database publication removed it. This consumer-first ordering is
+  specific to deleting an artifact an old consumer still requests; shape
+  changes to documents the browser reads remain producer-first as above.
 
 - `source-availability.json` is normalized by PalomarDatabase's executable
   source-availability contract and consumed under the same per-endpoint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,14 @@
   the matching Web deployment. Do not add an old-shape or per-entry fallback;
   invalid projections are supposed to fail closed.
 
+- The three browse surfaces—`browse/index.json`, `browse/<year>.json`, and
+  `browse/<day>/<page>.json`—are also exact closed producer/consumer contracts.
+  PalomarDatabase owns their head, year, page, count, and summary-row shapes;
+  change those producer-first. CI downloads one live head/year/page chain into
+  the named producer-contract fixture test, then the predeploy check traverses
+  every row the producer advertises. The traversal reconciles those surfaces;
+  it cannot independently prove that their common producer omitted nothing.
+
 - Entry records have one contract: `schema_version: 2` in `schema-v2.json`.
   Version 1 was an unused pre-launch draft; do not restore its validator,
   preservation fallback, public schema download, or legacy presentation.
@@ -34,8 +42,9 @@
   specific to deleting an artifact an old consumer still requests; shape
   changes to documents the browser reads remain producer-first as above.
   The consumer-first claim must be proved by `check-published.mjs --data`, which
-  traverses every browse page and per-ID version index and validates every
-  active entry before Pages artifact upload. A recent-only sample is not enough.
+  traverses every advertised browse page and per-ID version index and validates
+  every advertised active entry before Pages artifact upload. A recent-only
+  sample is not enough.
   `recent.json`, versions, browse/search, source availability, and independent
   render/evidence metadata intentionally retain their schema-v1 protocols;
   entry-schema cleanup must not rewrite them.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ This is one exact closed producer/consumer contract, not an extensible summary:
 a shape change must be published by PalomarDatabase first and followed by the
 matching website deployment. The consumer deliberately has no old-row fallback
 or per-entry recovery path.
+The `browse/index.json`, `browse/<year>.json`, and
+`browse/<day>/<page>.json` hierarchy is another exact, closed contract owned by
+PalomarDatabase and consumed by Web. Its head declares years and aggregate
+counts, each year declares its days and page ranges, and each page carries exact
+entry-history rows. Changes to any of those three shapes are producer-first
+contract changes, even though these documents intentionally remain
+`schema_version: 1`.
 Landing and verified search cards render before the source-availability
 manifest; if it arrives, their existing source controls are decorated in place.
 A linked `?q=` search does not also load the hidden recent listing; clearing the
@@ -123,11 +130,17 @@ The deployed data already contains only v2 entries and preservation-backed
 recent projections. The pre-launch removal therefore deploys this Web cleanup
 first, so its workflows stop fetching `schema-v1.json`; Database can then stop
 publishing and serving that obsolete document without breaking Web deployment.
-That ordering is gated by a complete public traversal: CI and Pages deployment
-walk the browse hierarchy, reconcile every per-result version index, and run the
-Web entry validator over every active permalink before an artifact is uploaded.
+That ordering is gated by a complete traversal of what the producer advertises:
+CI and Pages deployment walk the browse hierarchy, reconcile every advertised
+row with its per-result version index, and run the Web entry validator over each
+advertised active permalink before an artifact is uploaded. This catches drift
+between those public surfaces; it is not an independent proof that the producer
+omitted no row from all of them.
 The hourly published-site check repeats it. This is intentionally O(A) in
 active versions and is deployment/monitoring cost, not visitor page-load cost.
+It uses at most eight concurrent reads; each read gets at most three five-second
+attempts with short backoff. The hourly job has a fifteen-minute ceiling, and a
+new observation supersedes an older queued or stuck one.
 
 This cleanup does not renumber unrelated documents. `recent.json`, per-result
 version indexes, browse/search projections, and source availability remain

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ the worst moment to find out.
 The site accepts the sole current entry contract, `schema_version: 2`, and
 requires its source-preservation receipt. The unused pre-launch v1 draft has no
 browser fallback; an obsolete or malformed record fails closed.
+The deployed data already contains only v2 entries and preservation-backed
+recent projections. The pre-launch removal therefore deploys this Web cleanup
+first, so its workflows stop fetching `schema-v1.json`; Database can then stop
+publishing and serving that obsolete document without breaking Web deployment.
 
 The website is a presentation layer only. Public data and schemas live at the
 machine-readable data origin. A versioned ID

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ The scores are not published and are not in the record; a served record that had
 them would mean something upstream had gone wrong, and displaying it would be
 the worst moment to find out.
 
+The site accepts the sole current entry contract, `schema_version: 2`, and
+requires its source-preservation receipt. The unused pre-launch v1 draft has no
+browser fallback; an obsolete or malformed record fails closed.
+
 The website is a presentation layer only. Public data and schemas live at the
 machine-readable data origin. A versioned ID
 such as `PALOMAR-2026-07-29-000001-v1` names one immutable record. An ID without

--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ The deployed data already contains only v2 entries and preservation-backed
 recent projections. The pre-launch removal therefore deploys this Web cleanup
 first, so its workflows stop fetching `schema-v1.json`; Database can then stop
 publishing and serving that obsolete document without breaking Web deployment.
+That ordering is gated by a complete public traversal: CI and Pages deployment
+walk the browse hierarchy, reconcile every per-result version index, and run the
+Web entry validator over every active permalink before an artifact is uploaded.
+The hourly published-site check repeats it. This is intentionally O(A) in
+active versions and is deployment/monitoring cost, not visitor page-load cost.
+
+This cleanup does not renumber unrelated documents. `recent.json`, per-result
+version indexes, browse/search projections, and source availability remain
+their existing `schema_version: 1` protocols, as do independent render and
+evidence metadata formats. Only the accepted-entry contract is v2-only.
 
 The website is a presentation layer only. Public data and schemas live at the
 machine-readable data origin. A versioned ID

--- a/assets/app.js
+++ b/assets/app.js
@@ -290,15 +290,13 @@ function entryCard(
     ),
     internalLink("View record", localPageUrl("entry.html", entry)),
   );
-  if (location.archiveRepository) {
-    footer.append(
-      externalLink(
-        "Palomar preserved copy",
-        pinnedRepositoryDirectoryUrl(location.archiveRepository, entry.source.commit),
-        "archive-link",
-      ),
-    );
-  }
+  footer.append(
+    externalLink(
+      "Palomar preserved copy",
+      pinnedRepositoryDirectoryUrl(location.archiveRepository, entry.source.commit),
+      "archive-link",
+    ),
+  );
   if (versionCount > 1) {
     const historyLink = internalLink(
       `${versionCount} versions`,
@@ -1349,7 +1347,7 @@ function solutionMetadata(entry, renderMetadata, availability) {
         ),
         el("code", "", dependency.revision.slice(0, 12)),
       );
-      if (!location.useArchive && location.archiveRepository) {
+      if (!location.useArchive) {
         item.append(
           " · ",
           externalLink(

--- a/assets/app.js
+++ b/assets/app.js
@@ -1024,15 +1024,13 @@ function acceptanceCallout(entry, databaseBase) {
       evidenceDataUrl(entry, databaseBase, "review.json"),
     ),
   );
-  if (entry.preservation) {
-    evidenceLinks.append(
-      " · ",
-      dataLink(
-        "Source preservation receipt",
-        evidenceDataUrl(entry, databaseBase, "source-archive.json"),
-      ),
-    );
-  }
+  evidenceLinks.append(
+    " · ",
+    dataLink(
+      "Source preservation receipt",
+      evidenceDataUrl(entry, databaseBase, "source-archive.json"),
+    ),
+  );
   copy.append(
     el("strong", "", `Registered on ${displayDate(registrationDate(entry.registered_at))}`),
     assurance(
@@ -1085,21 +1083,6 @@ function sourceAvailabilityNotice(entry, availability) {
     location.commit,
     entry.source.project_path || ".",
   );
-  if (!location.archiveRepository) {
-    notice.classList.add("legacy");
-    notice.append(
-      el("strong", "", "Palomar has no preservation copy of this source"),
-      el(
-        "p",
-        "",
-        "This record was accepted before Palomar began archiving source repositories. " +
-          "The link goes to the original repository at the exact commit that was reviewed, " +
-          "but it may stop working if that repository is removed.",
-      ),
-      externalLink("Open the reviewed source", original),
-    );
-    return notice;
-  }
   const archived = pinnedRepositoryDirectoryUrl(
     location.archiveRepository,
     location.commit,

--- a/assets/rendering.js
+++ b/assets/rendering.js
@@ -39,7 +39,7 @@ export function challengeSourceUrl(entry, repositoryOverride = null) {
     throw new Error("entry has invalid canonical Challenge source metadata");
   }
   const selectedRepository = repositoryOverride || repository;
-  const isPreserved = entry?.preservation?.repositories?.some(
+  const isPreserved = entry.preservation.repositories.some(
     (row) => row.source_repository.toLowerCase() === repository.toLowerCase() &&
       row.commit === commit && row.fork_repository === selectedRepository,
   );

--- a/assets/rendering.js
+++ b/assets/rendering.js
@@ -39,11 +39,17 @@ export function challengeSourceUrl(entry, repositoryOverride = null) {
     throw new Error("entry has invalid canonical Challenge source metadata");
   }
   const selectedRepository = repositoryOverride || repository;
-  const isPreserved = entry.preservation.repositories.some(
-    (row) => row.source_repository.toLowerCase() === repository.toLowerCase() &&
-      row.commit === commit && row.fork_repository === selectedRepository,
+  const repositories = entry?.preservation?.repositories;
+  if (!Array.isArray(repositories)) {
+    throw new Error("entry has no canonical source preservation metadata");
+  }
+  const sourceMapping = repositories.find(
+    (row) => typeof row?.source_repository === "string" &&
+      row.source_repository.toLowerCase() === repository.toLowerCase() &&
+      row.commit === commit,
   );
-  if (selectedRepository !== repository && !isPreserved) {
+  if (!sourceMapping ||
+      (selectedRepository !== repository && sourceMapping.fork_repository !== selectedRepository)) {
     throw new Error("entry has invalid preserved Challenge source metadata");
   }
   return pinnedRepositoryFileUrl(selectedRepository, commit, challengePath).href;

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -8,7 +8,6 @@ const MAX_VERSIONS_PER_ID = 500;
 // unbounded one would let it come back without anything saying so.
 const RECENT_ITEMS = 200;
 export const ENTRY_SCHEMA_VERSION = 2;
-export const ENTRY_SCHEMA_VERSIONS = new Set([1, 2]);
 // The endpoint, not a document. There is no whole-registry document to name
 // any more: every surface is derived from this prefix by the function that
 // knows which one it wants.
@@ -329,27 +328,25 @@ export function validateRecent(value) {
     commit(string(source.commit, `${field}.source.commit`), `${field}.source.commit`);
     if (source.project_path !== null) safeRepositoryPath(source.project_path, `${field}.source.project_path`);
 
-    if (summary.preservation !== null) {
-      const preservation = exactObject(
-        summary.preservation,
-        ["repositories"],
-        `${field}.preservation`,
-      );
-      const repositories = array(preservation.repositories, `${field}.preservation.repositories`);
-      if (repositories.length !== 1) fail(`${field}.preservation must contain one source mapping`);
-      const mapping = exactObject(repositories[0], [
-        "source_repository",
-        "commit",
-        "fork_repository",
-      ], `${field}.preservation.repositories[0]`);
-      if (typeof mapping.source_repository !== "string" ||
-          mapping.source_repository.toLowerCase() !== repository.toLowerCase() ||
-          mapping.commit !== source.commit ||
-          typeof mapping.fork_repository !== "string" ||
-          !REPOSITORY_RE.test(mapping.fork_repository) ||
-          !mapping.fork_repository.startsWith("PalomarArchive/")) {
-        fail(`${field}.preservation does not match source`);
-      }
+    const preservation = exactObject(
+      summary.preservation,
+      ["repositories"],
+      `${field}.preservation`,
+    );
+    const repositories = array(preservation.repositories, `${field}.preservation.repositories`);
+    if (repositories.length !== 1) fail(`${field}.preservation must contain one source mapping`);
+    const mapping = exactObject(repositories[0], [
+      "source_repository",
+      "commit",
+      "fork_repository",
+    ], `${field}.preservation.repositories[0]`);
+    if (typeof mapping.source_repository !== "string" ||
+        mapping.source_repository.toLowerCase() !== repository.toLowerCase() ||
+        mapping.commit !== source.commit ||
+        typeof mapping.fork_repository !== "string" ||
+        !REPOSITORY_RE.test(mapping.fork_repository) ||
+        !mapping.fork_repository.startsWith("PalomarArchive/")) {
+      fail(`${field}.preservation does not match source`);
     }
   }
   return document;
@@ -833,7 +830,7 @@ function validateCanonicalRecordLinks(entry) {
 export function validateEntry(entry, summary) {
   object(entry, "entry");
   object(summary, "entry summary");
-  if (!ENTRY_SCHEMA_VERSIONS.has(entry.schema_version)) {
+  if (entry.schema_version !== ENTRY_SCHEMA_VERSION) {
     fail(`unsupported entry schema_version ${String(entry.schema_version)}`);
   }
   if (entry.status !== "accepted") fail("entry status is not accepted");
@@ -1054,58 +1051,56 @@ export function validateEntry(entry, summary) {
     }
   }
 
-  if (entry.schema_version >= 2 || entry.preservation !== undefined) {
-    const preservation = object(entry.preservation, "entry.preservation");
-    if (preservation.archive_owner !== "PalomarArchive") {
-      fail("entry.preservation.archive_owner is unsupported");
+  const preservation = object(entry.preservation, "entry.preservation");
+  if (preservation.archive_owner !== "PalomarArchive") {
+    fail("entry.preservation.archive_owner is unsupported");
+  }
+  if (!TIMESTAMP_RE.test(preservation.archived_at) ||
+      Number.isNaN(Date.parse(preservation.archived_at))) {
+    fail("entry.preservation.archived_at is malformed");
+  }
+  digest(preservation.receipt_sha256, "entry.preservation.receipt_sha256");
+  const expected = new Map();
+  const addExpected = (repository, revision) => {
+    expected.set(`${repository.toLowerCase()}\0${revision}`, [repository, revision]);
+  };
+  addExpected(source.repository, source.commit);
+  for (const dependency of formalization.project_dependencies) {
+    if (dependency.path === undefined) addExpected(dependency.repository, dependency.revision);
+  }
+  const substantive = entry.provenance.substantive_formalization;
+  if (substantive) addExpected(substantive.repository, substantive.commit);
+  const expectedRows = [...expected.values()].sort((left, right) => {
+    const leftKey = `${left[0].toLowerCase()}\0${left[1]}`;
+    const rightKey = `${right[0].toLowerCase()}\0${right[1]}`;
+    return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+  });
+  const actualRows = [];
+  const seen = new Set();
+  for (const [position, value] of array(
+    preservation.repositories,
+    "entry.preservation.repositories",
+  ).entries()) {
+    const row = object(value, `entry.preservation.repositories[${position}]`);
+    if (!REPOSITORY_RE.test(row.source_repository)) {
+      fail(`entry.preservation.repositories[${position}].source_repository is malformed`);
     }
-    if (!TIMESTAMP_RE.test(preservation.archived_at) ||
-        Number.isNaN(Date.parse(preservation.archived_at))) {
-      fail("entry.preservation.archived_at is malformed");
+    commit(row.commit, `entry.preservation.repositories[${position}].commit`);
+    if (!REPOSITORY_RE.test(row.fork_repository) ||
+        !row.fork_repository.startsWith("PalomarArchive/")) {
+      fail(`entry.preservation.repositories[${position}].fork_repository is malformed`);
     }
-    digest(preservation.receipt_sha256, "entry.preservation.receipt_sha256");
-    const expected = new Map();
-    const addExpected = (repository, revision) => {
-      expected.set(`${repository.toLowerCase()}\0${revision}`, [repository, revision]);
-    };
-    addExpected(source.repository, source.commit);
-    for (const dependency of formalization.project_dependencies) {
-      if (dependency.path === undefined) addExpected(dependency.repository, dependency.revision);
+    const key = `${row.source_repository.toLowerCase()}\0${row.commit}`;
+    if (seen.has(key)) fail(`entry.preservation.repositories[${position}] is duplicated`);
+    seen.add(key);
+    const expectedRef = `refs/tags/palomar/${entry.id}-v${entry.version}/${row.commit}`;
+    if (row.ref !== expectedRef) {
+      fail(`entry.preservation.repositories[${position}].ref is not canonical`);
     }
-    const substantive = entry.provenance.substantive_formalization;
-    if (substantive) addExpected(substantive.repository, substantive.commit);
-    const expectedRows = [...expected.values()].sort((left, right) => {
-      const leftKey = `${left[0].toLowerCase()}\0${left[1]}`;
-      const rightKey = `${right[0].toLowerCase()}\0${right[1]}`;
-      return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
-    });
-    const actualRows = [];
-    const seen = new Set();
-    for (const [position, value] of array(
-      preservation.repositories,
-      "entry.preservation.repositories",
-    ).entries()) {
-      const row = object(value, `entry.preservation.repositories[${position}]`);
-      if (!REPOSITORY_RE.test(row.source_repository)) {
-        fail(`entry.preservation.repositories[${position}].source_repository is malformed`);
-      }
-      commit(row.commit, `entry.preservation.repositories[${position}].commit`);
-      if (!REPOSITORY_RE.test(row.fork_repository) ||
-          !row.fork_repository.startsWith("PalomarArchive/")) {
-        fail(`entry.preservation.repositories[${position}].fork_repository is malformed`);
-      }
-      const key = `${row.source_repository.toLowerCase()}\0${row.commit}`;
-      if (seen.has(key)) fail(`entry.preservation.repositories[${position}] is duplicated`);
-      seen.add(key);
-      const expectedRef = `refs/tags/palomar/${entry.id}-v${entry.version}/${row.commit}`;
-      if (row.ref !== expectedRef) {
-        fail(`entry.preservation.repositories[${position}].ref is not canonical`);
-      }
-      actualRows.push([row.source_repository, row.commit]);
-    }
-    if (JSON.stringify(actualRows) !== JSON.stringify(expectedRows)) {
-      fail("entry.preservation.repositories does not exactly cover the source graph");
-    }
+    actualRows.push([row.source_repository, row.commit]);
+  }
+  if (JSON.stringify(actualRows) !== JSON.stringify(expectedRows)) {
+    fail("entry.preservation.repositories does not exactly cover the source graph");
   }
 
   const verification = object(entry.verification, "entry.verification");

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -1,5 +1,6 @@
 export const VERSIONS_SCHEMA_VERSION = 1;
 export const RECENT_SCHEMA_VERSION = 1;
+export const BROWSE_SCHEMA_VERSION = 1;
 // A result with five hundred registered versions is a bug, not a history, and
 // this is the one read surface whose size is not bounded by anything else.
 const MAX_VERSIONS_PER_ID = 500;
@@ -7,6 +8,8 @@ const MAX_VERSIONS_PER_ID = 500;
 // document this replaced was the whole registry, and a reader that accepted an
 // unbounded one would let it come back without anything saying so.
 const RECENT_ITEMS = 200;
+const BROWSE_PAGE_SERIALS = 200;
+const BROWSE_MAX_PAGE = Math.ceil(999_999 / BROWSE_PAGE_SERIALS);
 export const ENTRY_SCHEMA_VERSION = 2;
 // The endpoint, not a document. There is no whole-registry document to name
 // any more: every surface is derived from this prefix by the function that
@@ -73,6 +76,13 @@ function boundedString(value, field, maximum) {
 
 function integer(value, field) {
   if (!Number.isSafeInteger(value) || value < 1) fail(`${field} must be a positive integer`);
+  return value;
+}
+
+function nonnegativeInteger(value, field) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    fail(`${field} must be a non-negative integer`);
+  }
   return value;
 }
 
@@ -471,6 +481,22 @@ export function availabilityRecord(manifest, repository, revision, now = Date.no
   };
 }
 
+function validateEntrySummary(value, field) {
+  const summary = exactObject(
+    value,
+    ["id", "path", "status", "title", "version"],
+    field,
+  );
+  const id = string(summary.id, `${field}.id`);
+  if (!ID_RE.test(id)) fail(`${field}.id is malformed`);
+  const version = integer(summary.version, `${field}.version`);
+  boundedString(summary.title, `${field}.title`, 300);
+  if (summary.status !== "accepted") fail(`${field}.status is not accepted`);
+  const expectedPath = `entries/${id}-v${version}.json`;
+  if (summary.path !== expectedPath) fail(`${field}.path must be ${expectedPath}`);
+  return summary;
+}
+
 export function entryRecordUrl(summary, databaseBase) {
   object(summary, "entry summary");
   const id = string(summary.id, "entry summary id");
@@ -505,7 +531,7 @@ export function versionsUrl(id, databaseBase) {
  * result's name.
  */
 export function validateVersions(value, id) {
-  const document = object(value, "version index");
+  const document = exactObject(value, ["schema_version", "id", "entries"], "version index");
   if (document.schema_version !== VERSIONS_SCHEMA_VERSION) {
     fail(`unsupported version index schema_version ${String(document.schema_version)}`);
   }
@@ -515,19 +541,127 @@ export function validateVersions(value, id) {
   if (entries.length > MAX_VERSIONS_PER_ID) fail("version index is implausibly long");
   let previous = 0;
   for (const [position, row] of entries.entries()) {
-    const summary = object(row, `version index entries[${position}]`);
+    const field = `version index entries[${position}]`;
+    const summary = validateEntrySummary(row, field);
     if (summary.id !== id) fail(`version index entries[${position}] is a different result`);
-    const version = integer(summary.version, `version index entries[${position}].version`);
+    const version = summary.version;
     if (version <= previous) fail("version index is not in increasing version order");
     previous = version;
-    string(summary.title, `version index entries[${position}].title`);
-    if (summary.status !== "accepted") {
-      fail(`version index entries[${position}].status is not accepted`);
+  }
+  return document;
+}
+
+/** The bounded-by-years root of the complete public browse traversal. */
+export function validateBrowseHead(value) {
+  const document = exactObject(
+    value,
+    ["schema_version", "results", "versions", "years"],
+    "browse index",
+  );
+  if (document.schema_version !== BROWSE_SCHEMA_VERSION) {
+    fail(`unsupported browse index schema_version ${String(document.schema_version)}`);
+  }
+  const results = nonnegativeInteger(document.results, "browse index results");
+  const versions = nonnegativeInteger(document.versions, "browse index versions");
+  if (results > versions) fail("browse index has more results than versions");
+  let previous = "";
+  let countedResults = 0;
+  let countedVersions = 0;
+  const years = array(document.years, "browse index years");
+  for (const [position, value] of years.entries()) {
+    const field = `browse index years[${position}]`;
+    const row = exactObject(value, ["days", "results", "versions", "year"], field);
+    const year = string(row.year, `${field}.year`);
+    if (!/^[0-9]{4}$/.test(year) || year <= previous) {
+      fail("browse index years are malformed or not in increasing order");
     }
-    const expectedPath = `entries/${id}-v${version}.json`;
-    if (summary.path !== expectedPath) {
-      fail(`version index entries[${position}].path must be ${expectedPath}`);
+    previous = year;
+    const days = integer(row.days, `${field}.days`);
+    if (days > 366) fail(`${field}.days exceeds one calendar year`);
+    const yearResults = nonnegativeInteger(row.results, `${field}.results`);
+    const yearVersions = nonnegativeInteger(row.versions, `${field}.versions`);
+    if (yearResults > yearVersions) fail(`${field} has more results than versions`);
+    countedResults += yearResults;
+    countedVersions += yearVersions;
+  }
+  if (countedResults !== results || countedVersions !== versions) {
+    fail("browse index counts do not equal its year rows");
+  }
+  return document;
+}
+
+/** Every day and page range belonging to one browse-index year row. */
+export function validateBrowseYear(value, expected) {
+  const document = exactObject(value, ["schema_version", "year", "days"], "browse year");
+  if (document.schema_version !== BROWSE_SCHEMA_VERSION) {
+    fail(`unsupported browse year schema_version ${String(document.schema_version)}`);
+  }
+  if (document.year !== expected.year) fail("browse year is for a different year");
+  const days = array(document.days, "browse year days");
+  if (days.length !== expected.days) fail("browse year does not carry its declared number of days");
+  let previous = "";
+  let countedResults = 0;
+  let countedVersions = 0;
+  for (const [position, value] of days.entries()) {
+    const field = `browse year days[${position}]`;
+    const row = exactObject(
+      value,
+      ["day", "first_page", "last_page", "results", "versions"],
+      field,
+    );
+    const day = string(row.day, `${field}.day`);
+    const parsed = new Date(`${day}T00:00:00Z`);
+    if (!DATE_RE.test(day) || day.slice(0, 4) !== expected.year ||
+        Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== day ||
+        day <= previous) {
+      fail("browse year days are malformed or not in increasing order");
     }
+    previous = day;
+    const first = integer(row.first_page, `${field}.first_page`);
+    const last = integer(row.last_page, `${field}.last_page`);
+    if (last < first) fail(`${field} has a reversed page range`);
+    if (last > BROWSE_MAX_PAGE) fail(`${field} exceeds the identifier page range`);
+    const dayResults = nonnegativeInteger(row.results, `${field}.results`);
+    const dayVersions = nonnegativeInteger(row.versions, `${field}.versions`);
+    if (dayResults > dayVersions) fail(`${field} has more results than versions`);
+    countedResults += dayResults;
+    countedVersions += dayVersions;
+  }
+  if (countedResults !== expected.results || countedVersions !== expected.versions) {
+    fail("browse year counts do not equal its index row");
+  }
+  return document;
+}
+
+/** Every active version whose identifier places it on one public browse page. */
+export function validateBrowsePage(value, day, page) {
+  const document = exactObject(
+    value,
+    ["schema_version", "day", "page", "entries"],
+    "browse page",
+  );
+  if (document.schema_version !== BROWSE_SCHEMA_VERSION) {
+    fail(`unsupported browse page schema_version ${String(document.schema_version)}`);
+  }
+  if (document.day !== day || document.page !== page) {
+    fail("browse page identity does not match its URL");
+  }
+  let previousId = "";
+  let previousVersion = 0;
+  for (const [position, value] of array(document.entries, "browse page entries").entries()) {
+    const field = `browse page entries[${position}]`;
+    const summary = validateEntrySummary(value, field);
+    const match = ID_RE.exec(summary.id);
+    const expectedPage = Math.floor((Number(match[2]) - 1) / BROWSE_PAGE_SERIALS) + 1;
+    if (match[1] !== day || expectedPage !== page) {
+      fail(`${field} does not belong on this browse page`);
+    }
+    if (summary.id < previousId ||
+        (summary.id === previousId && summary.version <= previousVersion)) {
+      fail("browse page entries are not in increasing identity and version order");
+    }
+    previousId = summary.id;
+    previousVersion = summary.version;
   }
   return document;
 }

--- a/assets/source-preservation.mjs
+++ b/assets/source-preservation.mjs
@@ -6,7 +6,11 @@ import {
 
 /** Resolve one immutable repository revision to its recorded or preserved copy. */
 export function sourceLocation(entry, availability, repository, commit) {
-  const mapping = entry.preservation.repositories.find(
+  const repositories = entry?.preservation?.repositories;
+  if (!Array.isArray(repositories)) {
+    throw new Error("entry has no canonical source preservation receipt");
+  }
+  const mapping = repositories.find(
     (row) => row.source_repository.toLowerCase() === repository.toLowerCase() &&
       row.commit === commit,
   );

--- a/assets/source-preservation.mjs
+++ b/assets/source-preservation.mjs
@@ -6,18 +6,6 @@ import {
 
 /** Resolve one immutable repository revision to its recorded or preserved copy. */
 export function sourceLocation(entry, availability, repository, commit) {
-  if (!entry.preservation) {
-    return {
-      repository,
-      originalRepository: repository,
-      archiveRepository: null,
-      commit,
-      originalStatus: "unknown",
-      archiveStatus: "unknown",
-      checkedAt: null,
-      useArchive: false,
-    };
-  }
   const mapping = entry.preservation.repositories.find(
     (row) => row.source_repository.toLowerCase() === repository.toLowerCase() &&
       row.commit === commit,

--- a/assets/style.css
+++ b/assets/style.css
@@ -1019,8 +1019,7 @@ pre {
 }
 
 .source-availability.original-missing,
-.source-availability.archive-missing,
-.source-availability.legacy {
+.source-availability.archive-missing {
   border-left-color: #9a6700;
   background: #fff8df;
 }

--- a/scripts/check-published.mjs
+++ b/scripts/check-published.mjs
@@ -11,10 +11,20 @@
  * the check is a comparison rather than new machinery.
  */
 
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
+import { resolve } from "node:path";
 
 import { shippedFiles } from "./build-site.mjs";
-import { validateEntry, validateRecent } from "../assets/security.mjs";
+import {
+  entryRecordUrl,
+  validateBrowseHead,
+  validateBrowsePage,
+  validateBrowseYear,
+  validateEntry,
+  validateRecent,
+  validateVersions,
+  versionsUrl,
+} from "../assets/security.mjs";
 
 const STAMP = /assets\/app\.js\?v=([A-Za-z0-9._-]+)/;
 
@@ -44,40 +54,215 @@ export function publishState(html, expected) {
 }
 
 /**
- * Can the current website contract load what the landing page shows?
+ * Can the current website contract load every active public entry permalink?
  *
- * This deliberately uses the same validators, and now the same document, as
- * the browser. It catches a valid publication whose shape has drifted away
- * from what the UI accepts. It asked about every active entry while there was
- * a document naming them all; there is not one any more, and asking about the
- * page a visitor actually loads is both the check that matters and the only
- * one whose cost does not grow with the registry.
+ * The browser normally reads one bounded surface at a time. Deployment and
+ * published-site health deliberately do the linear whole-public-tree check it
+ * should not make a visitor do: browse head to years to pages, every per-ID
+ * version index, then every active entry. Counts and row equality make that a
+ * coverage proof rather than a sample. `recent.json` is also checked against
+ * each current history head, because it is the landing page's separate exact
+ * projection.
  */
+const PUBLIC_DATA_CONCURRENCY = 8;
+
+async function mapBounded(items, task) {
+  const values = [...items];
+  const results = new Array(values.length);
+  let next = 0;
+  const worker = async () => {
+    while (next < values.length) {
+      const position = next;
+      next += 1;
+      results[position] = await task(values[position], position);
+    }
+  };
+  await Promise.all(
+    Array.from(
+      { length: Math.min(PUBLIC_DATA_CONCURRENCY, values.length) },
+      () => worker(),
+    ),
+  );
+  return results;
+}
+
+async function fetchJson(url, fetcher) {
+  const response = await fetcher(url, { cache: "no-store" });
+  if (!response.ok) throw new Error(`${url} responded ${response.status}`);
+  return response.json();
+}
+
+const PUBLIC_VALIDATORS = {
+  validateBrowseHead,
+  validateBrowsePage,
+  validateBrowseYear,
+  validateEntry,
+  validateRecent,
+  validateVersions,
+};
+
 export async function publicDataState(
   databaseUrl,
   fetcher = fetch,
-  validators = { validateRecent, validateEntry },
+  validators = PUBLIC_VALIDATORS,
 ) {
   const base = new URL(databaseUrl.endsWith("/") ? databaseUrl : `${databaseUrl}/`);
-  const pageUrl = new URL("recent.json", base);
   try {
-    const pageResponse = await fetcher(pageUrl, { cache: "no-store" });
-    if (!pageResponse.ok) {
-      return { healthy: false, reason: `${pageUrl} responded ${pageResponse.status}` };
-    }
-    const recent = validators.validateRecent(await pageResponse.json());
-    await Promise.all(recent.entries.map(async (summary) => {
-      const entryUrl = new URL(summary.path, base);
-      const response = await fetcher(entryUrl, { cache: "no-store" });
-      if (!response.ok) throw new Error(`${entryUrl} responded ${response.status}`);
-      validators.validateEntry(await response.json(), summary);
+    const recent = validators.validateRecent(
+      await fetchJson(new URL("recent.json", base), fetcher),
+    );
+    const browse = validators.validateBrowseHead(
+      await fetchJson(new URL("browse/index.json", base), fetcher),
+    );
+    const years = await mapBounded(browse.years, async (year) => validators.validateBrowseYear(
+      await fetchJson(new URL(`browse/${year.year}.json`, base), fetcher),
+      year,
+    ));
+    const pageTasks = years.flatMap((year) => year.days.flatMap((day) =>
+      Array.from(
+        { length: day.last_page - day.first_page + 1 },
+        (_unused, offset) => ({ day, page: day.first_page + offset }),
+      )));
+    const pages = await mapBounded(pageTasks, async ({ day, page }) => ({
+      day,
+      document: validators.validateBrowsePage(
+        await fetchJson(new URL(`browse/${day.day}/${page}.json`, base), fetcher),
+        day.day,
+        page,
+      ),
     }));
+
+    const byDay = new Map();
+    for (const { day, document } of pages) {
+      const rows = byDay.get(day.day) ?? [];
+      rows.push(...document.entries);
+      byDay.set(day.day, rows);
+    }
+    for (const year of years) {
+      for (const day of year.days) {
+        const rows = byDay.get(day.day) ?? [];
+        if (rows.length !== day.versions || new Set(rows.map((row) => row.id)).size !== day.results) {
+          throw new Error(`browse counts do not equal the rows served for ${day.day}`);
+        }
+      }
+    }
+
+    const summaries = pages.flatMap(({ document }) => document.entries);
+    const identifiers = [...new Set(summaries.map((summary) => summary.id))].sort();
+    if (summaries.length !== browse.versions || identifiers.length !== browse.results) {
+      throw new Error("browse index counts do not equal the complete page traversal");
+    }
+    const paths = new Set(summaries.map((summary) => summary.path));
+    if (paths.size !== summaries.length) throw new Error("browse pages repeat an entry permalink");
+
+    const browsedById = new Map(identifiers.map((id) => [id, []]));
+    for (const summary of summaries) browsedById.get(summary.id).push(summary);
+    const histories = await mapBounded(identifiers, async (id) => {
+      const history = validators.validateVersions(
+        await fetchJson(versionsUrl(id, base), fetcher),
+        id,
+      );
+      const browsed = browsedById.get(id);
+      const summariesEqual = history.entries.length === browsed.length &&
+        history.entries.every((row, position) => {
+          const other = browsed[position];
+          return row.id === other.id && row.version === other.version &&
+            row.title === other.title && row.status === other.status && row.path === other.path;
+        });
+      if (!summariesEqual) {
+        throw new Error(`version index for ${id} does not equal its browse history`);
+      }
+      return history;
+    });
+
+    const historiesById = new Map(histories.map((history) => [history.id, history.entries]));
+    for (const summary of recent.entries) {
+      const history = historiesById.get(summary.id);
+      const current = history?.at(-1);
+      if (!current || summary.version !== current.version || summary.title !== current.title ||
+          summary.status !== current.status || summary.path !== current.path ||
+          summary.versions !== history.length) {
+        throw new Error(`recent row for ${summary.id} does not equal its current version history`);
+      }
+    }
+
+    await mapBounded(histories.flatMap((history) => history.entries), async (summary) => {
+      validators.validateEntry(
+        await fetchJson(entryRecordUrl(summary, base), fetcher),
+        summary,
+      );
+    });
     return {
       healthy: true,
-      reason: `the website contract accepts all ${recent.entries.length} entries the landing page shows`,
+      reason: `the website contract accepts all ${browse.versions} active entry versions ` +
+        `across ${browse.results} results`,
     };
   } catch (error) {
     return { healthy: false, reason: `public registry data is incompatible: ${error.message}` };
+  }
+}
+
+/**
+ * Does a canonical Database checkout contain only the entry contract Web ships?
+ *
+ * Public CI cannot clone the private canonical repository, so its mandatory
+ * gate is `publicDataState`. This companion is the local producer-branch gate:
+ * no alternate schema document, and every historical canonical entry through
+ * the same validator the deployed browser uses.
+ */
+export async function canonicalDataState(databaseRoot, validator = validateEntry) {
+  const root = resolve(databaseRoot);
+  try {
+    const rootNames = await readdir(root);
+    const schemas = rootNames.filter((name) => /^schema-v[1-9][0-9]*\.json$/.test(name)).sort();
+    if (JSON.stringify(schemas) !== JSON.stringify(["schema-v2.json"])) {
+      throw new Error(`canonical Database entry schemas are ${schemas.join(", ") || "missing"}`);
+    }
+    const schema = JSON.parse(await readFile(resolve(root, "schema-v2.json"), "utf8"));
+    const preservation = schema?.properties?.preservation;
+    const mapping = preservation?.properties?.repositories?.items;
+    const exactNames = (value, expected) => Array.isArray(value) &&
+      value.length === expected.length && expected.every((name) => value.includes(name));
+    if (schema?.properties?.schema_version?.const !== 2 ||
+        !schema?.required?.includes("preservation") || preservation?.type !== "object" ||
+        preservation?.additionalProperties !== false ||
+        !exactNames(preservation?.required, [
+          "archive_owner", "archived_at", "receipt_sha256", "repositories",
+        ]) || preservation?.properties?.archive_owner?.const !== "PalomarArchive" ||
+        preservation?.properties?.repositories?.type !== "array" ||
+        preservation?.properties?.repositories?.minItems !== 1 || mapping?.type !== "object" ||
+        mapping?.additionalProperties !== false || !exactNames(mapping?.required, [
+          "source_repository", "commit", "fork_repository", "ref",
+        ]) || !exactNames(Object.keys(mapping?.properties ?? {}), [
+          "source_repository", "commit", "fork_repository", "ref",
+        ])) {
+      throw new Error("schema-v2.json does not require the preservation-backed entry contract");
+    }
+    const entryRoot = resolve(root, "entries");
+    const entries = (await readdir(entryRoot)).filter((name) => name.endsWith(".json")).sort();
+    if (!entries.length) throw new Error("canonical Database contains no entry to exercise");
+    await mapBounded(entries, async (name) => {
+      const record = JSON.parse(await readFile(resolve(entryRoot, name), "utf8"));
+      if (record.schema_version !== 2 || !record.preservation) {
+        throw new Error(`${name} is not a preservation-backed schema-v2 entry`);
+      }
+      const expectedName = `${record.id}-v${record.version}.json`;
+      if (name !== expectedName) throw new Error(`${name} does not match its entry identity`);
+      validator(record, {
+        id: record.id,
+        version: record.version,
+        title: record.title,
+        status: record.status,
+        path: `entries/${name}`,
+        published_at: record.registered_at,
+      });
+    });
+    return {
+      healthy: true,
+      reason: `the website contract accepts all ${entries.length} canonical historical entries`,
+    };
+  } catch (error) {
+    return { healthy: false, reason: `canonical Database is incompatible: ${error.message}` };
   }
 }
 
@@ -147,6 +332,12 @@ async function main(argv) {
   const url = options.get("url");
   const expected = options.get("expect");
   const data = options.get("data");
+  const canonical = options.get("canonical");
+  if (canonical && !data && !url && !expected) {
+    const state = await canonicalDataState(canonical);
+    console.log(`${canonical}: ${state.reason}`);
+    return state.healthy ? 0 : 1;
+  }
   if (data && !url && !expected) {
     const state = await publicDataState(data);
     console.log(`${data}: ${state.reason}`);
@@ -160,7 +351,7 @@ async function main(argv) {
   if (!url || !expected) {
     console.error(
       "usage: check-published.mjs --url <site> --expect <commit> | --data <registry-data>"
-        + " | --links",
+        + " | --canonical <Database checkout> | --links",
     );
     return 2;
   }

--- a/scripts/check-published.mjs
+++ b/scripts/check-published.mjs
@@ -11,8 +11,7 @@
  * the check is a comparison rather than new machinery.
  */
 
-import { readFile, readdir } from "node:fs/promises";
-import { resolve } from "node:path";
+import { readFile } from "node:fs/promises";
 
 import { shippedFiles } from "./build-site.mjs";
 import {
@@ -59,12 +58,18 @@ export function publishState(html, expected) {
  * The browser normally reads one bounded surface at a time. Deployment and
  * published-site health deliberately do the linear whole-public-tree check it
  * should not make a visitor do: browse head to years to pages, every per-ID
- * version index, then every active entry. Counts and row equality make that a
- * coverage proof rather than a sample. `recent.json` is also checked against
- * each current history head, because it is the landing page's separate exact
- * projection.
+ * version index, then every active entry. Counts and row equality reconcile
+ * every row the producer advertises; they are not an independent proof that
+ * the producer omitted nothing. `recent.json` is also checked against each
+ * current history head and entry, because it is the landing page's separate
+ * exact projection.
  */
 const PUBLIC_DATA_CONCURRENCY = 8;
+const PUBLIC_REQUEST_POLICY = Object.freeze({
+  attempts: 3,
+  backoffMs: 200,
+  timeoutMs: 5_000,
+});
 
 async function mapBounded(items, task) {
   const values = [...items];
@@ -86,10 +91,41 @@ async function mapBounded(items, task) {
   return results;
 }
 
-async function fetchJson(url, fetcher) {
-  const response = await fetcher(url, { cache: "no-store" });
-  if (!response.ok) throw new Error(`${url} responded ${response.status}`);
-  return response.json();
+const wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+async function fetchJson(url, fetcher, policy) {
+  let lastError;
+  for (let attempt = 1; attempt <= policy.attempts; attempt += 1) {
+    const controller = new AbortController();
+    let timer;
+    const timeout = new Promise((_, reject) => {
+      timer = setTimeout(() => {
+        const error = new Error(`${url} timed out after ${policy.timeoutMs}ms`);
+        controller.abort(error);
+        reject(error);
+      }, policy.timeoutMs);
+    });
+    try {
+      const response = await Promise.race([
+        fetcher(url, { cache: "no-store", signal: controller.signal }),
+        timeout,
+      ]);
+      if (!response.ok) {
+        const error = new Error(`${url} responded ${response.status}`);
+        error.retryable = response.status === 408 || response.status === 425 ||
+          response.status === 429 || response.status >= 500;
+        throw error;
+      }
+      return await Promise.race([response.json(), timeout]);
+    } catch (error) {
+      lastError = error;
+      if (error.retryable === false || attempt === policy.attempts) throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+    await wait(policy.backoffMs * (2 ** (attempt - 1)));
+  }
+  throw lastError;
 }
 
 const PUBLIC_VALIDATORS = {
@@ -105,17 +141,19 @@ export async function publicDataState(
   databaseUrl,
   fetcher = fetch,
   validators = PUBLIC_VALIDATORS,
+  requestPolicy = PUBLIC_REQUEST_POLICY,
 ) {
   const base = new URL(databaseUrl.endsWith("/") ? databaseUrl : `${databaseUrl}/`);
+  const policy = { ...PUBLIC_REQUEST_POLICY, ...requestPolicy };
   try {
     const recent = validators.validateRecent(
-      await fetchJson(new URL("recent.json", base), fetcher),
+      await fetchJson(new URL("recent.json", base), fetcher, policy),
     );
     const browse = validators.validateBrowseHead(
-      await fetchJson(new URL("browse/index.json", base), fetcher),
+      await fetchJson(new URL("browse/index.json", base), fetcher, policy),
     );
     const years = await mapBounded(browse.years, async (year) => validators.validateBrowseYear(
-      await fetchJson(new URL(`browse/${year.year}.json`, base), fetcher),
+      await fetchJson(new URL(`browse/${year.year}.json`, base), fetcher, policy),
       year,
     ));
     const pageTasks = years.flatMap((year) => year.days.flatMap((day) =>
@@ -126,7 +164,7 @@ export async function publicDataState(
     const pages = await mapBounded(pageTasks, async ({ day, page }) => ({
       day,
       document: validators.validateBrowsePage(
-        await fetchJson(new URL(`browse/${day.day}/${page}.json`, base), fetcher),
+        await fetchJson(new URL(`browse/${day.day}/${page}.json`, base), fetcher, policy),
         day.day,
         page,
       ),
@@ -159,7 +197,7 @@ export async function publicDataState(
     for (const summary of summaries) browsedById.get(summary.id).push(summary);
     const histories = await mapBounded(identifiers, async (id) => {
       const history = validators.validateVersions(
-        await fetchJson(versionsUrl(id, base), fetcher),
+        await fetchJson(versionsUrl(id, base), fetcher, policy),
         id,
       );
       const browsed = browsedById.get(id);
@@ -175,6 +213,15 @@ export async function publicDataState(
       return history;
     });
 
+    const fetchedEntries = await mapBounded(
+      histories.flatMap((history) => history.entries),
+      async (summary) => {
+        const entry = await fetchJson(entryRecordUrl(summary, base), fetcher, policy);
+        validators.validateEntry(entry, summary);
+        return [summary.path, entry];
+      },
+    );
+    const entriesByPath = new Map(fetchedEntries);
     const historiesById = new Map(histories.map((history) => [history.id, history.entries]));
     for (const summary of recent.entries) {
       const history = historiesById.get(summary.id);
@@ -184,14 +231,11 @@ export async function publicDataState(
           summary.versions !== history.length) {
         throw new Error(`recent row for ${summary.id} does not equal its current version history`);
       }
+      const entry = entriesByPath.get(summary.path);
+      if (!entry || summary.published_at !== entry.registered_at) {
+        throw new Error(`recent row for ${summary.id} does not match its entry registered_at`);
+      }
     }
-
-    await mapBounded(histories.flatMap((history) => history.entries), async (summary) => {
-      validators.validateEntry(
-        await fetchJson(entryRecordUrl(summary, base), fetcher),
-        summary,
-      );
-    });
     return {
       healthy: true,
       reason: `the website contract accepts all ${browse.versions} active entry versions ` +
@@ -199,70 +243,6 @@ export async function publicDataState(
     };
   } catch (error) {
     return { healthy: false, reason: `public registry data is incompatible: ${error.message}` };
-  }
-}
-
-/**
- * Does a canonical Database checkout contain only the entry contract Web ships?
- *
- * Public CI cannot clone the private canonical repository, so its mandatory
- * gate is `publicDataState`. This companion is the local producer-branch gate:
- * no alternate schema document, and every historical canonical entry through
- * the same validator the deployed browser uses.
- */
-export async function canonicalDataState(databaseRoot, validator = validateEntry) {
-  const root = resolve(databaseRoot);
-  try {
-    const rootNames = await readdir(root);
-    const schemas = rootNames.filter((name) => /^schema-v[1-9][0-9]*\.json$/.test(name)).sort();
-    if (JSON.stringify(schemas) !== JSON.stringify(["schema-v2.json"])) {
-      throw new Error(`canonical Database entry schemas are ${schemas.join(", ") || "missing"}`);
-    }
-    const schema = JSON.parse(await readFile(resolve(root, "schema-v2.json"), "utf8"));
-    const preservation = schema?.properties?.preservation;
-    const mapping = preservation?.properties?.repositories?.items;
-    const exactNames = (value, expected) => Array.isArray(value) &&
-      value.length === expected.length && expected.every((name) => value.includes(name));
-    if (schema?.properties?.schema_version?.const !== 2 ||
-        !schema?.required?.includes("preservation") || preservation?.type !== "object" ||
-        preservation?.additionalProperties !== false ||
-        !exactNames(preservation?.required, [
-          "archive_owner", "archived_at", "receipt_sha256", "repositories",
-        ]) || preservation?.properties?.archive_owner?.const !== "PalomarArchive" ||
-        preservation?.properties?.repositories?.type !== "array" ||
-        preservation?.properties?.repositories?.minItems !== 1 || mapping?.type !== "object" ||
-        mapping?.additionalProperties !== false || !exactNames(mapping?.required, [
-          "source_repository", "commit", "fork_repository", "ref",
-        ]) || !exactNames(Object.keys(mapping?.properties ?? {}), [
-          "source_repository", "commit", "fork_repository", "ref",
-        ])) {
-      throw new Error("schema-v2.json does not require the preservation-backed entry contract");
-    }
-    const entryRoot = resolve(root, "entries");
-    const entries = (await readdir(entryRoot)).filter((name) => name.endsWith(".json")).sort();
-    if (!entries.length) throw new Error("canonical Database contains no entry to exercise");
-    await mapBounded(entries, async (name) => {
-      const record = JSON.parse(await readFile(resolve(entryRoot, name), "utf8"));
-      if (record.schema_version !== 2 || !record.preservation) {
-        throw new Error(`${name} is not a preservation-backed schema-v2 entry`);
-      }
-      const expectedName = `${record.id}-v${record.version}.json`;
-      if (name !== expectedName) throw new Error(`${name} does not match its entry identity`);
-      validator(record, {
-        id: record.id,
-        version: record.version,
-        title: record.title,
-        status: record.status,
-        path: `entries/${name}`,
-        published_at: record.registered_at,
-      });
-    });
-    return {
-      healthy: true,
-      reason: `the website contract accepts all ${entries.length} canonical historical entries`,
-    };
-  } catch (error) {
-    return { healthy: false, reason: `canonical Database is incompatible: ${error.message}` };
   }
 }
 
@@ -332,12 +312,6 @@ async function main(argv) {
   const url = options.get("url");
   const expected = options.get("expect");
   const data = options.get("data");
-  const canonical = options.get("canonical");
-  if (canonical && !data && !url && !expected) {
-    const state = await canonicalDataState(canonical);
-    console.log(`${canonical}: ${state.reason}`);
-    return state.healthy ? 0 : 1;
-  }
   if (data && !url && !expected) {
     const state = await publicDataState(data);
     console.log(`${data}: ${state.reason}`);
@@ -351,7 +325,7 @@ async function main(argv) {
   if (!url || !expected) {
     console.error(
       "usage: check-published.mjs --url <site> --expect <commit> | --data <registry-data>"
-        + " | --canonical <Database checkout> | --links",
+        + " | --links",
     );
     return 2;
   }

--- a/tests/check-published.test.js
+++ b/tests/check-published.test.js
@@ -47,11 +47,45 @@ test("the stamp is read from the asset URL the build actually writes", async () 
   }
 });
 
-test("live-data health fetches and validates every entry the landing page shows", async () => {
+test("live-data health traverses browse and history to validate every public permalink", async () => {
   const calls = [];
+  const first = {
+    id: "PALOMAR-2026-08-08-000001",
+    version: 1,
+    title: "One",
+    status: "accepted",
+    path: "entries/PALOMAR-2026-08-08-000001-v1.json",
+  };
+  const second = {
+    ...first,
+    version: 2,
+    title: "Two",
+    path: "entries/PALOMAR-2026-08-08-000001-v2.json",
+  };
   const responses = new Map([
-    ["https://data.example/recent.json", { entries: [{ path: "entries/one.json" }] }],
-    ["https://data.example/entries/one.json", { id: "one" }],
+    ["https://data.example/recent.json", { entries: [{ ...second, versions: 2 }] }],
+    ["https://data.example/browse/index.json", {
+      results: 1,
+      versions: 2,
+      years: [{ year: "2026", days: 1, results: 1, versions: 2 }],
+    }],
+    ["https://data.example/browse/2026.json", {
+      year: "2026",
+      days: [{
+        day: "2026-08-08",
+        first_page: 1,
+        last_page: 1,
+        results: 1,
+        versions: 2,
+      }],
+    }],
+    ["https://data.example/browse/2026-08-08/1.json", { entries: [first, second] }],
+    ["https://data.example/versions/PALOMAR-2026-08-08-000001.json", {
+      id: first.id,
+      entries: [first, second],
+    }],
+    ["https://data.example/entries/PALOMAR-2026-08-08-000001-v1.json", { id: "one-v1" }],
+    ["https://data.example/entries/PALOMAR-2026-08-08-000001-v2.json", { id: "one-v2" }],
   ]);
   const fetcher = async (url) => {
     calls.push(String(url));
@@ -66,6 +100,22 @@ test("live-data health fetches and validates every entry the landing page shows"
       validated.push("recent");
       return page;
     },
+    validateBrowseHead(page) {
+      validated.push("browse-head");
+      return page;
+    },
+    validateBrowseYear(page, expected) {
+      validated.push(`year:${expected.year}`);
+      return page;
+    },
+    validateBrowsePage(page, day, number) {
+      validated.push(`page:${day}:${number}`);
+      return page;
+    },
+    validateVersions(page, id) {
+      validated.push(`versions:${id}`);
+      return page;
+    },
     validateEntry(value, summary) {
       validated.push(`${value.id}:${summary.path}`);
     },
@@ -74,9 +124,73 @@ test("live-data health fetches and validates every entry the landing page shows"
   assert.equal(state.healthy, true);
   assert.deepEqual(calls, [
     "https://data.example/recent.json",
-    "https://data.example/entries/one.json",
+    "https://data.example/browse/index.json",
+    "https://data.example/browse/2026.json",
+    "https://data.example/browse/2026-08-08/1.json",
+    "https://data.example/versions/PALOMAR-2026-08-08-000001.json",
+    "https://data.example/entries/PALOMAR-2026-08-08-000001-v1.json",
+    "https://data.example/entries/PALOMAR-2026-08-08-000001-v2.json",
   ]);
-  assert.deepEqual(validated, ["recent", "one:entries/one.json"]);
+  assert.deepEqual(validated, [
+    "recent",
+    "browse-head",
+    "year:2026",
+    "page:2026-08-08:1",
+    `versions:${first.id}`,
+    `one-v1:${first.path}`,
+    `one-v2:${second.path}`,
+  ]);
+  assert.match(state.reason, /all 2 active entry versions across 1 results/);
+});
+
+test("live-data health fails closed when a version index omits or rewrites browse history", async () => {
+  const id = "PALOMAR-2026-08-08-000001";
+  const browseRow = {
+    id,
+    version: 1,
+    title: "Browse title",
+    status: "accepted",
+    path: `entries/${id}-v1.json`,
+  };
+  const responses = new Map([
+    ["https://data.example/recent.json", { entries: [] }],
+    ["https://data.example/browse/index.json", {
+      results: 1,
+      versions: 1,
+      years: [{ year: "2026", days: 1, results: 1, versions: 1 }],
+    }],
+    ["https://data.example/browse/2026.json", {
+      year: "2026",
+      days: [{
+        day: "2026-08-08",
+        first_page: 1,
+        last_page: 1,
+        results: 1,
+        versions: 1,
+      }],
+    }],
+    ["https://data.example/browse/2026-08-08/1.json", { entries: [browseRow] }],
+    ["https://data.example/versions/PALOMAR-2026-08-08-000001.json", {
+      id,
+      entries: [{ ...browseRow, title: "Rewritten title" }],
+    }],
+  ]);
+  const identityValidators = {
+    validateRecent: (value) => value,
+    validateBrowseHead: (value) => value,
+    validateBrowseYear: (value) => value,
+    validateBrowsePage: (value) => value,
+    validateVersions: (value) => value,
+    validateEntry() { assert.fail("an unreconciled permalink must not be accepted"); },
+  };
+  const state = await publicDataState(
+    "https://data.example",
+    async (url) => ({ ok: true, async json() { return responses.get(String(url)); } }),
+    identityValidators,
+  );
+
+  assert.equal(state.healthy, false);
+  assert.match(state.reason, /version index .* does not equal its browse history/);
 });
 
 test("live-data health fails on the same contract error a visitor would see", async () => {

--- a/tests/check-published.test.js
+++ b/tests/check-published.test.js
@@ -11,6 +11,69 @@ const sha = "b500f02dec58268ea22de28332f63136dac092d9";
 const page = (version) =>
   `<html><head><script type="module" src="assets/app.js?v=${version}"></script></head></html>`;
 
+const registryValidators = {
+  validateRecent: (value) => value,
+  validateBrowseHead: (value) => value,
+  validateBrowseYear: (value) => value,
+  validateBrowsePage: (value) => value,
+  validateVersions: (value) => value,
+  validateEntry() {},
+};
+
+function oneEntryRegistry() {
+  const id = "PALOMAR-2026-08-08-000001";
+  const row = {
+    id,
+    version: 1,
+    title: "One",
+    status: "accepted",
+    path: `entries/${id}-v1.json`,
+  };
+  const registeredAt = "2026-08-08T12:00:00Z";
+  const recent = { ...row, versions: 1, published_at: registeredAt };
+  const head = {
+    results: 1,
+    versions: 1,
+    years: [{ year: "2026", days: 1, results: 1, versions: 1 }],
+  };
+  const year = {
+    year: "2026",
+    days: [{
+      day: "2026-08-08",
+      first_page: 1,
+      last_page: 1,
+      results: 1,
+      versions: 1,
+    }],
+  };
+  const browsePage = { entries: [row] };
+  const history = { id, entries: [row] };
+  const entry = { id, registered_at: registeredAt };
+  return {
+    entry,
+    head,
+    history,
+    page: browsePage,
+    recent,
+    row,
+    year,
+    responses: new Map([
+      ["https://data.example/recent.json", { entries: [recent] }],
+      ["https://data.example/browse/index.json", head],
+      ["https://data.example/browse/2026.json", year],
+      ["https://data.example/browse/2026-08-08/1.json", browsePage],
+      [`https://data.example/versions/${id}.json`, history],
+      [`https://data.example/entries/${id}-v1.json`, entry],
+    ]),
+  };
+}
+
+const responseFrom = (responses) => async (url) => ({
+  ok: true,
+  status: 200,
+  async json() { return responses.get(String(url)); },
+});
+
 test("a page built from the expected commit is fresh", () => {
   const state = publishState(page(sha), sha);
   assert.equal(state.fresh, true);
@@ -49,6 +112,7 @@ test("the stamp is read from the asset URL the build actually writes", async () 
 
 test("live-data health traverses browse and history to validate every public permalink", async () => {
   const calls = [];
+  const registeredAt = "2026-08-08T12:00:00Z";
   const first = {
     id: "PALOMAR-2026-08-08-000001",
     version: 1,
@@ -63,7 +127,9 @@ test("live-data health traverses browse and history to validate every public per
     path: "entries/PALOMAR-2026-08-08-000001-v2.json",
   };
   const responses = new Map([
-    ["https://data.example/recent.json", { entries: [{ ...second, versions: 2 }] }],
+    ["https://data.example/recent.json", {
+      entries: [{ ...second, versions: 2, published_at: registeredAt }],
+    }],
     ["https://data.example/browse/index.json", {
       results: 1,
       versions: 2,
@@ -84,8 +150,14 @@ test("live-data health traverses browse and history to validate every public per
       id: first.id,
       entries: [first, second],
     }],
-    ["https://data.example/entries/PALOMAR-2026-08-08-000001-v1.json", { id: "one-v1" }],
-    ["https://data.example/entries/PALOMAR-2026-08-08-000001-v2.json", { id: "one-v2" }],
+    ["https://data.example/entries/PALOMAR-2026-08-08-000001-v1.json", {
+      id: "one-v1",
+      registered_at: "2026-08-08T11:00:00Z",
+    }],
+    ["https://data.example/entries/PALOMAR-2026-08-08-000001-v2.json", {
+      id: "one-v2",
+      registered_at: registeredAt,
+    }],
   ]);
   const fetcher = async (url) => {
     calls.push(String(url));
@@ -202,6 +274,136 @@ test("live-data health fails on the same contract error a visitor would see", as
 
   assert.equal(state.healthy, false);
   assert.match(state.reason, /entry\.review\.scores must be an object/);
+});
+
+test("live-data health retries a transient request and recovers", async () => {
+  const fixture = oneEntryRegistry();
+  let recentAttempts = 0;
+  const fetcher = async (url) => {
+    if (String(url).endsWith("/recent.json") && recentAttempts++ === 0) {
+      return { ok: false, status: 503 };
+    }
+    return responseFrom(fixture.responses)(url);
+  };
+  const state = await publicDataState(
+    "https://data.example",
+    fetcher,
+    registryValidators,
+    { attempts: 2, backoffMs: 0, timeoutMs: 100 },
+  );
+
+  assert.equal(state.healthy, true, state.reason);
+  assert.equal(recentAttempts, 2);
+});
+
+test("live-data health does not retry a permanent response", async () => {
+  let attempts = 0;
+  const state = await publicDataState(
+    "https://data.example",
+    async () => {
+      attempts += 1;
+      return { ok: false, status: 404 };
+    },
+    registryValidators,
+    { attempts: 3, backoffMs: 0, timeoutMs: 100 },
+  );
+
+  assert.equal(state.healthy, false);
+  assert.equal(attempts, 1);
+  assert.match(state.reason, /recent\.json responded 404/);
+});
+
+test("live-data health times out, aborts, and bounds every retry", async () => {
+  const signals = [];
+  const state = await publicDataState(
+    "https://data.example",
+    (_url, { signal }) => new Promise((_resolve, reject) => {
+      signals.push(signal);
+      signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+    }),
+    registryValidators,
+    { attempts: 2, backoffMs: 0, timeoutMs: 5 },
+  );
+
+  assert.equal(state.healthy, false);
+  assert.equal(signals.length, 2);
+  assert.ok(signals.every((signal) => signal.aborted));
+  assert.match(state.reason, /recent\.json timed out after 5ms/);
+});
+
+test("live-data health rejects day and global count mismatches", async () => {
+  const dayFixture = oneEntryRegistry();
+  dayFixture.year.days[0].versions = 2;
+  let state = await publicDataState(
+    "https://data.example",
+    responseFrom(dayFixture.responses),
+    registryValidators,
+  );
+  assert.equal(state.healthy, false);
+  assert.match(state.reason, /browse counts do not equal the rows served/);
+
+  const globalFixture = oneEntryRegistry();
+  globalFixture.head.versions = 2;
+  state = await publicDataState(
+    "https://data.example",
+    responseFrom(globalFixture.responses),
+    registryValidators,
+  );
+  assert.equal(state.healthy, false);
+  assert.match(state.reason, /index counts do not equal the complete page traversal/);
+});
+
+test("live-data health rejects duplicate permalinks before fetching histories", async () => {
+  const fixture = oneEntryRegistry();
+  const duplicate = {
+    ...fixture.row,
+    id: "PALOMAR-2026-08-08-000002",
+  };
+  fixture.page.entries.push(duplicate);
+  fixture.head.results = 2;
+  fixture.head.versions = 2;
+  fixture.year.days[0].results = 2;
+  fixture.year.days[0].versions = 2;
+  const state = await publicDataState(
+    "https://data.example",
+    responseFrom(fixture.responses),
+    registryValidators,
+  );
+
+  assert.equal(state.healthy, false);
+  assert.match(state.reason, /browse pages repeat an entry permalink/);
+});
+
+test("live-data health rejects a recent row absent from advertised history", async () => {
+  const fixture = oneEntryRegistry();
+  fixture.recent.id = "PALOMAR-2026-08-08-000002";
+  fixture.recent.path = "entries/PALOMAR-2026-08-08-000002-v1.json";
+  const state = await publicDataState(
+    "https://data.example",
+    responseFrom(fixture.responses),
+    registryValidators,
+  );
+
+  assert.equal(state.healthy, false);
+  assert.match(state.reason, /recent row .* does not equal its current version history/);
+});
+
+test("live-data health checks recent publication time against the already fetched entry", async () => {
+  const fixture = oneEntryRegistry();
+  fixture.recent.published_at = "2026-08-08T13:00:00Z";
+  let entryFetches = 0;
+  const state = await publicDataState(
+    "https://data.example",
+    async (url) => {
+      if (String(url) === `https://data.example/${fixture.row.path}`) entryFetches += 1;
+      return responseFrom(fixture.responses)(url);
+    },
+    registryValidators,
+  );
+
+  assert.equal(state.healthy, false);
+  assert.equal(entryFetches, 1);
+  assert.match(state.reason, /does not match its entry registered_at/);
 });
 
 test("every registry document the site links to is one the registry still serves", async () => {

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -183,20 +183,11 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
 def recent_row(record: dict, versions: int) -> dict:
     """Project exactly the landing-card contract emitted by PalomarDatabase."""
     source = record["source"]
-    preservation = record.get("preservation")
-    mapping = (
-        next(
-            (
-                item
-                for item in preservation["repositories"]
-                if item["source_repository"].casefold()
-                == source["repository"].casefold()
-                and item["commit"] == source["commit"]
-            ),
-            None,
-        )
-        if preservation
-        else None
+    mapping = next(
+        item
+        for item in record["preservation"]["repositories"]
+        if item["source_repository"].casefold() == source["repository"].casefold()
+        and item["commit"] == source["commit"]
     )
     return {
         "id": record["id"],
@@ -217,12 +208,14 @@ def recent_row(record: dict, versions: int) -> dict:
             "project_path": source.get("project_path"),
         },
         "preservation": {
-            "repositories": [{
-                "source_repository": mapping["source_repository"],
-                "commit": mapping["commit"],
-                "fork_repository": mapping["fork_repository"],
-            }]
-        } if mapping else None,
+            "repositories": [
+                {
+                    "source_repository": mapping["source_repository"],
+                    "commit": mapping["commit"],
+                    "fork_repository": mapping["fork_repository"],
+                }
+            ]
+        },
         "published_at": record["registered_at"],
         "versions": versions,
     }

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -184,11 +184,19 @@ def recent_row(record: dict, versions: int) -> dict:
     """Project exactly the landing-card contract emitted by PalomarDatabase."""
     source = record["source"]
     mapping = next(
-        item
-        for item in record["preservation"]["repositories"]
-        if item["source_repository"].casefold() == source["repository"].casefold()
-        and item["commit"] == source["commit"]
+        (
+            item
+            for item in record["preservation"]["repositories"]
+            if item["source_repository"].casefold() == source["repository"].casefold()
+            and item["commit"] == source["commit"]
+        ),
+        None,
     )
+    if mapping is None:
+        raise ValueError(
+            "browser fixture has no preservation mapping for "
+            f"{source['repository']}@{source['commit']}"
+        )
     return {
         "id": record["id"],
         "version": record["version"],

--- a/tests/fixtures/public-browse/index.json
+++ b/tests/fixtures/public-browse/index.json
@@ -1,0 +1,13 @@
+{
+  "results": 1,
+  "schema_version": 1,
+  "versions": 1,
+  "years": [
+    {
+      "days": 1,
+      "results": 1,
+      "versions": 1,
+      "year": "2026"
+    }
+  ]
+}

--- a/tests/fixtures/public-browse/page.json
+++ b/tests/fixtures/public-browse/page.json
@@ -1,0 +1,14 @@
+{
+  "day": "2026-08-08",
+  "entries": [
+    {
+      "id": "PALOMAR-2026-08-08-000001",
+      "path": "entries/PALOMAR-2026-08-08-000001-v1.json",
+      "status": "accepted",
+      "title": "kim-em/erdos-unit-distance-comparator",
+      "version": 1
+    }
+  ],
+  "page": 1,
+  "schema_version": 1
+}

--- a/tests/fixtures/public-browse/year.json
+++ b/tests/fixtures/public-browse/year.json
@@ -1,0 +1,13 @@
+{
+  "days": [
+    {
+      "day": "2026-08-08",
+      "first_page": 1,
+      "last_page": 1,
+      "results": 1,
+      "versions": 1
+    }
+  ],
+  "schema_version": 1,
+  "year": "2026"
+}

--- a/tests/registry-fixture.mjs
+++ b/tests/registry-fixture.mjs
@@ -25,7 +25,7 @@ export function secondVersion(overrides = {}) {
 
 export function recentRow(overrides = {}) {
   const record = entry();
-  const sourceMapping = record.preservation?.repositories.find(
+  const sourceMapping = record.preservation.repositories.find(
     (mapping) =>
       mapping.source_repository.toLowerCase() === record.source.repository.toLowerCase() &&
       mapping.commit === record.source.commit,
@@ -46,15 +46,13 @@ export function recentRow(overrides = {}) {
       commit: record.source.commit,
       project_path: record.source.project_path ?? null,
     },
-    preservation: sourceMapping
-      ? {
-          repositories: [{
-            source_repository: sourceMapping.source_repository,
-            commit: sourceMapping.commit,
-            fork_repository: sourceMapping.fork_repository,
-          }],
-        }
-      : null,
+    preservation: {
+      repositories: [{
+        source_repository: sourceMapping.source_repository,
+        commit: sourceMapping.commit,
+        fork_repository: sourceMapping.fork_repository,
+      }],
+    },
     published_at: record.registered_at,
     versions: 1,
     ...overrides,

--- a/tests/rendering.test.js
+++ b/tests/rendering.test.js
@@ -92,6 +92,10 @@ test("source URL is always the immutable canonical GitHub file", () => {
     `https://github.com/PalomarArchive/challenge/blob/${"1".repeat(40)}/Challenge.lean`,
   );
 
+  const unpreserved = entry();
+  delete unpreserved.preservation;
+  assert.throws(() => challengeSourceUrl(unpreserved), /no canonical source preservation metadata/);
+
   const traversal = entry();
   traversal.formalization.challenge_path = "../Task.lean";
   assert.throws(() => challengeSourceUrl(traversal), /canonical/);

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -203,11 +203,15 @@ test("recent is one exact complete projection, not a legacy summary shape", () =
     (page) => { page.entries[0].registered_at = page.entries[0].published_at; },
     (page) => { delete page.entries[0].source.project_path; },
     (page) => { page.entries[0].authors[0].github = "somebody"; },
+    (page) => { page.entries[0].preservation = null; },
     (page) => { page.entries[0].preservation.repositories = []; },
   ]) {
     const page = recent();
     mutate(page);
-    assert.throws(() => validateRecent(page), /invalid shape|must contain one source mapping/);
+    assert.throws(
+      () => validateRecent(page),
+      /invalid shape|preservation must be an object|must contain one source mapping/,
+    );
   }
 });
 
@@ -409,12 +413,6 @@ test("preservation must cover every immutable source", () => {
   const moving = entry();
   moving.preservation.repositories[0].ref = "refs/tags/latest";
   assert.throws(() => validateEntry(moving, summary()), /ref is not canonical/);
-});
-
-test("legacy schema v1 records remain readable without an archive mapping", () => {
-  const legacy = entry({ schema_version: 1 });
-  delete legacy.preservation;
-  assert.equal(validateEntry(legacy, summary()).schema_version, 1);
 });
 
 test("availability applies the inclusive freshness boundaries to each endpoint", () => {
@@ -620,7 +618,18 @@ test("withdrawn palomar-indexed provenance is rejected", () => {
 });
 
 test("entry schema, acceptance state, verdict, and selected identity fail closed", () => {
-  assert.throws(() => validateEntry(entry({ schema_version: 99 }), summary()), /unsupported entry/);
+  const unsupportedSchemas = [
+    entry({ schema_version: 1 }),
+    entry({ schema_version: 3 }),
+    entry({ schema_version: true }),
+    entry({ schema_version: "2" }),
+  ];
+  const missingSchema = entry();
+  delete missingSchema.schema_version;
+  unsupportedSchemas.push(missingSchema);
+  for (const record of unsupportedSchemas) {
+    assert.throws(() => validateEntry(record, summary()), /unsupported entry schema_version/);
+  }
   assert.throws(() => validateEntry(entry({ status: "draft" }), summary()), /not accepted/);
   const rejected = entry();
   rejected.review.verdict = "reject";

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -20,6 +20,7 @@ import {
 import {
   AVAILABILITY_MAX_AGE_MS,
   AVAILABILITY_MAX_CLOCK_SKEW_MS,
+  BROWSE_SCHEMA_VERSION,
   DEFAULT_DATABASE,
   DEFAULT_AVAILABILITY,
   ENTRY_SCHEMA_VERSION,
@@ -28,6 +29,8 @@ import {
   availabilityRecord,
   RESULT_ORIGIN_LABELS,
   REPOSITORY_ROLE_LABELS,
+  RECENT_SCHEMA_VERSION,
+  VERSIONS_SCHEMA_VERSION,
   entryRecordUrl,
   isLoopbackHostname,
   pinnedSourceDirectoryUrl,
@@ -42,6 +45,9 @@ import {
   tombstoneUrl,
   validateEntry,
   validateAvailability,
+  validateBrowseHead,
+  validateBrowsePage,
+  validateBrowseYear,
   validateRecent,
   validateTombstone,
   validateVersions,
@@ -854,13 +860,39 @@ test("every provenance value the schema allows has an explicit label", async () 
   }
 });
 
-test("the site validates exactly the schema version the database publishes", async () => {
+test("the site requires the Database entry version and exact preservation shape", async () => {
   const checkout = process.env.PALOMAR_DATABASE_CHECKOUT
     ?? new URL("../../PalomarDatabase/", import.meta.url).pathname;
   const schema = JSON.parse(
     await readFile(new URL("schema-v2.json", `file://${checkout}/`), "utf8"),
   );
   assert.strictEqual(schema.properties.schema_version.const, ENTRY_SCHEMA_VERSION);
+  assert.ok(schema.required.includes("preservation"));
+  const preservation = schema.properties.preservation;
+  assert.equal(preservation.type, "object");
+  assert.equal(preservation.additionalProperties, false);
+  assert.deepEqual(
+    [...preservation.required].sort(),
+    ["archive_owner", "archived_at", "receipt_sha256", "repositories"].sort(),
+  );
+  assert.deepEqual(
+    Object.keys(preservation.properties).sort(),
+    ["archive_owner", "archived_at", "receipt_sha256", "repositories"].sort(),
+  );
+  assert.equal(preservation.properties.archive_owner.const, "PalomarArchive");
+  const repositories = preservation.properties.repositories;
+  assert.equal(repositories.type, "array");
+  assert.equal(repositories.minItems, 1);
+  assert.equal(repositories.items.type, "object");
+  assert.equal(repositories.items.additionalProperties, false);
+  assert.deepEqual(
+    [...repositories.items.required].sort(),
+    ["source_repository", "commit", "fork_repository", "ref"].sort(),
+  );
+  assert.deepEqual(
+    Object.keys(repositories.items.properties).sort(),
+    ["source_repository", "commit", "fork_repository", "ref"].sort(),
+  );
 });
 
 test("the favicon ships with the site and every page asks for it", async () => {
@@ -916,6 +948,50 @@ test("a version index URL cannot leave the database origin", () => {
     "https://data.example.org/versions/PALOMAR-2026-07-29-000123.json");
   assert.throws(() => versionsUrl("../../etc/passwd", base), /malformed/);
   assert.throws(() => versionsUrl("PALOMAR-2026-07-29-00012", base), /malformed/);
+});
+
+test("browse enumerates every schema-v1 history row without becoming an entry schema", () => {
+  assert.equal(RECENT_SCHEMA_VERSION, 1);
+  assert.equal(VERSIONS_SCHEMA_VERSION, 1);
+  assert.equal(BROWSE_SCHEMA_VERSION, 1);
+  const row = {
+    id: "PALOMAR-2026-07-29-000123",
+    version: 1,
+    title: "A result",
+    status: "accepted",
+    path: "entries/PALOMAR-2026-07-29-000123-v1.json",
+  };
+  const yearRow = { year: "2026", days: 1, results: 1, versions: 1 };
+  const head = { schema_version: 1, results: 1, versions: 1, years: [yearRow] };
+  const dayRow = {
+    day: "2026-07-29",
+    first_page: 1,
+    last_page: 1,
+    results: 1,
+    versions: 1,
+  };
+  const year = { schema_version: 1, year: "2026", days: [dayRow] };
+  const page = { schema_version: 1, day: dayRow.day, page: 1, entries: [row] };
+  assert.equal(validateBrowseHead(head), head);
+  assert.equal(validateBrowseYear(year, yearRow), year);
+  assert.equal(validateBrowsePage(page, dayRow.day, 1), page);
+
+  assert.throws(
+    () => validateBrowseHead({ ...head, versions: 2 }),
+    /counts do not equal/,
+  );
+  assert.throws(
+    () => validateBrowseYear({ ...year, year: "2027" }, yearRow),
+    /different year/,
+  );
+  assert.throws(
+    () => validateBrowsePage({ ...page, page: 2 }, dayRow.day, 1),
+    /identity does not match/,
+  );
+  assert.throws(
+    () => validateBrowsePage({ ...page, schema_version: 2 }, dayRow.day, 1),
+    /schema_version/,
+  );
 });
 
 const SEARCH_BASE = "https://data.example.test/";

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -994,6 +994,25 @@ test("browse enumerates every schema-v1 history row without becoming an entry sc
   );
 });
 
+test("the producer-supplied browse head, year, and page keep Web's exact contract", async () => {
+  // CI overwrites these checked snapshots from the live producer before this
+  // test. Keeping the three levels legible here makes an exactObject failure
+  // name the producer/consumer surface that drifted, rather than leaving that
+  // shape implicit inside the complete public traversal.
+  const fixture = (name) => new URL(`fixtures/public-browse/${name}.json`, import.meta.url);
+  const head = JSON.parse(await readFile(fixture("index"), "utf8"));
+  const expectedYear = head.years.at(-1);
+  assert.ok(expectedYear, "the producer browse head has no year to exercise");
+  const year = JSON.parse(await readFile(fixture("year"), "utf8"));
+  const expectedDay = year.days.at(-1);
+  assert.ok(expectedDay, "the producer browse year has no day to exercise");
+  const page = JSON.parse(await readFile(fixture("page"), "utf8"));
+
+  assert.equal(validateBrowseHead(head), head);
+  assert.equal(validateBrowseYear(year, expectedYear), year);
+  assert.equal(validateBrowsePage(page, expectedDay.day, expectedDay.first_page), page);
+});
+
 const SEARCH_BASE = "https://data.example.test/";
 
 function searchHead(overrides = {}) {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -20,18 +20,16 @@ function fileAtPreviousDeployment(path) {
 }
 
 /**
- * Which entry schemas the previous deployment's validator would accept.
+ * Which entry schema the previous deployment's validator would accept.
  *
  * Cached JavaScript can only be compatible with records it can read. When the
  * published schema changes, cached JavaScript is deliberately incompatible,
  * and asserting otherwise would only be satisfiable by never changing it.
  */
-function entrySchemasAtPreviousDeployment() {
+function entrySchemaAtPreviousDeployment() {
   const source = fileAtPreviousDeployment("assets/security.mjs");
-  const set = /ENTRY_SCHEMA_VERSIONS = new Set\(\[([0-9,\s]*)\]\)/.exec(source);
-  if (set) return new Set(set[1].split(",").map((n) => Number(n.trim())));
   const single = /ENTRY_SCHEMA_VERSION = ([0-9]+)/.exec(source);
-  return single ? new Set([Number(single[1])]) : new Set();
+  return single ? Number(single[1]) : null;
 }
 
 const currentEntrySchema = Number(
@@ -452,53 +450,34 @@ test("an archive warning says the original works only after a fresh confirmation
   await expect(notice.getByRole("link", { name: "Original source" })).toBeVisible();
 });
 
-test("an entry accepted before source archiving explains the limitation as a warning", async ({ page }) => {
+test("entry schema v1 fails closed before rendering", async ({ page }) => {
   await page.route("**/entries/PALOMAR-2026-07-29-000123-v1.json", async (route) => {
     const response = await route.fetch();
-    const legacy = await response.json();
-    legacy.schema_version = 1;
-    delete legacy.preservation;
-    await route.fulfill({ response, json: legacy });
+    const obsolete = await response.json();
+    obsolete.schema_version = 1;
+    await route.fulfill({ response, json: obsolete });
   });
   await page.goto(
     `/entry.html?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`,
   );
 
-  const notice = page.locator(".source-availability.legacy");
-  await expect(notice).toContainText("Palomar has no preservation copy of this source");
-  await expect(notice).toContainText("before Palomar began archiving source repositories");
-  await expect(notice).toContainText("may stop working if that repository is removed");
-  await expect(notice.getByRole("link", { name: "Open the reviewed source" })).toHaveAttribute(
-    "href",
-    /github\.com\/example\/challenge\/tree\/1{40}\/project$/,
-  );
-  await expect(notice).toHaveCSS("background-color", "rgb(255, 248, 223)");
-  await expect(notice).toHaveCSS("padding-left", "20px");
+  await expect(page.locator(".entry-heading")).toHaveCount(0);
+  await expect(page.locator("#status")).toHaveClass(/error/);
+  await expect(page.locator("#status")).toContainText("unsupported entry schema_version 1");
 });
 
-test("a card for a result accepted before archiving does not call its original unavailable", async ({ page }) => {
-  // A record with no preservation block was accepted before Palomar archived
-  // anything, so nothing has ever been checked about its repository. The card
-  // read that silence as a missing original and printed "Original unavailable"
-  // beside somebody else's repository, which is a published claim about a
-  // third party's work made on no evidence.
+test("a recent row without the required preservation mapping fails closed", async ({ page }) => {
   await page.route("**/database/recent.json", async (route) => {
     const response = await route.fetch();
     const recent = await response.json();
-    const legacy = recent.entries.find((row) => row.id === "PALOMAR-2026-07-29-000123");
-    legacy.preservation = null;
+    recent.entries[0].preservation = null;
     await route.fulfill({ response, json: recent });
   });
   await page.goto(`/?database=${database}`);
 
-  const legacyCard = page.locator(".entry-card", { hasText: "PALOMAR-2026-07-29-000123" });
-  await expect(legacyCard).toHaveCount(1);
-  await expect(legacyCard.locator(".source-status")).toHaveCount(0);
-  await expect(legacyCard.locator(".archive-link")).toHaveCount(0);
-  // The other card is unpreserved by nothing: it still offers its copy.
-  await expect(
-    page.locator(".entry-card", { hasText: "PALOMAR-2026-07-29-000124" }).locator(".archive-link"),
-  ).toHaveCount(1);
+  await expect(page.locator(".entry-card")).toHaveCount(0);
+  await expect(page.locator("#status")).toHaveClass(/error/);
+  await expect(page.locator("#status")).toContainText("preservation must be an object");
 });
 
 test("a card says the original is unavailable exactly when the manifest says so", async ({ page }) => {
@@ -825,7 +804,7 @@ test("larger Challenge falls back to the dedicated wrapper", async ({ page }) =>
 test("current HTML remains compatible with cached JavaScript from the previous deployment", async ({ page }) => {
   test.skip(!previousRef, "PALOMAR_PREVIOUS_REF is only set in deployment and pull-request CI");
   test.skip(
-    !entrySchemasAtPreviousDeployment().has(currentEntrySchema),
+    entrySchemaAtPreviousDeployment() !== currentEntrySchema,
     "the published entry schema changed, so cached JavaScript cannot read current records",
   );
   // The same reasoning, one level up: a bundle that reads a document the

--- a/tests/source-preservation.test.mjs
+++ b/tests/source-preservation.test.mjs
@@ -155,6 +155,15 @@ test("source location rejects a repository revision absent from the preservation
   );
 });
 
+test("source location rejects a missing preservation receipt instead of falling back", () => {
+  const record = entry();
+  delete record.preservation;
+  assert.throws(
+    () => topSourceLocation(record, null),
+    /no canonical source preservation receipt/,
+  );
+});
+
 test("card decoration isolates a malformed entry and still decorates its peer", () => {
   withFakeDocument((warnings) => {
     const bad = entry();

--- a/tests/source-preservation.test.mjs
+++ b/tests/source-preservation.test.mjs
@@ -93,23 +93,6 @@ function withFakeDocument(run) {
   }
 }
 
-test("source location stays on the recorded repository without preservation evidence", () => {
-  const record = entry({ preservation: null });
-  assert.deepEqual(
-    sourceLocation(record, manifest({ original: "missing" }), record.source.repository, COMMIT),
-    {
-      repository: "example/challenge",
-      originalRepository: "example/challenge",
-      archiveRepository: null,
-      commit: COMMIT,
-      originalStatus: "unknown",
-      archiveStatus: "unknown",
-      checkedAt: null,
-      useArchive: false,
-    },
-  );
-});
-
 test("source location switches only from a confirmed missing original to its recorded archive", () => {
   const record = entry();
   const availability = manifest({ original: "missing", archive: "available" });


### PR DESCRIPTION
## Summary

- require the sole current entry contract, `schema_version: 2`, at every Web entry boundary
- remove v1 preservation fallbacks, legacy notices, nullable archive guards, fixtures, and browser behavior
- require every accepted entry and `recent.json` card projection to carry canonical preservation metadata
- stop Web CI and Pages deployment from downloading the obsolete `schema-v1.json` contract
- fail closed before Pages artifact upload unless Web can reconcile every producer-advertised browse/history row and validate every advertised active entry permalink
- bound public checks to eight concurrent reads, with three five-second attempts and short backoff per read; bound and supersede the hourly workflow itself
- restore `recent.published_at` reconciliation with the current entry's `registered_at` without fetching an entry twice
- retain unrelated schema-version-1 protocols: recent, per-result versions, browse/search, source availability, and independent render/evidence metadata

## Dependency and deployment order

This is the consumer half of PalomarDatabase #99 at exact producer head `7d7d9dc355a41201a52ae2cc3e824d8a5fd6f2f3`.

Deploy this consumer first, but only after its mandatory all-version gate shows the current advertised publication is already compatible:

1. Confirm this PR's CI has traversed every producer-advertised live browse page and per-result version index, reconciled every advertised row, and accepted every advertised active permalink as schema v2 with preservation.
2. Merge this Web PR and wait for its Pages deployment and published-site checks.
3. Confirm the deployed Web workflows no longer fetch `schema-v1.json`.
4. Merge PalomarDatabase #99, then wait for both its publication and data Worker deployment.
5. Confirm `schema-v2.json` and every served entry remain v2, every `recent.json` row retains its preservation mapping, and `schema-v1.json` responds 404.

The currently deployed publication already contains only v2, preservation-backed active entries, so current and amended Web both accept its entry data. Database #99 publication immediately activates a snapshot without `schema-v1.json`, before its Worker deployment; deploying Database first would therefore break the old Web workflows that still curl that document.

This consumer-first exception applies to deleting a producer artifact the old consumer still requests. It does not change the ordinary producer-first rule for a shape change to data the browser reads. The public gate is intentionally O(A) in advertised active versions and is a deployment/monitoring cost, not visitor page-load cost. It reconciles every row the producer advertises; it is not an independent proof that the producer omitted nothing from all public surfaces.

## Validation

- `PALOMAR_DATABASE_CHECKOUT=/tmp/.../PalomarDatabase npm test` — 109/109 pass against Database #99 exact head `7d7d9dc355a41201a52ae2cc3e824d8a5fd6f2f3`, including exact schema-v2 preservation shape and a live producer-supplied browse head/year/page chain
- one-time manual inspection at that exact Database head — the only versioned entry schema is `schema-v2.json`; every canonical historical entry is schema v2 and carries preservation metadata
- `node scripts/check-published.mjs --data https://data.palomar-registry.org` — reconciles and accepts every currently advertised active entry version/permalink, including recent publication time
- `PALOMAR_PREVIOUS_REF=origin/main npm run test:browser` under Nixpkgs Chromium — 53/53 pass
- `npm run build -- --version final-opus-review --output .site-test-final-opus`
- `node scripts/check-published.mjs --links` — all four linked registry documents are served
- JavaScript and Python syntax checks; `git diff --check`
