### PR TITLE
Extract formalization presentation from app monolith

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,10 @@
   dispatch, and route-level errors. `assets/challenge-presentation.mjs` owns the
   named-declarations render metadata's correspondence to the accepted entry,
   its source/dependency controls, inline-versus-wrapper presentation, iframe
-  sandbox/height handling, and the missing-artifact fallback;
+  sandbox/height handling, and the missing-artifact fallback.
+  `assets/formalization-presentation.mjs` owns statement trust labels plus the
+  statement and accepted-proof dependency DOM, while continuing to consume
+  source locations and confined URLs from their existing owners;
   `assets/app.js` owns data loading and remaining page composition. Do not
   duplicate registry-document validation, source resolution, or route
   orchestration across those modules; the route module still rejects malformed

--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ freshness, `source-preservation.mjs` matches validated manifest observations to
 the preservation receipt before resolving repository locations and decorating
 existing cards, `entry-pages.mjs` owns entry-route input and page-state
 transitions, `challenge-presentation.mjs` owns the named-declarations artifact's
-entry correspondence and presentation states, and `app.js` loads records and
-composes the remaining page-level views.
+entry correspondence and presentation states, `formalization-presentation.mjs`
+owns statement trust labels and the statement/proof dependency presentation,
+and `app.js` loads records and composes the remaining page-level views.
 
 Runtime reads use the browser's normal HTTP cache behavior. The public data
 service gives successful documents a 60-second browser/shared-cache lifetime,

--- a/assets/app.js
+++ b/assets/app.js
@@ -28,9 +28,9 @@ import {
   renderEntryPage,
 } from "./entry-pages.mjs";
 import { createChallengePresentation } from "./challenge-presentation.mjs";
+import { createFormalizationPresentation } from "./formalization-presentation.mjs";
 import {
   decorateCardSet,
-  sourceDirectoryUrl,
   sourceFileUrl,
   sourceLocation,
   topSourceLocation,
@@ -215,14 +215,11 @@ function displayTimestamp(value) {
   }).format(when)} UTC`;
 }
 
-function trustBadge(entry) {
-  const high = entry.trust.level === "high";
-  const badge = el("span", `trust-badge ${high ? "high" : "qualified"}`);
-  badge.textContent = high
-    ? "Statement dependencies: Mathlib only"
-    : "Statement dependencies: additional libraries";
-  return badge;
-}
+const {
+  solutionMetadata,
+  statementDependencies,
+  trustBadge,
+} = createFormalizationPresentation({ document });
 
 function entryCard(
   entry,
@@ -1113,91 +1110,6 @@ function provenanceSection(entry, availability) {
   return section;
 }
 
-function solutionMetadata(entry, renderMetadata, availability) {
-  const section = el("section", "entry-solution");
-  const heading = el("div", "section-heading");
-  const title = el("div");
-  title.append(el("div", "eyebrow", "Accepted proof"), el("h2", "", "Verified proof"));
-  heading.append(title, el("span", "decision accepted-decision", "Accepted"));
-  section.append(heading);
-  section.append(
-    el(
-      "p",
-      "solution-summary",
-      "Lean checked the accepted proof using the exact versions of the source files and libraries listed below.",
-    ),
-  );
-
-  const details = el("dl", "details solution-details");
-  details.append(
-    externalDetailRow(
-      "Proof file",
-      entry.formalization.solution_path,
-      sourceFileUrl(entry, entry.formalization.solution_path, availability),
-    ),
-    detailRow("Proof file checksum (SHA-256)", entry.verification.solution_sha256),
-  );
-  if (renderMetadata?.schema_version >= 2) {
-    const row = el("div", "detail-row");
-    row.append(el("dt", "", "Libraries imported by the proof"));
-    const value = el("dd", "token-list");
-    for (const item of renderMetadata.solution_imports) value.append(el("code", "", item));
-    row.append(value);
-    details.append(row);
-  }
-  section.append(details);
-
-  const dependencies = entry.formalization.project_dependencies;
-  const closure = el("details", "solution-dependencies");
-  closure.append(
-    el(
-      "summary",
-      "",
-      `${dependencies.length} project dependencies used by the proof`,
-    ),
-  );
-  const list = el("ul", "dependency-list");
-  for (const dependency of dependencies) {
-    const item = el("li");
-    if (dependency.path !== undefined) {
-      item.append(
-        externalLink(
-          dependency.name,
-          sourceDirectoryUrl(entry, dependency.path, availability),
-        ),
-        el("code", "", dependency.path),
-      );
-    } else {
-      const location = sourceLocation(
-        entry,
-        availability,
-        dependency.repository,
-        dependency.revision,
-      );
-      item.append(
-        externalLink(
-          location.useArchive ? `${dependency.repository} (Palomar copy)` : dependency.repository,
-          pinnedRepositoryDirectoryUrl(location.repository, dependency.revision),
-        ),
-        el("code", "", dependency.revision.slice(0, 12)),
-      );
-      if (!location.useArchive) {
-        item.append(
-          " · ",
-          externalLink(
-            "Palomar preserved copy",
-            pinnedRepositoryDirectoryUrl(location.archiveRepository, dependency.revision),
-          ),
-        );
-      }
-    }
-    list.append(item);
-  }
-  closure.append(list);
-  section.append(closure);
-  return section;
-}
-
 async function renderEntry(
   entry,
   content,
@@ -1320,39 +1232,7 @@ async function renderEntry(
     );
   }
 
-  const trust = el("section", "entry-trust");
-  trust.id = "statement-dependencies";
-  const trustTitle = el("div", "section-heading");
-  const trustBlock = el("div");
-  trustBlock.append(
-    el("div", "eyebrow", "Statement dependencies"),
-    el(
-      "h2",
-      "",
-      entry.trust.level === "high"
-        ? "Depends only on Mathlib"
-        : "Depends on additional libraries",
-    ),
-  );
-  trustTitle.append(trustBlock, trustBadge(entry));
-  trust.append(trustTitle);
-  const imports = el("div", "token-list");
-  for (const item of entry.trust.challenge_imports) imports.append(el("code", "", item));
-  trust.append(el("h3", "", "Libraries imported by the statement"), imports);
-  if (entry.trust.challenge_dependencies.length) {
-    trust.append(el("h3", "", "Source repositories"));
-    const dependencies = el("ul", "plain-list");
-    for (const dependency of entry.trust.challenge_dependencies) {
-      dependencies.append(el("li", "", dependency.repository));
-    }
-    trust.append(dependencies);
-  }
-  if (entry.trust.reasons.length) {
-    trust.append(el("h3", "", "Why additional libraries are needed"));
-    const reasons = el("ul", "reason-list");
-    for (const reason of entry.trust.reasons) reasons.append(el("li", "", reason));
-    trust.append(reasons);
-  }
+  const trust = statementDependencies(entry);
 
   const editorial = el("section", "entry-editorial");
   const editorialTitle = el("div", "section-heading");

--- a/assets/formalization-presentation.mjs
+++ b/assets/formalization-presentation.mjs
@@ -1,0 +1,179 @@
+import {
+  pinnedRepositoryDirectoryUrl,
+  safeExternalUrl,
+} from "./security.mjs";
+import {
+  sourceDirectoryUrl,
+  sourceFileUrl,
+  sourceLocation,
+} from "./source-preservation.mjs";
+
+/**
+ * Bind the statement and proof dependency presentation to its DOM adapter.
+ *
+ * Entry validation, source preservation, URL confinement, artifact metadata,
+ * and page composition remain in their existing modules. This boundary owns
+ * only the trust label and the statement/proof dependency DOM presented from
+ * those accepted inputs.
+ */
+export function createFormalizationPresentation({ document }) {
+  function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined) node.textContent = text;
+    return node;
+  }
+
+  function externalLink(text, href) {
+    const node = el("a", "", text);
+    node.href = safeExternalUrl(href).href;
+    return node;
+  }
+
+  function detailRow(label, value) {
+    const row = el("div", "detail-row");
+    row.append(el("dt", "", label), el("dd", "", String(value)));
+    return row;
+  }
+
+  function trustBadge(entry) {
+    const high = entry.trust.level === "high";
+    const badge = el("span", `trust-badge ${high ? "high" : "qualified"}`);
+    badge.textContent = high
+      ? "Statement dependencies: Mathlib only"
+      : "Statement dependencies: additional libraries";
+    return badge;
+  }
+
+  function statementDependencies(entry) {
+    const section = el("section", "entry-trust");
+    section.id = "statement-dependencies";
+    const heading = el("div", "section-heading");
+    const title = el("div");
+    title.append(
+      el("div", "eyebrow", "Statement dependencies"),
+      el(
+        "h2",
+        "",
+        entry.trust.level === "high"
+          ? "Depends only on Mathlib"
+          : "Depends on additional libraries",
+      ),
+    );
+    heading.append(title, trustBadge(entry));
+    section.append(heading);
+    const imports = el("div", "token-list");
+    for (const item of entry.trust.challenge_imports) imports.append(el("code", "", item));
+    section.append(el("h3", "", "Libraries imported by the statement"), imports);
+    if (entry.trust.challenge_dependencies.length) {
+      section.append(el("h3", "", "Source repositories"));
+      const dependencies = el("ul", "plain-list");
+      for (const dependency of entry.trust.challenge_dependencies) {
+        dependencies.append(el("li", "", dependency.repository));
+      }
+      section.append(dependencies);
+    }
+    if (entry.trust.reasons.length) {
+      section.append(el("h3", "", "Why additional libraries are needed"));
+      const reasons = el("ul", "reason-list");
+      for (const reason of entry.trust.reasons) reasons.append(el("li", "", reason));
+      section.append(reasons);
+    }
+    return section;
+  }
+
+  function solutionMetadata(entry, renderMetadata, availability) {
+    const section = el("section", "entry-solution");
+    const heading = el("div", "section-heading");
+    const title = el("div");
+    title.append(el("div", "eyebrow", "Accepted proof"), el("h2", "", "Verified proof"));
+    heading.append(title, el("span", "decision accepted-decision", "Accepted"));
+    section.append(heading);
+    section.append(
+      el(
+        "p",
+        "solution-summary",
+        "Lean checked the accepted proof using the exact versions of the source files and libraries listed below.",
+      ),
+    );
+
+    const details = el("dl", "details solution-details");
+    const proofRow = el("div", "detail-row");
+    proofRow.append(el("dt", "", "Proof file"));
+    const proofValue = el("dd");
+    proofValue.append(
+      externalLink(
+        entry.formalization.solution_path,
+        sourceFileUrl(entry, entry.formalization.solution_path, availability),
+      ),
+    );
+    proofRow.append(proofValue);
+    details.append(
+      proofRow,
+      detailRow("Proof file checksum (SHA-256)", entry.verification.solution_sha256),
+    );
+    if (renderMetadata?.schema_version >= 2) {
+      const row = el("div", "detail-row");
+      row.append(el("dt", "", "Libraries imported by the proof"));
+      const value = el("dd", "token-list");
+      for (const item of renderMetadata.solution_imports) value.append(el("code", "", item));
+      row.append(value);
+      details.append(row);
+    }
+    section.append(details);
+
+    const dependencies = entry.formalization.project_dependencies;
+    const closure = el("details", "solution-dependencies");
+    closure.append(
+      el(
+        "summary",
+        "",
+        `${dependencies.length} project dependencies used by the proof`,
+      ),
+    );
+    const list = el("ul", "dependency-list");
+    for (const dependency of dependencies) {
+      const item = el("li");
+      if (dependency.path !== undefined) {
+        item.append(
+          externalLink(
+            dependency.name,
+            sourceDirectoryUrl(entry, dependency.path, availability),
+          ),
+          el("code", "", dependency.path),
+        );
+      } else {
+        const location = sourceLocation(
+          entry,
+          availability,
+          dependency.repository,
+          dependency.revision,
+        );
+        item.append(
+          externalLink(
+            location.useArchive
+              ? `${dependency.repository} (Palomar copy)`
+              : dependency.repository,
+            pinnedRepositoryDirectoryUrl(location.repository, dependency.revision),
+          ),
+          el("code", "", dependency.revision.slice(0, 12)),
+        );
+        if (!location.useArchive) {
+          item.append(
+            " · ",
+            externalLink(
+              "Palomar preserved copy",
+              pinnedRepositoryDirectoryUrl(location.archiveRepository, dependency.revision),
+            ),
+          );
+        }
+      }
+      list.append(item);
+    }
+    closure.append(list);
+    section.append(closure);
+    return section;
+  }
+
+  return { solutionMetadata, statementDependencies, trustBadge };
+}

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -10,6 +10,7 @@ const browserModuleFiles = [
   "app.js",
   "challenge-presentation.mjs",
   "entry-pages.mjs",
+  "formalization-presentation.mjs",
   "loading.mjs",
   "rendering.js",
   "searching.mjs",

--- a/tests/build-site.test.js
+++ b/tests/build-site.test.js
@@ -26,6 +26,10 @@ test("deployment build versions coupled browser assets", async () => {
       path.join(destination, "assets", "challenge-presentation.mjs"),
       "utf8",
     );
+    const formalizationPresentation = await readFile(
+      path.join(destination, "assets", "formalization-presentation.mjs"),
+      "utf8",
+    );
     await readFile(path.join(destination, "assets", "entry-pages.mjs"), "utf8");
     const preservation = await readFile(
       path.join(destination, "assets", "source-preservation.mjs"),
@@ -46,6 +50,7 @@ test("deployment build versions coupled browser assets", async () => {
     await readFile(path.join(destination, "assets", "about.js"), "utf8");
     assert.match(app, /\.\/challenge-presentation\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/entry-pages\.mjs\?v=0123456789abcdef/);
+    assert.match(app, /\.\/formalization-presentation\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/security\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/loading\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/searching\.mjs\?v=0123456789abcdef/);
@@ -56,6 +61,11 @@ test("deployment build versions coupled browser assets", async () => {
     assert.match(challengePresentation, /\.\/security\.mjs\?v=0123456789abcdef/);
     assert.match(
       challengePresentation,
+      /\.\/source-preservation\.mjs\?v=0123456789abcdef/,
+    );
+    assert.match(formalizationPresentation, /\.\/security\.mjs\?v=0123456789abcdef/);
+    assert.match(
+      formalizationPresentation,
       /\.\/source-preservation\.mjs\?v=0123456789abcdef/,
     );
     assert.match(searching, /\.\/loading\.mjs\?v=0123456789abcdef/);

--- a/tests/formalization-presentation.test.mjs
+++ b/tests/formalization-presentation.test.mjs
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createFormalizationPresentation } from "../assets/formalization-presentation.mjs";
+import { validateAvailability } from "../assets/security.mjs";
+import {
+  COMMIT,
+  availabilityEndpoint,
+  availabilityManifest,
+  availabilityRow,
+  entry,
+} from "./registry-fixture.mjs";
+
+const CHECKED_AT = new Date(Math.floor(Date.now() / 1_000) * 1_000)
+  .toISOString()
+  .replace(".000Z", "Z");
+
+function fakeDocument() {
+  return {
+    createElement(tag) {
+      return {
+        children: [],
+        className: "",
+        href: "",
+        id: "",
+        tagName: tag.toUpperCase(),
+        textContent: "",
+        append(...children) {
+          this.children.push(...children);
+        },
+      };
+    },
+  };
+}
+
+function descendants(root) {
+  const found = [];
+  const visit = (value) => {
+    if (!value || typeof value !== "object" || !Array.isArray(value.children)) return;
+    found.push(value);
+    value.children.forEach(visit);
+  };
+  visit(root);
+  return found;
+}
+
+function byClass(root, className) {
+  return descendants(root).filter((node) =>
+    String(node.className).split(" ").includes(className));
+}
+
+function byTag(root, tagName) {
+  return descendants(root).filter((node) => node.tagName === tagName.toUpperCase());
+}
+
+function texts(root, tagName) {
+  return byTag(root, tagName).map((node) => node.textContent);
+}
+
+test("the trust badge and statement dependency section present the accepted trust record", () => {
+  const presentation = createFormalizationPresentation({ document: fakeDocument() });
+  const high = entry();
+  assert.equal(
+    presentation.trustBadge(high).textContent,
+    "Statement dependencies: Mathlib only",
+  );
+  const highSection = presentation.statementDependencies(high);
+  assert.equal(highSection.id, "statement-dependencies");
+  assert.ok(texts(highSection, "h2").includes("Depends only on Mathlib"));
+  assert.deepEqual(texts(highSection, "code"), ["Mathlib"]);
+  assert.equal(byClass(highSection, "reason-list").length, 0);
+
+  const qualified = entry();
+  qualified.trust = {
+    ...qualified.trust,
+    level: "qualified",
+    challenge_imports: ["Mathlib", "TauCeti"],
+    challenge_dependencies: [{ repository: "TauCetiProject/TauCeti" }],
+    reasons: ["The statement uses a domain-specific definition."],
+  };
+  assert.equal(
+    presentation.trustBadge(qualified).textContent,
+    "Statement dependencies: additional libraries",
+  );
+  const section = presentation.statementDependencies(qualified);
+  assert.ok(texts(section, "h2").includes("Depends on additional libraries"));
+  assert.deepEqual(texts(section, "code"), ["Mathlib", "TauCeti"]);
+  assert.deepEqual(texts(byClass(section, "plain-list")[0], "li"), [
+    "TauCetiProject/TauCeti",
+  ]);
+  assert.deepEqual(texts(byClass(section, "reason-list")[0], "li"), [
+    "The statement uses a domain-specific definition.",
+  ]);
+});
+
+test("the proof section presents imports and every preserved dependency kind", () => {
+  const { solutionMetadata } = createFormalizationPresentation({ document: fakeDocument() });
+  const record = entry();
+  record.formalization.project_dependencies.unshift({ name: "shared", path: "shared" });
+  const section = solutionMetadata(
+    record,
+    { schema_version: 2, solution_imports: ["ExampleDependency"] },
+    null,
+  );
+
+  assert.equal(section.className, "entry-solution");
+  assert.deepEqual(texts(section, "code"), [
+    "ExampleDependency",
+    "shared",
+    COMMIT.slice(0, 12),
+  ]);
+  assert.ok(texts(section, "summary").includes("2 project dependencies used by the proof"));
+  const links = byTag(section, "a");
+  assert.deepEqual(links.map((link) => link.textContent), [
+    "Solution.lean",
+    "shared",
+    "leanprover-community/mathlib4",
+    "Palomar preserved copy",
+  ]);
+  assert.equal(
+    links[0].href,
+    `https://github.com/example/challenge/blob/${COMMIT}/Solution.lean`,
+  );
+  assert.equal(
+    links[1].href,
+    `https://github.com/example/challenge/tree/${COMMIT}/shared`,
+  );
+  assert.equal(
+    links[3].href,
+    `https://github.com/PalomarArchive/mathlib4--fixture/tree/${COMMIT}`,
+  );
+});
+
+test("confirmed missing originals switch the proof and dependency links to their copies", () => {
+  const { solutionMetadata } = createFormalizationPresentation({ document: fakeDocument() });
+  const record = entry();
+  const missing = availabilityEndpoint({ status: "missing", checked_at: CHECKED_AT });
+  const availability = validateAvailability(availabilityManifest([
+    availabilityRow({ original: missing }),
+    availabilityRow({
+      source_repository: "leanprover-community/mathlib4",
+      fork_repository: "PalomarArchive/mathlib4--fixture",
+      original: missing,
+    }),
+  ], { generated_at: CHECKED_AT }));
+  const section = solutionMetadata(record, { schema_version: 1 }, availability);
+  const links = byTag(section, "a");
+
+  assert.deepEqual(texts(section, "code"), [COMMIT.slice(0, 12)]);
+  assert.deepEqual(links.map((link) => link.textContent), [
+    "Solution.lean",
+    "leanprover-community/mathlib4 (Palomar copy)",
+  ]);
+  assert.equal(
+    links[0].href,
+    `https://github.com/PalomarArchive/example--challenge--fixture/blob/${COMMIT}/Solution.lean`,
+  );
+  assert.equal(
+    links[1].href,
+    `https://github.com/PalomarArchive/mathlib4--fixture/tree/${COMMIT}`,
+  );
+});

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -836,6 +836,37 @@ test("larger Challenge falls back to the dedicated wrapper", async ({ page }) =>
   await expect(page.locator("#statement-dependencies")).toBeInViewport();
 });
 
+test("qualified statement and proof dependencies retain their distinct presentation", async ({ page }) => {
+  await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000124&version=1&database=${database}`);
+
+  const statement = page.locator("#statement-dependencies");
+  await expect(statement.getByRole("heading", { name: "Depends on additional libraries" }))
+    .toBeVisible();
+  await expect(statement.locator(".trust-badge")).toHaveText(
+    "Statement dependencies: additional libraries",
+  );
+  await expect(statement.locator(".plain-list li")).toHaveText([
+    "leanprover-community/mathlib4",
+    "TauCetiProject/TauCeti",
+  ]);
+  await expect(statement.locator(".reason-list li")).toHaveText("Challenge imports Tau Ceti");
+
+  const proof = page.locator(".entry-solution");
+  await expect(proof.getByRole("heading", { name: "Verified proof" })).toBeVisible();
+  await expect(proof.locator(".solution-dependencies summary")).toHaveText(
+    "1 project dependencies used by the proof",
+  );
+  await proof.locator(".solution-dependencies summary").click();
+  await expect(proof.getByRole("link", { name: "example/dependency" })).toHaveAttribute(
+    "href",
+    `https://github.com/example/dependency/tree/${"3".repeat(40)}`,
+  );
+  await expect(proof.getByRole("link", { name: "Palomar preserved copy" })).toHaveAttribute(
+    "href",
+    `https://github.com/PalomarArchive/example--dependency/tree/${"3".repeat(40)}`,
+  );
+});
+
 test("current HTML remains compatible with cached JavaScript from the previous deployment", async ({ page }) => {
   test.skip(!previousRef, "PALOMAR_PREVIOUS_REF is only set in deployment and pull-request CI");
   test.skip(


### PR DESCRIPTION
## Summary

- extract statement-trust and accepted-proof dependency presentation from `assets/app.js` into a focused shipped browser module
- keep entry validation, URL confinement, source-preservation decisions, Challenge artifact handling, loading, search, routes, and page composition in their existing owners
- add direct module tests for high/qualified trust, statement imports/reasons, proof imports, local/external dependencies, preservation links, and confirmed archive switching
- extend the versioned browser graph, architecture documentation, and Playwright coverage for the qualified statement/proof boundary

`assets/app.js` falls from 1,521 to 1,401 lines. The new 179-line production module has the single explicit adapter `{ document }`; there is no compatibility layer or shared DOM-builder abstraction.

## Deployment compatibility

The work is based on deployed merge `88f1495a9661c21e382b170bbefdf747abfca119`, after Pages run `31283341058` completed both test and deployment jobs successfully and live HTML/app/module URLs identified that exact merge. The build ships the new module and versions every local edge. Both previous-deployment Playwright cases pass, covering cached-old/fresh-new adjacent deployments.

## Validation

- `PALOMAR_DATABASE_CHECKOUT=$(realpath ../PalomarDatabase) npm test` — 132/132 passed against Database `9fc7a5ad5dc9f595213844a781669818804aa68a`
- `npm run build -- --version 88f1495a9661c21e382b170bbefdf747abfca119 --output .site` — passed
- `PALOMAR_PREVIOUS_REF=88f1495a9661c21e382b170bbefdf747abfca119 npm run test:browser` — 55/55 passed, including both previous-deployment cases
- `node scripts/check-published.mjs --data https://data.palomar-registry.org` — accepted all 1 active versions across 1 result
- `node scripts/check-published.mjs --links` — all four published documentation links passed
- syntax and `git diff --check` — passed

Draft only: no merge or deployment has been performed. Exact-head Actions must pass before merge.
