### PR TITLE
Extract entry page controllers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,12 @@
   `assets/security.mjs`. `assets/source-preservation.mjs` consumes that
   validated contract, matches manifest observations to preservation-receipt
   mappings, and owns repository resolution plus in-place card decoration;
-  `assets/app.js` owns page composition. Do not duplicate validation across
-  those modules.
+  `assets/entry-pages.mjs` owns entry-route parameter validation, progressive
+  visibility, immutable-URL replacement, fragment scrolling, tombstone
+  dispatch, and route-level errors; `assets/app.js` owns data loading and page
+  composition. Do not duplicate registry-document validation or route
+  orchestration across those modules; the route module still rejects malformed
+  URL identifiers before asking the document loader to do any work.
 
 - The browser suite needs `python3` on `PATH`, for the fixture server. Two of
   its tests want `PALOMAR_PREVIOUS_REF` and skip silently without it, which only

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ The browser code keeps the data boundary separate from presentation:
 `security.mjs` validates registry and availability documents and owns endpoint
 freshness, `source-preservation.mjs` matches validated manifest observations to
 the preservation receipt before resolving repository locations and decorating
-existing cards, and `app.js` composes the page-level views.
+existing cards, `entry-pages.mjs` owns entry-route input and page-state
+transitions, and `app.js` loads records and composes the page-level views.
 
 Runtime reads use the browser's normal HTTP cache behavior. The public data
 service gives successful documents a 60-second browser/shared-cache lifetime,

--- a/assets/app.js
+++ b/assets/app.js
@@ -30,6 +30,10 @@ import {
 import { loadSettledBounded } from "./loading.mjs";
 import { createRegistrySearch, validateSearchQuery } from "./searching.mjs";
 import {
+  renderChallengePage,
+  renderEntryPage,
+} from "./entry-pages.mjs";
+import {
   decorateCardSet,
   sourceDirectoryUrl,
   sourceFileUrl,
@@ -40,8 +44,6 @@ import {
 const CANONICAL_WEB_BASE = "https://palomar-registry.org/";
 
 const params = new URLSearchParams(window.location.search);
-const PALOMAR_ID = /^PALOMAR-\d{4}-\d{2}-\d{2}-\d{6}$/;
-const VERSION_PARAMETER = /^[1-9][0-9]*$/;
 const ARXIV_FILTER_RE = /^[a-z]+(?:-[a-z]+)*(?:\.[A-Za-z-]+)?$/;
 const MSC2020_FILTER_RE = /^[0-9]{2}(?:[A-Z][0-9]{2}|-[0-9]{2})$/;
 const FILTER_UPDATE_DELAY_MS = 200;
@@ -1648,115 +1650,40 @@ function renderExactTombstone(tombstone, content) {
   content.hidden = false;
 }
 
-async function renderEntryPage() {
-  const status = document.querySelector("#status");
-  const content = document.querySelector("#entry-content");
-  const id = params.get("id");
-  const versionParameter = params.get("version");
-  const version = versionParameter === null || !VERSION_PARAMETER.test(versionParameter)
-    ? null
-    : Number(versionParameter);
-  if (
-    !PALOMAR_ID.test(id || "") ||
-    (versionParameter !== null &&
-      (!VERSION_PARAMETER.test(versionParameter) || !Number.isSafeInteger(version)))
-  ) {
-    status.textContent = "This registry link has a missing or invalid Palomar ID or version.";
-    status.classList.add("error");
-    return;
-  }
-  try {
-    const requestedHash = window.location.hash;
-    const loaded = await loadEntry(id, version);
-    if (loaded.tombstone) {
-      status.hidden = true;
-      renderExactTombstone(loaded.tombstone, content);
-      return;
-    }
-    const {
-      entry,
-      canonicalUrl,
-      renderBase,
-      versions,
-      currentVersion,
-      availability,
-      databaseBase,
-    } = loaded;
-    if (version === null) {
-      const resolvedUrl = localPageUrl("entry.html", entry);
-      resolvedUrl.hash = requestedHash;
-      window.history.replaceState(null, "", resolvedUrl);
-    }
-    status.hidden = true;
-    content.hidden = false;
-    await renderEntry(
-      entry,
-      content,
-      canonicalUrl,
-      renderBase,
-      versions,
-      currentVersion,
-      availability,
-      databaseBase,
-    );
-    const anchorTarget = requestedHash.startsWith("#")
-      ? document.getElementById(decodeURIComponent(requestedHash.slice(1)))
-      : null;
-    if (anchorTarget) anchorTarget.scrollIntoView();
-  } catch (error) {
-    status.textContent = `The registry entry could not be loaded: ${error.message}`;
-    status.classList.add("error");
-  }
-}
-
-async function renderChallengePage() {
-  const status = document.querySelector("#status");
-  const content = document.querySelector("#render-content");
-  const id = params.get("id");
-  const versionParameter = params.get("version") || "";
-  const version = Number(versionParameter);
-  if (
-    !PALOMAR_ID.test(id || "") ||
-    !VERSION_PARAMETER.test(versionParameter) ||
-    !Number.isSafeInteger(version)
-  ) {
-    status.textContent = "This render link is missing a valid Palomar ID and version.";
-    status.classList.add("error");
-    return;
-  }
-  try {
-    const loaded = await loadEntry(id, version);
-    if (loaded.tombstone) {
-      status.hidden = true;
-      renderExactTombstone(loaded.tombstone, content);
-      return;
-    }
-    const { entry, renderBase, availability } = loaded;
-    document.title = `Named compared declarations — ${entry.title} — Palomar`;
-    const heading = el("header", "entry-heading");
-    heading.append(
-      el("div", "entry-id", `${entry.id} v${entry.version}`),
-      el("h1", "", entry.title),
-    );
-    const challenge = await challengePresentation(
-      entry,
-      renderBase,
-      { forceFrame: true, availability },
-    );
-    content.append(heading, challenge.section);
-    status.hidden = true;
-    content.hidden = false;
-  } catch (error) {
-    status.textContent = `The named compared declarations could not be loaded: ${error.message}`;
-    status.classList.add("error");
-  }
-}
-
 if (document.body.dataset.page === "index") {
   // A linked search is its own view. Avoid fetching and exposing a hidden
   // recent listing until the query is cleared; then load it exactly once.
   const hasInitialSearch = wireSearch();
   if (!hasInitialSearch) ensureLanding();
 }
-if (document.body.dataset.page === "entry") renderEntryPage();
-if (document.body.dataset.page === "render") renderChallengePage();
+if (document.body.dataset.page === "entry") {
+  renderEntryPage({
+    params,
+    document,
+    location: window.location,
+    history: window.history,
+    loadEntry,
+    localPageUrl,
+    renderEntry: (loaded, content) => renderEntry(
+      loaded.entry,
+      content,
+      loaded.canonicalUrl,
+      loaded.renderBase,
+      loaded.versions,
+      loaded.currentVersion,
+      loaded.availability,
+      loaded.databaseBase,
+    ),
+    renderExactTombstone,
+  });
+}
+if (document.body.dataset.page === "render") {
+  renderChallengePage({
+    params,
+    document,
+    loadEntry,
+    renderExactTombstone,
+    el,
+    challengePresentation,
+  });
+}

--- a/assets/entry-pages.mjs
+++ b/assets/entry-pages.mjs
@@ -1,0 +1,110 @@
+const PALOMAR_ID = /^PALOMAR-\d{4}-\d{2}-\d{2}-\d{6}$/;
+const VERSION_PARAMETER = /^[1-9][0-9]*$/;
+
+function parsedVersion(value) {
+  if (!VERSION_PARAMETER.test(value)) return null;
+  const version = Number(value);
+  return Number.isSafeInteger(version) ? version : null;
+}
+
+/**
+ * Orchestrate the entry route around the data loader and page composer.
+ *
+ * The caller retains those two domain boundaries. This module owns URL input,
+ * progressive visibility, immutable-URL replacement, fragment scrolling, and
+ * the route's public failure text so those state transitions are testable
+ * without importing the whole browser application.
+ */
+export async function renderEntryPage({
+  params,
+  document,
+  location,
+  history,
+  loadEntry,
+  localPageUrl,
+  renderEntry,
+  renderExactTombstone,
+}) {
+  const status = document.querySelector("#status");
+  const content = document.querySelector("#entry-content");
+  const id = params.get("id");
+  const versionParameter = params.get("version");
+  const version = versionParameter === null ? null : parsedVersion(versionParameter);
+  if (!PALOMAR_ID.test(id || "") || (versionParameter !== null && version === null)) {
+    status.textContent = "This registry link has a missing or invalid Palomar ID or version.";
+    status.classList.add("error");
+    return;
+  }
+  try {
+    const requestedHash = location.hash;
+    const loaded = await loadEntry(id, version);
+    if (loaded.tombstone) {
+      status.hidden = true;
+      renderExactTombstone(loaded.tombstone, content);
+      return;
+    }
+    const { entry } = loaded;
+    if (version === null) {
+      const resolvedUrl = localPageUrl("entry.html", entry);
+      resolvedUrl.hash = requestedHash;
+      history.replaceState(null, "", resolvedUrl);
+    }
+    status.hidden = true;
+    content.hidden = false;
+    await renderEntry(loaded, content);
+    const anchorTarget = requestedHash.startsWith("#")
+      ? document.getElementById(decodeURIComponent(requestedHash.slice(1)))
+      : null;
+    if (anchorTarget) anchorTarget.scrollIntoView();
+  } catch (error) {
+    status.textContent = `The registry entry could not be loaded: ${error.message}`;
+    status.classList.add("error");
+  }
+}
+
+/** Orchestrate the dedicated named-declarations route. */
+export async function renderChallengePage({
+  params,
+  document,
+  loadEntry,
+  renderExactTombstone,
+  el,
+  challengePresentation,
+}) {
+  const status = document.querySelector("#status");
+  const content = document.querySelector("#render-content");
+  const id = params.get("id");
+  const versionParameter = params.get("version") || "";
+  const version = parsedVersion(versionParameter);
+  if (!PALOMAR_ID.test(id || "") || version === null) {
+    status.textContent = "This render link is missing a valid Palomar ID and version.";
+    status.classList.add("error");
+    return;
+  }
+  try {
+    const loaded = await loadEntry(id, version);
+    if (loaded.tombstone) {
+      status.hidden = true;
+      renderExactTombstone(loaded.tombstone, content);
+      return;
+    }
+    const { entry, renderBase, availability } = loaded;
+    document.title = `Named compared declarations — ${entry.title} — Palomar`;
+    const heading = el("header", "entry-heading");
+    heading.append(
+      el("div", "entry-id", `${entry.id} v${entry.version}`),
+      el("h1", "", entry.title),
+    );
+    const challenge = await challengePresentation(
+      entry,
+      renderBase,
+      { forceFrame: true, availability },
+    );
+    content.append(heading, challenge.section);
+    status.hidden = true;
+    content.hidden = false;
+  } catch (error) {
+    status.textContent = `The named compared declarations could not be loaded: ${error.message}`;
+    status.classList.add("error");
+  }
+}

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -8,6 +8,7 @@ const publicFiles = [...htmlFiles, "site.webmanifest", "favicon.svg"];
 const browserModuleFiles = [
   "about.js",
   "app.js",
+  "entry-pages.mjs",
   "loading.mjs",
   "rendering.js",
   "searching.mjs",

--- a/tests/build-site.test.js
+++ b/tests/build-site.test.js
@@ -22,6 +22,7 @@ test("deployment build versions coupled browser assets", async () => {
     const index = await readFile(path.join(destination, "index.html"), "utf8");
     const about = await readFile(path.join(destination, "about.html"), "utf8");
     const app = await readFile(path.join(destination, "assets", "app.js"), "utf8");
+    await readFile(path.join(destination, "assets", "entry-pages.mjs"), "utf8");
     const preservation = await readFile(
       path.join(destination, "assets", "source-preservation.mjs"),
       "utf8",
@@ -40,6 +41,7 @@ test("deployment build versions coupled browser assets", async () => {
     assert.match(about, /assets\/about\.js\?v=0123456789abcdef/);
     await readFile(path.join(destination, "assets", "about.js"), "utf8");
     assert.match(app, /\.\/rendering\.js\?v=0123456789abcdef/);
+    assert.match(app, /\.\/entry-pages\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/security\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/loading\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/searching\.mjs\?v=0123456789abcdef/);

--- a/tests/entry-pages.test.js
+++ b/tests/entry-pages.test.js
@@ -1,0 +1,247 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  renderChallengePage,
+  renderEntryPage,
+} from "../assets/entry-pages.mjs";
+
+function classList() {
+  const names = new Set();
+  return {
+    add: (...values) => values.forEach((value) => names.add(value)),
+    contains: (value) => names.has(value),
+  };
+}
+
+function node({ hidden = false } = {}) {
+  return {
+    children: [],
+    classList: classList(),
+    hidden,
+    textContent: "",
+    append(...children) {
+      this.children.push(...children);
+    },
+  };
+}
+
+function pageDocument(contentSelector) {
+  const status = node();
+  const content = node({ hidden: true });
+  const targets = new Map();
+  return {
+    content,
+    document: {
+      title: "",
+      querySelector(selector) {
+        if (selector === "#status") return status;
+        if (selector === contentSelector) return content;
+        return null;
+      },
+      getElementById(id) {
+        return targets.get(id) || null;
+      },
+    },
+    status,
+    targets,
+  };
+}
+
+function entryDependencies(overrides = {}) {
+  const view = pageDocument("#entry-content");
+  return {
+    view,
+    settings: {
+      params: new URLSearchParams("id=PALOMAR-2026-08-08-000001&version=2"),
+      document: view.document,
+      location: { hash: "" },
+      history: { replaceState() {} },
+      loadEntry: async () => ({ tombstone: {} }),
+      localPageUrl: () => new URL("https://palomar-registry.org/entry.html"),
+      renderEntry: async () => {},
+      renderExactTombstone: () => {},
+      ...overrides,
+    },
+  };
+}
+
+test("entry routes reject noncanonical parameters before loading data", async () => {
+  let loads = 0;
+  const { settings, view } = entryDependencies({
+    params: new URLSearchParams("id=PALOMAR-2026-08-08-000001&version=2.0"),
+    loadEntry: async () => {
+      loads += 1;
+    },
+  });
+
+  await renderEntryPage(settings);
+
+  assert.equal(loads, 0);
+  assert.equal(view.status.textContent, "This registry link has a missing or invalid Palomar ID or version.");
+  assert.equal(view.status.classList.contains("error"), true);
+  assert.equal(view.content.hidden, true);
+});
+
+test("unversioned entry routes expose content progressively then preserve and scroll the fragment", async () => {
+  const entry = { id: "PALOMAR-2026-08-08-000001", version: 3 };
+  const loaded = {
+    entry,
+    canonicalUrl: new URL("https://data.example/entry.json"),
+    renderBase: new URL("https://render.example/"),
+    versions: [{ version: 3 }],
+    currentVersion: 3,
+    availability: { repositories: [] },
+    databaseBase: new URL("https://data.example/"),
+  };
+  let releaseRender;
+  let renderStarted;
+  const rendering = new Promise((resolve) => {
+    releaseRender = resolve;
+  });
+  const started = new Promise((resolve) => {
+    renderStarted = resolve;
+  });
+  let replaced = null;
+  let scrolled = 0;
+  let renderedArguments = null;
+  const { settings, view } = entryDependencies({
+    params: new URLSearchParams(`id=${entry.id}`),
+    location: { hash: "#version-history" },
+    history: {
+      replaceState(state, title, url) {
+        replaced = { state, title, url };
+      },
+    },
+    loadEntry: async (id, version) => {
+      assert.equal(id, entry.id);
+      assert.equal(version, null);
+      return loaded;
+    },
+    localPageUrl: (page, selected) => {
+      assert.equal(page, "entry.html");
+      assert.equal(selected, entry);
+      return new URL(`https://palomar-registry.org/entry.html?id=${entry.id}&version=3`);
+    },
+    renderEntry: async (...args) => {
+      renderedArguments = args;
+      renderStarted();
+      await rendering;
+    },
+  });
+  view.targets.set("version-history", { scrollIntoView: () => { scrolled += 1; } });
+
+  const route = renderEntryPage(settings);
+  await started;
+  assert.equal(view.status.hidden, true);
+  assert.equal(view.content.hidden, false);
+  assert.equal(scrolled, 0);
+  releaseRender();
+  await route;
+
+  assert.deepEqual(renderedArguments, [loaded, view.content]);
+  assert.equal(replaced.state, null);
+  assert.equal(replaced.title, "");
+  assert.equal(replaced.url.href, `https://palomar-registry.org/entry.html?id=${entry.id}&version=3#version-history`);
+  assert.equal(scrolled, 1);
+});
+
+test("entry routes preserve exact tombstones and load failures", async (t) => {
+  await t.test("exact tombstone", async () => {
+    const tombstone = { id: "PALOMAR-2026-08-08-000001", version: 2 };
+    let rendered = null;
+    const { settings, view } = entryDependencies({
+      loadEntry: async () => ({ tombstone }),
+      renderExactTombstone: (...args) => {
+        rendered = args;
+      },
+    });
+
+    await renderEntryPage(settings);
+
+    assert.deepEqual(rendered, [tombstone, view.content]);
+    assert.equal(view.status.hidden, true);
+  });
+
+  await t.test("load failure", async () => {
+    const { settings, view } = entryDependencies({
+      loadEntry: async () => {
+        throw new Error("503 Unavailable");
+      },
+    });
+
+    await renderEntryPage(settings);
+
+    assert.equal(view.status.textContent, "The registry entry could not be loaded: 503 Unavailable");
+    assert.equal(view.status.classList.contains("error"), true);
+    assert.equal(view.content.hidden, true);
+  });
+});
+
+test("named-declaration routes validate before loading and reveal only completed views", async () => {
+  const invalid = pageDocument("#render-content");
+  let loads = 0;
+  await renderChallengePage({
+    params: new URLSearchParams("id=PALOMAR-2026-08-08-000001&version=02"),
+    document: invalid.document,
+    loadEntry: async () => { loads += 1; },
+  });
+  assert.equal(loads, 0);
+  assert.equal(invalid.status.textContent, "This render link is missing a valid Palomar ID and version.");
+  assert.equal(invalid.content.hidden, true);
+
+  const view = pageDocument("#render-content");
+  const entry = { id: "PALOMAR-2026-08-08-000001", version: 2, title: "A result" };
+  const section = node();
+  let releaseChallenge;
+  let challengeStarted;
+  const challenging = new Promise((resolve) => { releaseChallenge = resolve; });
+  const started = new Promise((resolve) => { challengeStarted = resolve; });
+  const route = renderChallengePage({
+    params: new URLSearchParams(`id=${entry.id}&version=2`),
+    document: view.document,
+    loadEntry: async () => ({
+      entry,
+      renderBase: new URL("https://render.example/"),
+      availability: { repositories: [] },
+    }),
+    renderExactTombstone: () => assert.fail("unexpected tombstone"),
+    el: (tag, className, text = "") => ({ ...node(), tag, className, textContent: text }),
+    challengePresentation: async (selected, renderBase, options) => {
+      assert.equal(selected, entry);
+      assert.equal(renderBase.href, "https://render.example/");
+      assert.deepEqual(options, { forceFrame: true, availability: { repositories: [] } });
+      challengeStarted();
+      await challenging;
+      return { section };
+    },
+  });
+
+  await started;
+  assert.equal(view.status.hidden, false);
+  assert.equal(view.content.hidden, true);
+  releaseChallenge();
+  await route;
+
+  assert.equal(view.document.title, "Named compared declarations — A result — Palomar");
+  assert.equal(view.status.hidden, true);
+  assert.equal(view.content.hidden, false);
+  assert.equal(view.content.children.length, 2);
+  assert.equal(view.content.children[1], section);
+});
+
+test("named-declaration routes use the shared exact-tombstone presentation", async () => {
+  const view = pageDocument("#render-content");
+  const tombstone = { id: "PALOMAR-2026-08-08-000001", version: 2 };
+  let rendered = null;
+
+  await renderChallengePage({
+    params: new URLSearchParams(`id=${tombstone.id}&version=2`),
+    document: view.document,
+    loadEntry: async () => ({ tombstone }),
+    renderExactTombstone: (...args) => { rendered = args; },
+  });
+
+  assert.deepEqual(rendered, [tombstone, view.content]);
+  assert.equal(view.status.hidden, true);
+});

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -618,12 +618,25 @@ test("entries display repository licence evidence and its boundary", async ({ pa
   await expect(evidence).toContainText("Cited papers, reused formalizations, and dependencies retain their own licences");
 });
 
-test("entry version parameters use canonical positive-integer spelling", async ({ page }) => {
+test("detail routes reject malformed parameters before registry I/O", async ({ page }) => {
+  const dataRequests = [];
+  page.on("request", (request) => {
+    const path = new URL(request.url()).pathname;
+    if (path.startsWith("/database/")) dataRequests.push(path);
+  });
   await page.goto(
     `/entry.html?id=PALOMAR-2026-07-29-000123&version=2.0&database=${database}`,
   );
   await expect(page.locator("#status")).toContainText("missing or invalid Palomar ID or version");
   await expect(page.locator("#entry-content")).toBeHidden();
+
+  await page.goto(
+    `/render.html?id=PALOMAR-2026-07-29-000123&version=02&database=${database}`,
+  );
+  await expect(page.locator("#status")).toContainText("missing a valid Palomar ID and version");
+  await expect(page.locator("#render-content")).toBeHidden();
+  await page.waitForLoadState("networkidle");
+  expect(dataRequests).toEqual([]);
 });
 
 test("an exact unavailable entry shows only its target and public date", async ({ page }) => {


### PR DESCRIPTION
## Summary

- extract the entry and named-declarations route controllers from `assets/app.js` into the focused shipped module `assets/entry-pages.mjs`
- keep data loading and entry DOM composition in `app.js`, and leave security validators, search, source preservation, and bounded loading unchanged
- preserve strict route input, progressive visibility, immutable-URL replacement, fragment scrolling, exact tombstones, and route-level failure text with direct controller tests and browser coverage
- add the module to the versioned shipped import graph and document the new ownership boundary

`assets/app.js` falls from 1,762 to 1,689 lines. The extracted production module is 110 lines and has no imports of its own; it is route orchestration rather than another data or validation layer.

## Compatibility

This changes no registry contract, endpoint, request ordering, cache rule, URL grammar, DOM structure, focus behavior, or reader-visible text. The existing current-JavaScript/cached-HTML and current-HTML/cached-JavaScript browser checks both pass against base `29a1d5875cecb72493c6498a268462f3ad10d6b4`.

## Evidence

- `PALOMAR_DATABASE_CHECKOUT=<current PalomarDatabase main> npm test` — 116 tests pass
- `npm run build -- --version 29a1d5875cecb72493c6498a268462f3ad10d6b4 --output .site` — passes; the complete shipped module graph is present and versioned
- `PALOMAR_PREVIOUS_REF=29a1d5875cecb72493c6498a268462f3ad10d6b4 npm run test:browser` with Nixpkgs Chromium — all 53 browser tests pass, including both previous-deployment cases
- `node scripts/check-published.mjs --data https://data.palomar-registry.org` — all advertised live entry versions are accepted
- `node scripts/check-published.mjs --links` — all four linked registry documents are served
- `node --check assets/app.js assets/entry-pages.mjs` and `git diff --check` — pass
