### PR TITLE
Extract immutable entry history presentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,9 @@
   `assets/formalization-presentation.mjs` owns statement trust labels plus the
   statement and accepted-proof dependency DOM, while continuing to consume
   source locations and confined URLs from their existing owners;
+  `assets/entry-history-presentation.mjs` owns canonical entry links,
+  supersession notices, and the immutable version-history DOM, while consuming
+  validated records and the existing confined local-entry URL builder;
   `assets/app.js` owns data loading and remaining page composition. Do not
   duplicate registry-document validation, source resolution, or route
   orchestration across those modules; the route module still rejects malformed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,8 @@
   `assets/formalization-presentation.mjs` owns statement trust labels plus the
   statement and accepted-proof dependency DOM, while continuing to consume
   source locations and confined URLs from their existing owners;
-  `assets/entry-history-presentation.mjs` owns canonical entry links,
-  supersession notices, and the immutable version-history DOM, while consuming
+  `assets/entry-history-presentation.mjs` owns the entry page's canonical link,
+  supersession notice, and immutable version-history section, while consuming
   validated records and the existing confined local-entry URL builder;
   `assets/app.js` owns data loading and remaining page composition. Do not
   duplicate registry-document validation, source resolution, or route

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ existing cards, `entry-pages.mjs` owns entry-route input and page-state
 transitions, `challenge-presentation.mjs` owns the named-declarations artifact's
 entry correspondence and presentation states, `formalization-presentation.mjs`
 owns statement trust labels and the statement/proof dependency presentation,
-`entry-history-presentation.mjs` owns canonical entry links, supersession
-notices, and immutable version-history presentation, and `app.js` loads records
-and composes the remaining page-level views.
+`entry-history-presentation.mjs` owns the entry page's canonical link,
+supersession notice, and immutable version-history section, and `app.js` loads
+records and composes the remaining page-level views.
 
 Runtime reads use the browser's normal HTTP cache behavior. The public data
 service gives successful documents a 60-second browser/shared-cache lifetime,

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ existing cards, `entry-pages.mjs` owns entry-route input and page-state
 transitions, `challenge-presentation.mjs` owns the named-declarations artifact's
 entry correspondence and presentation states, `formalization-presentation.mjs`
 owns statement trust labels and the statement/proof dependency presentation,
-and `app.js` loads records and composes the remaining page-level views.
+`entry-history-presentation.mjs` owns canonical entry links, supersession
+notices, and immutable version-history presentation, and `app.js` loads records
+and composes the remaining page-level views.
 
 Runtime reads use the browser's normal HTTP cache behavior. The public data
 service gives successful documents a 60-second browser/shared-cache lifetime,

--- a/assets/app.js
+++ b/assets/app.js
@@ -28,6 +28,7 @@ import {
   renderEntryPage,
 } from "./entry-pages.mjs";
 import { createChallengePresentation } from "./challenge-presentation.mjs";
+import { createEntryHistoryPresentation } from "./entry-history-presentation.mjs";
 import { createFormalizationPresentation } from "./formalization-presentation.mjs";
 import {
   decorateCardSet,
@@ -35,8 +36,6 @@ import {
   sourceLocation,
   topSourceLocation,
 } from "./source-preservation.mjs";
-
-const CANONICAL_WEB_BASE = "https://palomar-registry.org/";
 
 const params = new URLSearchParams(window.location.search);
 const ARXIV_FILTER_RE = /^[a-z]+(?:-[a-z]+)*(?:\.[A-Za-z-]+)?$/;
@@ -710,95 +709,11 @@ const challengePresentation = createChallengePresentation({
   localPageUrl,
 });
 
-function canonicalEntryPageUrl(entry) {
-  const target = new URL("entry.html", CANONICAL_WEB_BASE);
-  target.searchParams.set("id", entry.id);
-  target.searchParams.set("version", String(entry.version));
-  return safeExternalUrl(target);
-}
-
-function setCanonicalEntryPage(entry) {
-  let canonical = document.querySelector('link[rel="canonical"]');
-  if (!canonical) {
-    canonical = document.createElement("link");
-    canonical.rel = "canonical";
-    document.head.append(canonical);
-  }
-  canonical.href = canonicalEntryPageUrl(entry).href;
-}
-
-function versionNotice(entry, currentVersion) {
-  if (entry.version === currentVersion) return null;
-  const notice = el("aside", "version-notice");
-  const heading = el("h2", "", "Newer version available");
-  heading.id = "newer-version-heading";
-  notice.setAttribute("aria-labelledby", heading.id);
-  notice.append(
-    heading,
-    el(
-      "p",
-      "",
-      `You are viewing immutable version ${entry.version}. Version ${currentVersion} is the current version of this record.`,
-    ),
-  );
-  notice.append(
-    internalLink(
-      `View current version ${currentVersion}`,
-      localPageUrl("entry.html", { id: entry.id, version: currentVersion }),
-    ),
-  );
-  return notice;
-}
-
-function versionHistory(entry, versions, currentVersion) {
-  const section = el("section", "version-history");
-  section.id = "version-history";
-  section.setAttribute("aria-labelledby", "version-history-heading");
-  const heading = el("div", "section-heading");
-  const title = el("div");
-  title.append(
-    el("div", "eyebrow", "Registry history"),
-    el("h2", "", "Versions"),
-  );
-  title.querySelector("h2").id = "version-history-heading";
-  heading.append(title);
-  section.append(
-    heading,
-    el(
-      "p",
-      "version-history-intro",
-      "Every version is an immutable accepted snapshot. The authorship, statement, proof, review comments, and dependency information on this page belong to the selected version only.",
-    ),
-  );
-
-  const list = el("ol", "version-list");
-  list.reversed = true;
-  list.setAttribute("role", "list");
-  for (const summary of [...versions].reverse()) {
-    const item = el("li");
-    const label = `Version ${summary.version}`;
-    if (summary.version === entry.version) {
-      const selected = el("strong", "selected-version", label);
-      selected.setAttribute("aria-current", "true");
-      item.append(selected);
-    } else {
-      item.append(internalLink(label, localPageUrl("entry.html", summary)));
-    }
-    item.append(
-      el(
-        "span",
-        `version-state ${summary.version === currentVersion ? "current" : "superseded"}`,
-        summary.version === currentVersion ? "Current" : "Superseded",
-      ),
-    );
-    if (summary.version === entry.version) {
-      item.append(el("span", "viewing-version", "Viewing"));
-    }
-    list.append(item);
-  }
-  section.append(list);
-  return section;
-}
+const {
+  setCanonicalEntryPage,
+  versionHistory,
+  versionNotice,
+} = createEntryHistoryPresentation({ document, localPageUrl, window });
 
 /** One kind of assurance, named so the two can be told apart at a glance. */
 function assurance(kind, sentence) {

--- a/assets/entry-history-presentation.mjs
+++ b/assets/entry-history-presentation.mjs
@@ -1,0 +1,115 @@
+import { safeExternalUrl, safeInternalUrl } from "./security.mjs";
+
+const CANONICAL_WEB_BASE = "https://palomar-registry.org/";
+
+/**
+ * Bind immutable-version history presentation to the page's DOM and local URL
+ * builder. Entry/version validation, route orchestration, and page composition
+ * remain with their existing owners; this boundary receives only validated
+ * records and version summaries.
+ */
+export function createEntryHistoryPresentation({ document, localPageUrl, window }) {
+  function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined) node.textContent = text;
+    return node;
+  }
+
+  function localLink(text, entry) {
+    const node = el("a", "", text);
+    node.href = safeInternalUrl(
+      localPageUrl("entry.html", entry),
+      window.location.href,
+    ).href;
+    return node;
+  }
+
+  function canonicalEntryPageUrl(entry) {
+    const target = new URL("entry.html", CANONICAL_WEB_BASE);
+    target.searchParams.set("id", entry.id);
+    target.searchParams.set("version", String(entry.version));
+    return safeExternalUrl(target);
+  }
+
+  function setCanonicalEntryPage(entry) {
+    let canonical = document.querySelector('link[rel="canonical"]');
+    if (!canonical) {
+      canonical = document.createElement("link");
+      canonical.rel = "canonical";
+      document.head.append(canonical);
+    }
+    canonical.href = canonicalEntryPageUrl(entry).href;
+  }
+
+  function versionNotice(entry, currentVersion) {
+    if (entry.version === currentVersion) return null;
+    const notice = el("aside", "version-notice");
+    const heading = el("h2", "", "Newer version available");
+    heading.id = "newer-version-heading";
+    notice.setAttribute("aria-labelledby", heading.id);
+    notice.append(
+      heading,
+      el(
+        "p",
+        "",
+        `You are viewing immutable version ${entry.version}. Version ${currentVersion} is the current version of this record.`,
+      ),
+      localLink(
+        `View current version ${currentVersion}`,
+        { id: entry.id, version: currentVersion },
+      ),
+    );
+    return notice;
+  }
+
+  function versionHistory(entry, versions, currentVersion) {
+    const section = el("section", "version-history");
+    section.id = "version-history";
+    section.setAttribute("aria-labelledby", "version-history-heading");
+    const heading = el("div", "section-heading");
+    const title = el("div");
+    const titleHeading = el("h2", "", "Versions");
+    titleHeading.id = "version-history-heading";
+    title.append(el("div", "eyebrow", "Registry history"), titleHeading);
+    heading.append(title);
+    section.append(
+      heading,
+      el(
+        "p",
+        "version-history-intro",
+        "Every version is an immutable accepted snapshot. The authorship, statement, proof, review comments, and dependency information on this page belong to the selected version only.",
+      ),
+    );
+
+    const list = el("ol", "version-list");
+    list.reversed = true;
+    list.setAttribute("role", "list");
+    for (const summary of [...versions].reverse()) {
+      const item = el("li");
+      const label = `Version ${summary.version}`;
+      if (summary.version === entry.version) {
+        const selected = el("strong", "selected-version", label);
+        selected.setAttribute("aria-current", "true");
+        item.append(selected);
+      } else {
+        item.append(localLink(label, summary));
+      }
+      item.append(
+        el(
+          "span",
+          `version-state ${summary.version === currentVersion ? "current" : "superseded"}`,
+          summary.version === currentVersion ? "Current" : "Superseded",
+        ),
+      );
+      if (summary.version === entry.version) {
+        item.append(el("span", "viewing-version", "Viewing"));
+      }
+      list.append(item);
+    }
+    section.append(list);
+    return section;
+  }
+
+  return { setCanonicalEntryPage, versionHistory, versionNotice };
+}

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -9,6 +9,7 @@ const browserModuleFiles = [
   "about.js",
   "app.js",
   "challenge-presentation.mjs",
+  "entry-history-presentation.mjs",
   "entry-pages.mjs",
   "formalization-presentation.mjs",
   "loading.mjs",

--- a/tests/build-site.test.js
+++ b/tests/build-site.test.js
@@ -186,7 +186,7 @@ test("the MSC descriptions shown to readers are readable", async () => {
 test("the app graph writes down no data origin the database override cannot redirect", async () => {
   // `?database=` names the endpoint every read surface is resolved against, so
   // a fixture directory can stand in for the live service. A data URL spelled
-  // out as a literal in app.js is outside that arrangement by construction.
+  // out in a consumer module is outside that arrangement by construction.
   // `FEED_BASE` and the `categoryFeedBase()` that read it were the last of
   // those: they outlived the category feed links, which were removed when
   // every one of them answered 404, and went on naming a `feeds/` directory
@@ -194,16 +194,22 @@ test("the app graph writes down no data origin the database override cannot redi
   // is a different thing and stays in the history presenter, because an
   // entry's canonical link has to point at the official URL even when the page
   // is being read from a fixture.
-  const app = await readFile(new URL("../assets/app.js", import.meta.url), "utf8");
   const entryHistory = await readFile(
     new URL("../assets/entry-history-presentation.mjs", import.meta.url),
     "utf8",
   );
-  assert.equal(
-    app.includes("data.palomar-registry.org"),
-    false,
-    "app.js names the data origin directly instead of resolving against the chosen endpoint",
-  );
+  // security.mjs owns the canonical DEFAULT_* endpoints that the loopback
+  // override selects away from. Every consumer must resolve against that
+  // selected endpoint rather than spelling out the production data origin.
+  for (const file of shippedFiles.filter((name) => /^assets\/.*\.m?js$/.test(name))) {
+    if (file === "assets/security.mjs") continue;
+    const source = await readFile(new URL(`../${file}`, import.meta.url), "utf8");
+    assert.equal(
+      source.includes("data.palomar-registry.org"),
+      false,
+      `${file} names the data origin directly instead of resolving against the chosen endpoint`,
+    );
+  }
   assert.match(
     entryHistory,
     /const CANONICAL_WEB_BASE = "https:\/\/palomar-registry\.org\/";/,

--- a/tests/build-site.test.js
+++ b/tests/build-site.test.js
@@ -26,6 +26,10 @@ test("deployment build versions coupled browser assets", async () => {
       path.join(destination, "assets", "challenge-presentation.mjs"),
       "utf8",
     );
+    const entryHistoryPresentation = await readFile(
+      path.join(destination, "assets", "entry-history-presentation.mjs"),
+      "utf8",
+    );
     const formalizationPresentation = await readFile(
       path.join(destination, "assets", "formalization-presentation.mjs"),
       "utf8",
@@ -49,6 +53,7 @@ test("deployment build versions coupled browser assets", async () => {
     assert.match(about, /assets\/about\.js\?v=0123456789abcdef/);
     await readFile(path.join(destination, "assets", "about.js"), "utf8");
     assert.match(app, /\.\/challenge-presentation\.mjs\?v=0123456789abcdef/);
+    assert.match(app, /\.\/entry-history-presentation\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/entry-pages\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/formalization-presentation\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/security\.mjs\?v=0123456789abcdef/);
@@ -59,6 +64,7 @@ test("deployment build versions coupled browser assets", async () => {
     assert.match(rendering, /\.\/security\.mjs\?v=0123456789abcdef/);
     assert.match(challengePresentation, /\.\/rendering\.js\?v=0123456789abcdef/);
     assert.match(challengePresentation, /\.\/security\.mjs\?v=0123456789abcdef/);
+    assert.match(entryHistoryPresentation, /\.\/security\.mjs\?v=0123456789abcdef/);
     assert.match(
       challengePresentation,
       /\.\/source-preservation\.mjs\?v=0123456789abcdef/,
@@ -177,7 +183,7 @@ test("the MSC descriptions shown to readers are readable", async () => {
   assert.equal(codes["52C10"], "Erdős problems and related topics of discrete geometry");
 });
 
-test("app.js writes down no data origin the database override cannot redirect", async () => {
+test("the app graph writes down no data origin the database override cannot redirect", async () => {
   // `?database=` names the endpoint every read surface is resolved against, so
   // a fixture directory can stand in for the live service. A data URL spelled
   // out as a literal in app.js is outside that arrangement by construction.
@@ -185,15 +191,23 @@ test("app.js writes down no data origin the database override cannot redirect", 
   // those: they outlived the category feed links, which were removed when
   // every one of them answered 404, and went on naming a `feeds/` directory
   // that nothing fetched and no reader could reach. The canonical web origin
-  // is a different thing and stays, because an entry's canonical link has to
-  // point at the official URL even when the page is being read from a fixture.
+  // is a different thing and stays in the history presenter, because an
+  // entry's canonical link has to point at the official URL even when the page
+  // is being read from a fixture.
   const app = await readFile(new URL("../assets/app.js", import.meta.url), "utf8");
+  const entryHistory = await readFile(
+    new URL("../assets/entry-history-presentation.mjs", import.meta.url),
+    "utf8",
+  );
   assert.equal(
     app.includes("data.palomar-registry.org"),
     false,
     "app.js names the data origin directly instead of resolving against the chosen endpoint",
   );
-  assert.match(app, /const CANONICAL_WEB_BASE = "https:\/\/palomar-registry\.org\/";/);
+  assert.match(
+    entryHistory,
+    /const CANONICAL_WEB_BASE = "https:\/\/palomar-registry\.org\/";/,
+  );
 });
 
 test("everything the pages fetch at runtime is actually shipped", async () => {

--- a/tests/entry-history-presentation.test.mjs
+++ b/tests/entry-history-presentation.test.mjs
@@ -141,6 +141,14 @@ test("history is newest-first, identifies the selected snapshot, and leaves inpu
     "Version 2SupersededViewing",
     "Version 1Superseded",
   ]);
+  assert.deepEqual(byClass(list, "version-state").map((node) => node.textContent), [
+    "Current",
+    "Superseded",
+    "Superseded",
+  ]);
+  assert.equal(byClass(list, "current").length, 1);
+  assert.equal(byClass(list, "superseded").length, 2);
+  assert.equal(byClass(list, "viewing-version").length, 1);
   assert.equal(byClass(list, "selected-version")[0].attributes.get("aria-current"), "true");
   assert.deepEqual(byTag(list, "a").map((node) => node.href), [
     `https://fixture.invalid/entry.html?id=${id}&version=3`,

--- a/tests/entry-history-presentation.test.mjs
+++ b/tests/entry-history-presentation.test.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createEntryHistoryPresentation } from "../assets/entry-history-presentation.mjs";
+
+function fakeDocument() {
+  function createElement(tag) {
+    return {
+      attributes: new Map(),
+      children: [],
+      className: "",
+      href: "",
+      id: "",
+      rel: "",
+      reversed: false,
+      tagName: tag.toUpperCase(),
+      textContent: "",
+      append(...children) {
+        this.children.push(...children);
+      },
+      setAttribute(name, value) {
+        this.attributes.set(name, value);
+      },
+    };
+  }
+
+  const head = createElement("head");
+  return {
+    head,
+    createElement,
+    querySelector(selector) {
+      if (selector !== 'link[rel="canonical"]') {
+        throw new Error(`unsupported fixture selector: ${selector}`);
+      }
+      return head.children.find((node) => node.tagName === "LINK" && node.rel === "canonical") ?? null;
+    },
+  };
+}
+
+function descendants(root) {
+  const found = [];
+  const visit = (value) => {
+    if (!value || typeof value !== "object" || !Array.isArray(value.children)) return;
+    found.push(value);
+    value.children.forEach(visit);
+  };
+  visit(root);
+  return found;
+}
+
+function byTag(root, tagName) {
+  return descendants(root).filter((node) => node.tagName === tagName.toUpperCase());
+}
+
+function byClass(root, className) {
+  return descendants(root).filter((node) =>
+    String(node.className).split(" ").includes(className));
+}
+
+function fullText(root) {
+  if (typeof root === "string") return root;
+  return [root.textContent, ...root.children.map(fullText)].join("");
+}
+
+function localPageUrl(page, entry) {
+  const url = new URL(page, "https://fixture.invalid/");
+  url.searchParams.set("id", entry.id);
+  url.searchParams.set("version", String(entry.version));
+  return url;
+}
+
+const window = { location: { href: "https://fixture.invalid/entry.html" } };
+
+test("canonical entry links are inserted once and updated for the selected immutable version", () => {
+  const document = fakeDocument();
+  const { setCanonicalEntryPage } = createEntryHistoryPresentation({
+    document,
+    localPageUrl,
+    window,
+  });
+
+  setCanonicalEntryPage({ id: "PALOMAR-2026-08-08-000001", version: 1 });
+  setCanonicalEntryPage({ id: "PALOMAR-2026-08-08-000001", version: 2 });
+
+  assert.equal(document.head.children.length, 1);
+  assert.equal(document.head.children[0].rel, "canonical");
+  assert.equal(
+    document.head.children[0].href,
+    "https://palomar-registry.org/entry.html?id=PALOMAR-2026-08-08-000001&version=2",
+  );
+});
+
+test("only a superseded version presents a labelled link to the current version", () => {
+  const document = fakeDocument();
+  const { versionNotice } = createEntryHistoryPresentation({ document, localPageUrl, window });
+  const entry = { id: "PALOMAR-2026-08-08-000001", version: 1 };
+
+  assert.equal(versionNotice(entry, 1), null);
+  const notice = versionNotice(entry, 3);
+
+  assert.equal(notice.attributes.get("aria-labelledby"), "newer-version-heading");
+  assert.equal(byTag(notice, "h2")[0].id, "newer-version-heading");
+  assert.match(fullText(notice), /Version 3 is the current version/);
+  assert.equal(byTag(notice, "a")[0].textContent, "View current version 3");
+  assert.equal(
+    byTag(notice, "a")[0].href,
+    "https://fixture.invalid/entry.html?id=PALOMAR-2026-08-08-000001&version=3",
+  );
+});
+
+test("history links remain confined even if its local URL adapter regresses", () => {
+  const presentation = createEntryHistoryPresentation({
+    document: fakeDocument(),
+    localPageUrl: () => new URL("https://attacker.invalid/entry.html"),
+    window,
+  });
+
+  assert.throws(
+    () => presentation.versionNotice({ id: "PALOMAR-2026-08-08-000001", version: 1 }, 2),
+    /internal record link escaped the Palomar origin/,
+  );
+});
+
+test("history is newest-first, identifies the selected snapshot, and leaves input order intact", () => {
+  const document = fakeDocument();
+  const { versionHistory } = createEntryHistoryPresentation({ document, localPageUrl, window });
+  const id = "PALOMAR-2026-08-08-000001";
+  const versions = [1, 2, 3].map((version) => ({ id, version }));
+  const original = structuredClone(versions);
+
+  const history = versionHistory({ id, version: 2 }, versions, 3);
+
+  assert.equal(history.id, "version-history");
+  assert.equal(history.attributes.get("aria-labelledby"), "version-history-heading");
+  assert.equal(byTag(history, "h2")[0].id, "version-history-heading");
+  const list = byTag(history, "ol")[0];
+  assert.equal(list.reversed, true);
+  assert.equal(list.attributes.get("role"), "list");
+  assert.deepEqual(byTag(list, "li").map(fullText), [
+    "Version 3Current",
+    "Version 2SupersededViewing",
+    "Version 1Superseded",
+  ]);
+  assert.equal(byClass(list, "selected-version")[0].attributes.get("aria-current"), "true");
+  assert.deepEqual(byTag(list, "a").map((node) => node.href), [
+    `https://fixture.invalid/entry.html?id=${id}&version=3`,
+    `https://fixture.invalid/entry.html?id=${id}&version=1`,
+  ]);
+  assert.deepEqual(versions, original);
+});

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -896,9 +896,19 @@ test("current HTML remains compatible with cached JavaScript from the previous d
     body: fileAtPreviousDeployment("assets/rendering.js"),
     contentType: "text/javascript; charset=utf-8",
   }));
+  // Pin only these cached entry points by intent. Their imports resolve to the
+  // fresh shared modules, which is the adjacent Pages deployment boundary this
+  // regression exercises.
 
   await page.goto(`/?database=${database}`);
   await expect(page.locator(".entry-card")).toHaveCount(2);
+  await expect(page.locator("#status")).not.toContainText("could not be loaded");
+
+  await page.goto(
+    `/entry.html?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`,
+  );
+  await expect(page.locator(".version-notice")).toHaveCount(1);
+  await expect(page.locator("#version-history li")).toHaveCount(2);
   await expect(page.locator("#status")).not.toContainText("could not be loaded");
 });
 


### PR DESCRIPTION
## Summary

- move the entry page's canonical link, supersession notice, and immutable version-history section into a focused `entry-history-presentation.mjs` boundary
- reduce `assets/app.js` from 1,401 to 1,316 lines without changing existing security, route, loading, or data-contract ownership
- keep local links fail closed through the existing security URL confinement and add direct tests for canonical updates, current/superseded states and styling hooks, ordering, selection, input immutability, and hostile adapter output
- ship and version the complete new module graph, require every consumer module to avoid hard-coded data origins, and reconcile architecture documentation
- extend the adjacent-deployment gate through an entry page while intentionally combining cached old entry scripts with fresh shared modules

Existing browser-module exports remain unchanged so cached JavaScript from the adjacent deployment can still link against fresh shared modules.

## Evidence

Base: `143a5c28bf50663163cb055bf7091b8b0559df74`

- `npm ci`: 0 vulnerabilities
- `PALOMAR_DATABASE_CHECKOUT=/tmp/.../PalomarDatabase npm test`: 136/136 passed against Database `9fc7a5ad5dc9f595213844a781669818804aa68a`
- `PALOMAR_ASSET_VERSION=reviewed npm run build`: passed
- `node scripts/check-published.mjs --data https://data.palomar-registry.org/`: all 1 active versions accepted
- `node scripts/check-published.mjs --links`: all 4 linked registry documents served
- Nix Chromium with `PALOMAR_PREVIOUS_REF=143a5c28bf50663163cb055bf7091b8b0559df74 npm run test:browser`: 55/55 passed, including both adjacent-deployment gates and the cached-old entry route
- syntax and `git diff --check`: passed

## Cost and contracts

There are no registry reads, validation rules, document shapes, or deployment-order changes. The browser graph gains one fixed cacheable module request on pages loading `app.js`; it does not add a data request or a term that grows with registry size, versions, or search inputs. Total source is mainly relocated, with a small module/test wrapper overhead. As with the preceding module extractions, rolling back to an artifact that lacks the new file while a client retains the newer versioned app graph can produce a bounded asset 404 until that client refreshes the page; rollback should therefore republish cache-busting HTML rather than only the old asset tree.