### PR TITLE
Extract challenge presentation from app monolith

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,8 +65,12 @@
   mappings, and owns repository resolution plus in-place card decoration;
   `assets/entry-pages.mjs` owns entry-route parameter validation, progressive
   visibility, immutable-URL replacement, fragment scrolling, tombstone
-  dispatch, and route-level errors; `assets/app.js` owns data loading and page
-  composition. Do not duplicate registry-document validation or route
+  dispatch, and route-level errors. `assets/challenge-presentation.mjs` owns the
+  named-declarations render metadata's correspondence to the accepted entry,
+  its source/dependency controls, inline-versus-wrapper presentation, iframe
+  sandbox/height handling, and the missing-artifact fallback;
+  `assets/app.js` owns data loading and remaining page composition. Do not
+  duplicate registry-document validation, source resolution, or route
   orchestration across those modules; the route module still rejects malformed
   URL identifiers before asking the document loader to do any work.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ The browser code keeps the data boundary separate from presentation:
 freshness, `source-preservation.mjs` matches validated manifest observations to
 the preservation receipt before resolving repository locations and decorating
 existing cards, `entry-pages.mjs` owns entry-route input and page-state
-transitions, and `app.js` loads records and composes the page-level views.
+transitions, `challenge-presentation.mjs` owns the named-declarations artifact's
+entry correspondence and presentation states, and `app.js` loads records and
+composes the remaining page-level views.
 
 Runtime reads use the browser's normal HTTP cache behavior. The public data
 service gives successful documents a 60-second browser/shared-cache lifetime,

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,10 +1,4 @@
 import {
-  challengeArtifactUrl,
-  challengeMetadataUrl,
-  challengeSourceUrl,
-  isInlineChallenge,
-} from "./rendering.js";
-import {
   databaseBaseFor,
   RESULT_ORIGIN_LABELS,
   REPOSITORY_ROLE_LABELS,
@@ -33,6 +27,7 @@ import {
   renderChallengePage,
   renderEntryPage,
 } from "./entry-pages.mjs";
+import { createChallengePresentation } from "./challenge-presentation.mjs";
 import {
   decorateCardSet,
   sourceDirectoryUrl,
@@ -153,10 +148,6 @@ function authorNames(entry) {
 
 function theoremNames(entry) {
   return entry.formalization.theorem_names.join(", ");
-}
-
-function pathBasename(path) {
-  return path.split("/").at(-1);
 }
 
 function classification(entry) {
@@ -715,6 +706,13 @@ function localPageUrl(page, entry) {
   return safeInternalUrl(target, window.location.href);
 }
 
+const challengePresentation = createChallengePresentation({
+  fetchJson,
+  document,
+  window,
+  localPageUrl,
+});
+
 function canonicalEntryPageUrl(entry) {
   const target = new URL("entry.html", CANONICAL_WEB_BASE);
   target.searchParams.set("id", entry.id);
@@ -803,172 +801,6 @@ function versionHistory(entry, versions, currentVersion) {
   }
   section.append(list);
   return section;
-}
-
-function challengeFrame(entry, renderBase) {
-  const frame = el("iframe", "challenge-frame");
-  frame.src = safeDataUrl(
-    challengeArtifactUrl(entry, renderBase).href,
-    window.location.href,
-  ).href;
-  frame.title = `Named compared declarations for ${entry.id} version ${entry.version}`;
-  frame.loading = "lazy";
-  frame.referrerPolicy = "no-referrer";
-  frame.setAttribute("sandbox", "allow-scripts");
-  frame.setAttribute("scrolling", "auto");
-  window.addEventListener("message", (event) => {
-    if (event.source !== frame.contentWindow || event.data?.type !== "palomar-render-height") {
-      return;
-    }
-    const height = event.data.height;
-    if (!Number.isSafeInteger(height) || height <= 0) return;
-    frame.style.height = `${Math.max(160, Math.min(672, height + 2))}px`;
-    frame.dataset.heightAdjusted = "true";
-  });
-  return frame;
-}
-
-function validateChallengeMetadata(entry, metadata) {
-  const expectedDeclarations = [
-    ...entry.formalization.theorem_names,
-    ...entry.formalization.definition_names,
-  ];
-  const expectedImports = entry.trust.challenge_imports;
-  const sameArray = (left, right) =>
-    Array.isArray(left) && left.length === right.length &&
-      left.every((value, index) => value === right[index]);
-  if (
-    ![1, 2].includes(metadata?.schema_version) ||
-    !sameArray(metadata.declarations, expectedDeclarations) ||
-    !sameArray(metadata.imports, expectedImports) ||
-    !(metadata.module_doc === null ||
-      (typeof metadata.module_doc === "string" && metadata.module_doc.length <= 256 * 1024))
-  ) {
-    throw new Error("Challenge render metadata does not match the registry entry");
-  }
-  if (
-    metadata.schema_version >= 2 &&
-    (!Array.isArray(metadata.solution_imports) ||
-      metadata.solution_imports.length > 1_000 ||
-      !metadata.solution_imports.every((item) => typeof item === "string" && item.length > 0))
-  ) {
-    throw new Error("Challenge render metadata contains invalid Solution imports");
-  }
-  return metadata;
-}
-
-function challengeMetadata(metadata) {
-  const panel = el("div", "challenge-metadata");
-  panel.append(el("div", "eyebrow", "Statement file information"));
-  const imports = el("div", "challenge-metadata-row");
-  imports.append(el("strong", "", "Libraries imported by the statement"));
-  const tokens = el("span", "token-list");
-  for (const item of metadata.imports) tokens.append(el("code", "", item));
-  imports.append(tokens);
-  panel.append(imports);
-  if (metadata.module_doc) {
-    const moduleDoc = el("details", "challenge-module-doc");
-    moduleDoc.append(el("summary", "", "Notes from the statement file"));
-    moduleDoc.append(el("pre", "", metadata.module_doc));
-    panel.append(moduleDoc);
-  } else {
-    panel.append(el("p", "challenge-no-module-doc", "No notes were found in the statement file."));
-  }
-  return panel;
-}
-
-async function challengePresentation(
-  entry,
-  renderBase,
-  { forceFrame = false, dependenciesOnThisPage = false, availability = null } = {},
-) {
-  const section = el("section", "challenge-presentation");
-  const heading = el("div", "section-heading");
-  const titleBlock = el("div");
-  titleBlock.append(
-    el("div", "eyebrow", "Formal comparison surface"),
-    el("h2", "", "Named compared declarations"),
-  );
-  heading.append(titleBlock);
-  section.append(heading);
-
-  const links = el("p", "challenge-links");
-  // On the entry page the dependencies are a little further down, and a link
-  // that rebuilds the entry URL reads as a trip somewhere else. The dedicated
-  // render page does not carry them, so from there it is a trip somewhere else.
-  const dependencyRecordUrl = dependenciesOnThisPage
-    ? new URL("#statement-dependencies", window.location.href)
-    : localPageUrl("entry.html", entry);
-  if (!dependenciesOnThisPage) dependencyRecordUrl.hash = "statement-dependencies";
-  const comparatorPath = entry.formalization.comparator_config_path;
-  const challengePath = entry.formalization.challenge_path;
-  const challengeFilename = pathBasename(challengePath);
-  const location = topSourceLocation(entry, availability);
-  links.append(
-    externalLink(
-      `View full pinned statement file (${challengeFilename})`,
-      challengeSourceUrl(entry, location.repository),
-      "challenge-source",
-    ),
-    " · ",
-    internalLink(
-      "Inspect statement dependencies",
-      dependencyRecordUrl,
-    ),
-    " · ",
-    externalLink(
-      `View comparator configuration (${pathBasename(comparatorPath)})`,
-      sourceFileUrl(entry, comparatorPath, availability),
-      "comparator-source",
-    ),
-  );
-  const inline = isInlineChallenge(entry);
-  if (!forceFrame && !inline) {
-    links.append(
-      " · ",
-      internalLink("Open formatted statement", localPageUrl("render.html", entry)),
-    );
-  }
-  section.append(links);
-  section.append(
-    el(
-      "p",
-      "challenge-surface-disclosure",
-      `The formatted view shows only the declarations named in this entry's comparator configuration. Comparator also checks the declarations used by their types. The full pinned ${challengeFilename} and dependency record expose the statement and dependency surface for inspection.`,
-    ),
-  );
-
-  let metadata;
-  try {
-    metadata = validateChallengeMetadata(
-      entry,
-      await fetchJson(challengeMetadataUrl(entry, renderBase)),
-    );
-  } catch (error) {
-    if (error.status !== 404) throw error;
-    section.append(
-      el(
-        "p",
-        "challenge-fallback",
-        "The formatted statement is not available for this entry yet. Use the statement file link above; the pinned source is the record either way.",
-      ),
-    );
-    return {section, metadata: null};
-  }
-  section.append(challengeMetadata(metadata));
-
-  if (forceFrame || inline) {
-    section.append(challengeFrame(entry, renderBase));
-  } else {
-    section.append(
-      el(
-        "p",
-        "challenge-fallback",
-        "This statement is too large to display here; use the formatted view above.",
-      ),
-    );
-  }
-  return {section, metadata};
 }
 
 /** One kind of assurance, named so the two can be told apart at a glance. */

--- a/assets/challenge-presentation.mjs
+++ b/assets/challenge-presentation.mjs
@@ -1,0 +1,212 @@
+import {
+  challengeArtifactUrl,
+  challengeMetadataUrl,
+  challengeSourceUrl,
+  isInlineChallenge,
+} from "./rendering.js";
+import {
+  safeDataUrl,
+  safeExternalUrl,
+  safeInternalUrl,
+} from "./security.mjs";
+import {
+  sourceFileUrl,
+  topSourceLocation,
+} from "./source-preservation.mjs";
+
+export function validateChallengeMetadata(entry, metadata) {
+  const expectedDeclarations = [
+    ...entry.formalization.theorem_names,
+    ...entry.formalization.definition_names,
+  ];
+  const expectedImports = entry.trust.challenge_imports;
+  const sameArray = (left, right) =>
+    Array.isArray(left) && left.length === right.length &&
+      left.every((value, index) => value === right[index]);
+  if (
+    ![1, 2].includes(metadata?.schema_version) ||
+    !sameArray(metadata.declarations, expectedDeclarations) ||
+    !sameArray(metadata.imports, expectedImports) ||
+    !(metadata.module_doc === null ||
+      (typeof metadata.module_doc === "string" && metadata.module_doc.length <= 256 * 1024))
+  ) {
+    throw new Error("Challenge render metadata does not match the registry entry");
+  }
+  if (
+    metadata.schema_version >= 2 &&
+    (!Array.isArray(metadata.solution_imports) ||
+      metadata.solution_imports.length > 1_000 ||
+      !metadata.solution_imports.every((item) => typeof item === "string" && item.length > 0))
+  ) {
+    throw new Error("Challenge render metadata contains invalid Solution imports");
+  }
+  return metadata;
+}
+
+/**
+ * Bind the named-declarations presentation to its browser and data adapters.
+ *
+ * Registry validation, source resolution, URL confinement, and inline policy
+ * remain in their existing modules. This boundary owns only the render
+ * artifact's correspondence to an entry and the DOM states used to present it.
+ */
+export function createChallengePresentation({ fetchJson, document, window, localPageUrl }) {
+  function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined) node.textContent = text;
+    return node;
+  }
+
+  function anchor(text, href, className) {
+    const node = el("a", className, text);
+    node.href = href.href;
+    return node;
+  }
+
+  function externalLink(text, href, className) {
+    return anchor(text, safeExternalUrl(href), className);
+  }
+
+  function internalLink(text, href, className) {
+    return anchor(text, safeInternalUrl(href, window.location.href), className);
+  }
+
+  function challengeFrame(entry, renderBase) {
+    const frame = el("iframe", "challenge-frame");
+    frame.src = safeDataUrl(
+      challengeArtifactUrl(entry, renderBase).href,
+      window.location.href,
+    ).href;
+    frame.title = `Named compared declarations for ${entry.id} version ${entry.version}`;
+    frame.loading = "lazy";
+    frame.referrerPolicy = "no-referrer";
+    frame.setAttribute("sandbox", "allow-scripts");
+    frame.setAttribute("scrolling", "auto");
+    window.addEventListener("message", (event) => {
+      if (
+        !frame.contentWindow ||
+        event.source !== frame.contentWindow ||
+        event.data?.type !== "palomar-render-height"
+      ) {
+        return;
+      }
+      const height = event.data.height;
+      if (!Number.isSafeInteger(height) || height <= 0) return;
+      frame.style.height = `${Math.max(160, Math.min(672, height + 2))}px`;
+      frame.dataset.heightAdjusted = "true";
+    });
+    return frame;
+  }
+
+  function metadataPanel(metadata) {
+    const panel = el("div", "challenge-metadata");
+    panel.append(el("div", "eyebrow", "Statement file information"));
+    const imports = el("div", "challenge-metadata-row");
+    imports.append(el("strong", "", "Libraries imported by the statement"));
+    const tokens = el("span", "token-list");
+    for (const item of metadata.imports) tokens.append(el("code", "", item));
+    imports.append(tokens);
+    panel.append(imports);
+    if (metadata.module_doc) {
+      const moduleDoc = el("details", "challenge-module-doc");
+      moduleDoc.append(el("summary", "", "Notes from the statement file"));
+      moduleDoc.append(el("pre", "", metadata.module_doc));
+      panel.append(moduleDoc);
+    } else {
+      panel.append(el("p", "challenge-no-module-doc", "No notes were found in the statement file."));
+    }
+    return panel;
+  }
+
+  return async function challengePresentation(
+    entry,
+    renderBase,
+    { forceFrame = false, dependenciesOnThisPage = false, availability = null } = {},
+  ) {
+    const section = el("section", "challenge-presentation");
+    const heading = el("div", "section-heading");
+    const titleBlock = el("div");
+    titleBlock.append(
+      el("div", "eyebrow", "Formal comparison surface"),
+      el("h2", "", "Named compared declarations"),
+    );
+    heading.append(titleBlock);
+    section.append(heading);
+
+    const links = el("p", "challenge-links");
+    // On the entry page the dependencies are a little further down, and a link
+    // that rebuilds the entry URL reads as a trip somewhere else. The dedicated
+    // render page does not carry them, so from there it is a trip somewhere else.
+    const dependencyRecordUrl = dependenciesOnThisPage
+      ? new URL("#statement-dependencies", window.location.href)
+      : localPageUrl("entry.html", entry);
+    if (!dependenciesOnThisPage) dependencyRecordUrl.hash = "statement-dependencies";
+    const comparatorPath = entry.formalization.comparator_config_path;
+    const challengePath = entry.formalization.challenge_path;
+    const challengeFilename = challengePath.split("/").at(-1);
+    const location = topSourceLocation(entry, availability);
+    links.append(
+      externalLink(
+        `View full pinned statement file (${challengeFilename})`,
+        challengeSourceUrl(entry, location.repository),
+        "challenge-source",
+      ),
+      " · ",
+      internalLink("Inspect statement dependencies", dependencyRecordUrl),
+      " · ",
+      externalLink(
+        `View comparator configuration (${comparatorPath.split("/").at(-1)})`,
+        sourceFileUrl(entry, comparatorPath, availability),
+        "comparator-source",
+      ),
+    );
+    const inline = isInlineChallenge(entry);
+    if (!forceFrame && !inline) {
+      links.append(
+        " · ",
+        internalLink("Open formatted statement", localPageUrl("render.html", entry)),
+      );
+    }
+    section.append(links);
+    section.append(
+      el(
+        "p",
+        "challenge-surface-disclosure",
+        `The formatted view shows only the declarations named in this entry's comparator configuration. Comparator also checks the declarations used by their types. The full pinned ${challengeFilename} and dependency record expose the statement and dependency surface for inspection.`,
+      ),
+    );
+
+    let metadata;
+    try {
+      metadata = validateChallengeMetadata(
+        entry,
+        await fetchJson(challengeMetadataUrl(entry, renderBase)),
+      );
+    } catch (error) {
+      if (error.status !== 404) throw error;
+      section.append(
+        el(
+          "p",
+          "challenge-fallback",
+          "The formatted statement is not available for this entry yet. Use the statement file link above; the pinned source is the record either way.",
+        ),
+      );
+      return { section, metadata: null };
+    }
+    section.append(metadataPanel(metadata));
+
+    if (forceFrame || inline) {
+      section.append(challengeFrame(entry, renderBase));
+    } else {
+      section.append(
+        el(
+          "p",
+          "challenge-fallback",
+          "This statement is too large to display here; use the formatted view above.",
+        ),
+      );
+    }
+    return { section, metadata };
+  };
+}

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -8,6 +8,7 @@ const publicFiles = [...htmlFiles, "site.webmanifest", "favicon.svg"];
 const browserModuleFiles = [
   "about.js",
   "app.js",
+  "challenge-presentation.mjs",
   "entry-pages.mjs",
   "loading.mjs",
   "rendering.js",

--- a/tests/build-site.test.js
+++ b/tests/build-site.test.js
@@ -22,6 +22,10 @@ test("deployment build versions coupled browser assets", async () => {
     const index = await readFile(path.join(destination, "index.html"), "utf8");
     const about = await readFile(path.join(destination, "about.html"), "utf8");
     const app = await readFile(path.join(destination, "assets", "app.js"), "utf8");
+    const challengePresentation = await readFile(
+      path.join(destination, "assets", "challenge-presentation.mjs"),
+      "utf8",
+    );
     await readFile(path.join(destination, "assets", "entry-pages.mjs"), "utf8");
     const preservation = await readFile(
       path.join(destination, "assets", "source-preservation.mjs"),
@@ -40,7 +44,7 @@ test("deployment build versions coupled browser assets", async () => {
     assert.match(about, /assets\/style\.css\?v=0123456789abcdef/);
     assert.match(about, /assets\/about\.js\?v=0123456789abcdef/);
     await readFile(path.join(destination, "assets", "about.js"), "utf8");
-    assert.match(app, /\.\/rendering\.js\?v=0123456789abcdef/);
+    assert.match(app, /\.\/challenge-presentation\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/entry-pages\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/security\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/loading\.mjs\?v=0123456789abcdef/);
@@ -48,6 +52,12 @@ test("deployment build versions coupled browser assets", async () => {
     assert.match(app, /\.\/source-preservation\.mjs\?v=0123456789abcdef/);
     assert.match(preservation, /\.\/security\.mjs\?v=0123456789abcdef/);
     assert.match(rendering, /\.\/security\.mjs\?v=0123456789abcdef/);
+    assert.match(challengePresentation, /\.\/rendering\.js\?v=0123456789abcdef/);
+    assert.match(challengePresentation, /\.\/security\.mjs\?v=0123456789abcdef/);
+    assert.match(
+      challengePresentation,
+      /\.\/source-preservation\.mjs\?v=0123456789abcdef/,
+    );
     assert.match(searching, /\.\/loading\.mjs\?v=0123456789abcdef/);
     assert.match(searching, /\.\/security\.mjs\?v=0123456789abcdef/);
     await readFile(path.join(destination, "assets", "loading.mjs"), "utf8");

--- a/tests/challenge-presentation.test.mjs
+++ b/tests/challenge-presentation.test.mjs
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createChallengePresentation,
+  validateChallengeMetadata,
+} from "../assets/challenge-presentation.mjs";
+import { entry } from "./registry-fixture.mjs";
+
+function renderMetadata(overrides = {}) {
+  return {
+    schema_version: 2,
+    declarations: ["Example.theorem"],
+    imports: ["Mathlib"],
+    solution_imports: [],
+    module_doc: "A module note.",
+    ...overrides,
+  };
+}
+
+function fakeBrowser(href = "http://127.0.0.1:4173/entry.html") {
+  const listeners = new Map();
+  function createElement(tag) {
+    return {
+      attributes: new Map(),
+      children: [],
+      className: "",
+      contentWindow: tag === "iframe" ? {} : undefined,
+      dataset: {},
+      href: "",
+      style: {},
+      tagName: tag.toUpperCase(),
+      textContent: "",
+      append(...children) {
+        this.children.push(...children);
+      },
+      setAttribute(name, value) {
+        this.attributes.set(name, String(value));
+      },
+      getAttribute(name) {
+        return this.attributes.get(name) ?? null;
+      },
+    };
+  }
+  return {
+    document: { createElement },
+    listeners,
+    window: {
+      location: { href },
+      addEventListener(name, listener) {
+        const registered = listeners.get(name) || [];
+        registered.push(listener);
+        listeners.set(name, registered);
+      },
+    },
+  };
+}
+
+function descendants(root) {
+  const found = [];
+  const visit = (value) => {
+    if (!value || typeof value !== "object" || !Array.isArray(value.children)) return;
+    found.push(value);
+    value.children.forEach(visit);
+  };
+  visit(root);
+  return found;
+}
+
+function byClass(root, className) {
+  return descendants(root).filter((node) =>
+    String(node.className).split(" ").includes(className));
+}
+
+test("render metadata must correspond exactly to the accepted entry", async (t) => {
+  const record = entry();
+  const current = renderMetadata();
+  assert.equal(validateChallengeMetadata(record, current), current);
+  const versionOne = renderMetadata({ schema_version: 1 });
+  delete versionOne.solution_imports;
+  assert.equal(validateChallengeMetadata(record, versionOne), versionOne);
+
+  for (const [name, mutate, message] of [
+    ["boolean schema", (value) => { value.schema_version = true; }, /does not match/],
+    ["future schema", (value) => { value.schema_version = 3; }, /does not match/],
+    ["different declaration", (value) => { value.declarations = ["Other.theorem"]; }, /does not match/],
+    ["different import", (value) => { value.imports = ["Batteries"]; }, /does not match/],
+    ["oversized module note", (value) => { value.module_doc = "x".repeat(256 * 1024 + 1); }, /does not match/],
+    ["missing Solution imports", (value) => { delete value.solution_imports; }, /invalid Solution imports/],
+    ["non-string Solution import", (value) => { value.solution_imports = [true]; }, /invalid Solution imports/],
+  ]) {
+    await t.test(name, () => {
+      const malformed = renderMetadata();
+      mutate(malformed);
+      assert.throws(() => validateChallengeMetadata(record, malformed), message);
+    });
+  }
+});
+
+test("an inline presentation keeps links confined and accepts height only from its frame", async () => {
+  const browser = fakeBrowser();
+  const record = entry();
+  const metadata = renderMetadata({ module_doc: null });
+  let fetched = null;
+  const present = createChallengePresentation({
+    ...browser,
+    fetchJson: async (url) => {
+      fetched = url;
+      return metadata;
+    },
+    localPageUrl: () => assert.fail("the inline entry view should not build another page URL"),
+  });
+
+  const result = await present(
+    record,
+    new URL("http://127.0.0.1:4173/database/"),
+    { dependenciesOnThisPage: true },
+  );
+
+  assert.equal(
+    fetched.href,
+    `http://127.0.0.1:4173/database/${record.challenge_render.artifact_path}challenge-metadata.json`,
+  );
+  assert.equal(result.metadata, metadata);
+  assert.equal(byClass(result.section, "challenge-metadata").length, 1);
+  assert.equal(byClass(result.section, "challenge-no-module-doc").length, 1);
+  assert.equal(byClass(result.section, "challenge-fallback").length, 0);
+  const [frame] = byClass(result.section, "challenge-frame");
+  assert.ok(frame);
+  assert.equal(frame.getAttribute("sandbox"), "allow-scripts");
+  assert.equal(frame.getAttribute("scrolling"), "auto");
+  assert.equal(frame.referrerPolicy, "no-referrer");
+  assert.equal(
+    frame.src,
+    `http://127.0.0.1:4173/database/${record.challenge_render.artifact_path}Challenge/index.html`,
+  );
+  const [source] = byClass(result.section, "challenge-source");
+  assert.equal(
+    source.href,
+    `https://github.com/example/challenge/blob/${record.source.commit}/Challenge.lean`,
+  );
+
+  const [onMessage] = browser.listeners.get("message");
+  onMessage({ source: {}, data: { type: "palomar-render-height", height: 500 } });
+  assert.equal(frame.style.height, undefined);
+  const contentWindow = frame.contentWindow;
+  frame.contentWindow = null;
+  onMessage({ source: null, data: { type: "palomar-render-height", height: 500 } });
+  assert.equal(frame.style.height, undefined);
+  frame.contentWindow = contentWindow;
+  onMessage({ source: frame.contentWindow, data: { type: "palomar-render-height", height: 100 } });
+  assert.equal(frame.style.height, "160px");
+  assert.equal(frame.dataset.heightAdjusted, "true");
+  onMessage({ source: frame.contentWindow, data: { type: "palomar-render-height", height: 1_000 } });
+  assert.equal(frame.style.height, "672px");
+});
+
+test("a missing large entry render keeps its source controls and uses the missing-artifact fallback", async () => {
+  const browser = fakeBrowser();
+  const record = entry();
+  record.trust.challenge_lines = 101;
+  const pageCalls = [];
+  const missing = new Error("404 Not Found");
+  missing.status = 404;
+  const present = createChallengePresentation({
+    ...browser,
+    fetchJson: async () => { throw missing; },
+    localPageUrl: (page, selected) => {
+      pageCalls.push([page, selected]);
+      return new URL(`http://127.0.0.1:4173/${page}?id=${selected.id}&version=${selected.version}`);
+    },
+  });
+
+  const result = await present(record, new URL("http://127.0.0.1:4173/database/"));
+
+  assert.equal(result.metadata, null);
+  assert.equal(byClass(result.section, "challenge-frame").length, 0);
+  assert.equal(byClass(result.section, "challenge-metadata").length, 0);
+  const [fallback] = byClass(result.section, "challenge-fallback");
+  assert.match(fallback.textContent, /formatted statement is not available/);
+  assert.deepEqual(pageCalls.map(([page]) => page), ["entry.html", "render.html"]);
+  assert.ok(byClass(result.section, "challenge-source")[0].href.startsWith("https://github.com/"));
+});
+
+test("transport and correspondence failures remain fatal to the containing route", async (t) => {
+  const record = entry();
+  for (const [name, failure] of [
+    ["transport", Object.assign(new Error("503 Unavailable"), { status: 503 })],
+    ["correspondence", renderMetadata({ declarations: ["Other.theorem"] })],
+  ]) {
+    await t.test(name, async () => {
+      const browser = fakeBrowser();
+      const present = createChallengePresentation({
+        ...browser,
+        fetchJson: async () => {
+          if (failure instanceof Error) throw failure;
+          return failure;
+        },
+        localPageUrl: () => new URL("http://127.0.0.1:4173/entry.html"),
+      });
+      await assert.rejects(
+        present(record, new URL("http://127.0.0.1:4173/database/")),
+        failure instanceof Error ? /503 Unavailable/ : /does not match/,
+      );
+    });
+  }
+});

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -789,6 +789,25 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   await expect(rendered.locator("#theorem-end")).toBeInViewport();
 });
 
+test("a missing formatted Challenge leaves the accepted entry and pinned source usable", async ({ page }) => {
+  await page.route("**/challenge-metadata.json", (route) =>
+    route.fulfill({ status: 404, body: "not published" }));
+
+  await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`);
+
+  await expect(page.locator(".entry-heading h1")).toBeVisible();
+  await expect(page.locator(".entry-evidence")).toBeVisible();
+  await expect(page.locator(".challenge-fallback")).toContainText(
+    "The formatted statement is not available for this entry yet",
+  );
+  await expect(page.locator(".challenge-presentation iframe")).toHaveCount(0);
+  await expect(page.locator(".challenge-source")).toHaveAttribute(
+    "href",
+    `https://github.com/example/challenge/blob/${"1".repeat(40)}/project/Comparator/Task.lean`,
+  );
+  await expect(page.locator("#status")).toBeHidden();
+});
+
 test("larger Challenge falls back to the dedicated wrapper", async ({ page }) => {
   await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000124&version=1&database=${database}`);
   await expect(page.locator("#statement-dependencies")).toContainText(
@@ -799,6 +818,9 @@ test("larger Challenge falls back to the dedicated wrapper", async ({ page }) =>
   );
   await expect(page.locator(".challenge-presentation iframe")).toHaveCount(0);
   await expect(page.locator(".challenge-fallback")).toBeVisible();
+  await expect(page.locator(".challenge-fallback")).toContainText(
+    "This statement is too large to display here",
+  );
   await page.getByRole("link", { name: "Open formatted statement" }).click();
   await expect(page).toHaveURL(/render\.html\?id=PALOMAR-2026-07-29-000124/);
   await expect(page.locator(".challenge-presentation iframe")).toHaveAttribute(


### PR DESCRIPTION
## Summary

- extract the named-declarations/Challenge presentation controller from `assets/app.js` into a focused shipped browser module
- keep registry validation, source resolution, URL confinement, inline policy, loading, route state, and page composition in their existing owners
- add direct correspondence/DOM/iframe/fallback tests plus a browser regression for a missing formatted artifact
- extend the versioned deployment graph and architecture documentation for the new module

`assets/app.js` falls from 1,689 to 1,521 lines. The new production module is 212 lines and exposes the small adapter boundary `{ fetchJson, document, window, localPageUrl }`; there is no compatibility layer or generic DOM-builder abstraction.

## Deployment compatibility

The work was based on deployed merge `b646399c7c8f034dd51347e6212f5f84f7ea91ad`, after Pages run `31282636922` completed successfully and the live HTML/app/module URLs identified that merge. The build rewrites the new module and every import edge with the deployment version. Both previous-deployment Playwright cases pass, covering cached-old/fresh-new adjacent deployments.

## Validation

- `PALOMAR_DATABASE_CHECKOUT=$(realpath ../PalomarDatabase) npm test` — 129/129 passed against Database `4cf7aa36f5cceb6b9ab99e65020f36ad0a6de04b`
- `npm run build -- --version b646399c7c8f034dd51347e6212f5f84f7ea91ad --output .site` — passed
- `PALOMAR_PREVIOUS_REF=b646399c7c8f034dd51347e6212f5f84f7ea91ad npm run test:browser` — 54/54 passed, including both previous-deployment cases
- `node scripts/check-published.mjs --data https://data.palomar-registry.org` — reconciled all 1 active entry versions across 1 result
- `node scripts/check-published.mjs --links` — all four published documentation links passed
- `node --check assets/app.js && node --check assets/challenge-presentation.mjs` — passed
- `git diff --check b646399c7c8f034dd51347e6212f5f84f7ea91ad..HEAD` — passed

Draft only: no merge or deployment has been performed. Exact-head Actions must pass before merge.
