### PR TITLE
Extract registry loading from the app controller

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,8 +76,9 @@
   supersession notice, and immutable version-history section, while consuming
   validated records and the existing confined local-entry URL builder;
   `assets/registry-loading.mjs` composes the selected endpoints, JSON
-  transport, page-scoped source-availability cache/retry policy, and exact
-  version/entry/tombstone reads without taking validation or route ownership;
+  transport, the bounded landing/search source-availability cache/retry policy,
+  the direct entry source-availability read, and exact recent/version/entry/
+  tombstone reads without taking validation or route ownership;
   `assets/app.js` owns remaining page composition and controller wiring. Do not
   duplicate registry-document validation, source resolution, or route
   orchestration across those modules; the route module still rejects malformed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,10 @@
   `assets/entry-history-presentation.mjs` owns the entry page's canonical link,
   supersession notice, and immutable version-history section, while consuming
   validated records and the existing confined local-entry URL builder;
-  `assets/app.js` owns data loading and remaining page composition. Do not
+  `assets/registry-loading.mjs` composes the selected endpoints, JSON
+  transport, page-scoped source-availability cache/retry policy, and exact
+  version/entry/tombstone reads without taking validation or route ownership;
+  `assets/app.js` owns remaining page composition and controller wiring. Do not
   duplicate registry-document validation, source resolution, or route
   orchestration across those modules; the route module still rejects malformed
   URL identifiers before asking the document loader to do any work.

--- a/README.md
+++ b/README.md
@@ -85,8 +85,10 @@ transitions, `challenge-presentation.mjs` owns the named-declarations artifact's
 entry correspondence and presentation states, `formalization-presentation.mjs`
 owns statement trust labels and the statement/proof dependency presentation,
 `entry-history-presentation.mjs` owns the entry page's canonical link,
-supersession notice, and immutable version-history section, and `app.js` loads
-records and composes the remaining page-level views.
+supersession notice, and immutable version-history section;
+`registry-loading.mjs` composes selected endpoints, JSON transport,
+page-scoped source-availability reads, and exact entry-history/record/tombstone
+loading; and `app.js` composes the remaining page-level views.
 
 Runtime reads use the browser's normal HTTP cache behavior. The public data
 service gives successful documents a 60-second browser/shared-cache lifetime,

--- a/README.md
+++ b/README.md
@@ -86,9 +86,10 @@ entry correspondence and presentation states, `formalization-presentation.mjs`
 owns statement trust labels and the statement/proof dependency presentation,
 `entry-history-presentation.mjs` owns the entry page's canonical link,
 supersession notice, and immutable version-history section;
-`registry-loading.mjs` composes selected endpoints, JSON transport,
-page-scoped source-availability reads, and exact entry-history/record/tombstone
-loading; and `app.js` composes the remaining page-level views.
+`registry-loading.mjs` composes selected endpoints, JSON transport, the bounded
+landing/search source-availability cache, the direct entry source-availability
+read, and exact recent/entry-history/record/tombstone loading; and `app.js`
+composes the remaining page-level views.
 
 Runtime reads use the browser's normal HTTP cache behavior. The public data
 service gives successful documents a 60-second browser/shared-cache lifetime,

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,27 +1,15 @@
 import {
-  databaseBaseFor,
   RESULT_ORIGIN_LABELS,
   REPOSITORY_ROLE_LABELS,
-  entryRecordUrl,
   isLoopbackHostname,
   pinnedRepositoryDirectoryUrl,
   safeDataUrl,
   safeExternalUrl,
   safeInternalUrl,
-  selectDatabaseUrl,
-  selectAvailabilityUrl,
   recentUrl,
-  selectRenderBase,
-  tombstoneUrl,
-  validateEntry,
-  validateAvailability,
   validateRecent,
-  validateVersions,
-  versionsUrl,
-  validateTombstone,
   workflowRunId,
 } from "./security.mjs";
-import { loadSettledBounded } from "./loading.mjs";
 import { createRegistrySearch, validateSearchQuery } from "./searching.mjs";
 import {
   renderChallengePage,
@@ -30,6 +18,7 @@ import {
 import { createChallengePresentation } from "./challenge-presentation.mjs";
 import { createEntryHistoryPresentation } from "./entry-history-presentation.mjs";
 import { createFormalizationPresentation } from "./formalization-presentation.mjs";
+import { createRegistryLoader } from "./registry-loading.mjs";
 import {
   decorateCardSet,
   sourceFileUrl,
@@ -41,20 +30,6 @@ const params = new URLSearchParams(window.location.search);
 const ARXIV_FILTER_RE = /^[a-z]+(?:-[a-z]+)*(?:\.[A-Za-z-]+)?$/;
 const MSC2020_FILTER_RE = /^[0-9]{2}(?:[A-Z][0-9]{2}|-[0-9]{2})$/;
 const FILTER_UPDATE_DELAY_MS = 200;
-const AVAILABILITY_TIMEOUT_MS = 30_000;
-
-function dataSource() {
-  const databaseBase = databaseBaseFor(
-    selectDatabaseUrl(window.location.href, window.location.search),
-  );
-  const renderBase = selectRenderBase(window.location.href, window.location.search, databaseBase);
-  const availabilityUrl = selectAvailabilityUrl(
-    window.location.href,
-    window.location.search,
-    databaseBase,
-  );
-  return { databaseBase, renderBase, availabilityUrl };
-}
 
 function el(tag, className, text) {
   const node = document.createElement(tag);
@@ -86,60 +61,18 @@ function setOptionalText(selector, text) {
   if (node) node.textContent = text;
 }
 
-async function fetchJson(url, { signal } = {}) {
-  const response = await fetch(url, { signal });
-  if (!response.ok) {
-    const error = new Error(`${response.status} ${response.statusText}`);
-    error.status = response.status;
-    throw error;
-  }
-  return response.json();
-}
+const {
+  dataSource,
+  fetchJson,
+  loadAvailabilityBounded,
+  loadEntry,
+} = createRegistryLoader({
+  fetch: (...args) => fetch(...args),
+  location: window.location,
+  warn: (message) => console.warn(message),
+});
 
 const searchRegistry = createRegistrySearch(fetchJson);
-
-async function fetchAvailability(url, { signal } = {}) {
-  return validateAvailability(await fetchJson(url, { signal }));
-}
-
-async function loadAvailability(url, { signal } = {}) {
-  try {
-    return await fetchAvailability(url, { signal });
-  } catch (error) {
-    console.warn(`Source availability is unavailable: ${error.message}`);
-    return null;
-  }
-}
-
-// The landing and search controllers can need the same manifest. Share a
-// successful bounded read, but never make one temporary failure or timeout the
-// page's answer for the rest of its lifetime.
-const availabilityLoads = new Map();
-function loadAvailabilityBounded(url) {
-  const key = url.href;
-  if (!availabilityLoads.has(key)) {
-    const loading = loadSettledBounded(
-      [url],
-      (selected, signal) => fetchAvailability(selected, { signal }),
-      { concurrency: 1, timeoutMs: AVAILABILITY_TIMEOUT_MS },
-    ).then(([loaded]) => {
-      if (loaded.status === "fulfilled") return loaded.value;
-      // A missing manifest is a stable legacy answer for this page load. A
-      // timeout, transport error, or invalid document may recover, so only
-      // those outcomes are evicted and retried by the next consumer.
-      if (loaded.reason?.status !== 404) {
-        availabilityLoads.delete(key);
-        console.warn(
-          `Source availability is unavailable: ` +
-            `${loaded.reason?.message || String(loaded.reason)}`,
-        );
-      }
-      return null;
-    });
-    availabilityLoads.set(key, loading);
-  }
-  return availabilityLoads.get(key);
-}
 
 function authorNames(entry) {
   return entry.authors.map((author) => author.name).join(", ");
@@ -1211,55 +1144,6 @@ async function renderEntry(
     ...(sourceNotice.classList.contains("preserved") ? [sourceNotice] : []),
     versionHistory(entry, versions, currentVersion),
   );
-}
-
-async function loadEntry(id, requestedVersion) {
-  const { databaseBase, renderBase, availabilityUrl } = dataSource();
-  const availabilityPromise = loadAvailability(availabilityUrl);
-  // The versions of this one result, not the whole registry. Reading a
-  // whole-registry index here meant fetching every record ever registered to
-  // render one page, and paying for it again every time anyone else published.
-  let versions = [];
-  try {
-    versions = validateVersions(await fetchJson(versionsUrl(id, databaseBase)), id).entries;
-  } catch (error) {
-    // Absent means no active version of this result, which is either an
-    // unknown identifier or one withdrawn entirely. Both are answered below,
-    // by the tombstone if there is one and by "not found" if there is not.
-    if (error.status !== 404) throw error;
-  }
-  const currentVersion = versions.length ? versions.at(-1).version : null;
-  const version = requestedVersion ?? currentVersion;
-  if (version === null && requestedVersion === undefined) throw new Error("entry not found");
-  const summary = versions.find((item) => item.version === version);
-  if (!summary) {
-    if (requestedVersion === null || requestedVersion === undefined) {
-      throw new Error("entry not found");
-    }
-    try {
-      const tombstone = validateTombstone(
-        await fetchJson(tombstoneUrl(id, requestedVersion, databaseBase)),
-        id,
-        requestedVersion,
-      );
-      return { tombstone };
-    } catch (error) {
-      if (error.status === 404) throw new Error("entry not found");
-      throw error;
-    }
-  }
-  const canonicalUrl = entryRecordUrl(summary, databaseBase);
-  const entry = validateEntry(await fetchJson(canonicalUrl), summary);
-  const availability = await availabilityPromise;
-  return {
-    entry,
-    canonicalUrl,
-    renderBase,
-    versions,
-    currentVersion,
-    availability,
-    databaseBase,
-  };
 }
 
 function renderExactTombstone(tombstone, content) {

--- a/assets/app.js
+++ b/assets/app.js
@@ -6,8 +6,6 @@ import {
   safeDataUrl,
   safeExternalUrl,
   safeInternalUrl,
-  recentUrl,
-  validateRecent,
   workflowRunId,
 } from "./security.mjs";
 import { createRegistrySearch, validateSearchQuery } from "./searching.mjs";
@@ -65,6 +63,7 @@ const {
   dataSource,
   fetchJson,
   loadAvailabilityBounded,
+  loadRecent,
   loadEntry,
 } = createRegistryLoader({
   fetch: (...args) => fetch(...args),
@@ -265,7 +264,7 @@ async function renderIndex() {
     // The publisher projects every landing-card field from validated canonical
     // entries into this bounded newest-first document. Rendering the selection
     // therefore costs one summary read, not one record read per card.
-    const recent = validateRecent(await fetchJson(recentUrl(databaseBase)));
+    const recent = await loadRecent(databaseBase);
     const entries = recent.entries;
     // GitHub Pages may briefly pair HTML and JavaScript from adjacent deployments.
     // Metrics are presentation-only, so a removed metric must not abort the registry.

--- a/assets/registry-loading.mjs
+++ b/assets/registry-loading.mjs
@@ -2,12 +2,14 @@ import { loadSettledBounded } from "./loading.mjs";
 import {
   databaseBaseFor,
   entryRecordUrl,
+  recentUrl,
   selectAvailabilityUrl,
   selectDatabaseUrl,
   selectRenderBase,
   tombstoneUrl,
   validateAvailability,
   validateEntry,
+  validateRecent,
   validateTombstone,
   validateVersions,
   versionsUrl,
@@ -22,7 +24,12 @@ const AVAILABILITY_TIMEOUT_MS = 30_000;
  * concurrency, and entry-pages.mjs owns route state. This boundary composes
  * those contracts into the reads shared by the app's page controllers.
  */
-export function createRegistryLoader({ fetch, location, warn }) {
+export function createRegistryLoader({
+  fetch,
+  location,
+  warn = () => {},
+  availabilityTimeoutMs = AVAILABILITY_TIMEOUT_MS,
+}) {
   function dataSource() {
     const databaseBase = databaseBaseFor(
       selectDatabaseUrl(location.href, location.search),
@@ -50,9 +57,9 @@ export function createRegistryLoader({ fetch, location, warn }) {
     return validateAvailability(await fetchJson(url, { signal }));
   }
 
-  async function loadAvailability(url, { signal } = {}) {
+  async function loadAvailability(url) {
     try {
-      return await fetchAvailability(url, { signal });
+      return await fetchAvailability(url);
     } catch (error) {
       warn(`Source availability is unavailable: ${error.message}`);
       return null;
@@ -69,7 +76,7 @@ export function createRegistryLoader({ fetch, location, warn }) {
       const loading = loadSettledBounded(
         [url],
         (selected, signal) => fetchAvailability(selected, { signal }),
-        { concurrency: 1, timeoutMs: AVAILABILITY_TIMEOUT_MS },
+        { concurrency: 1, timeoutMs: availabilityTimeoutMs },
       ).then(([loaded]) => {
         if (loaded.status === "fulfilled") return loaded.value;
         // A missing manifest is a stable absence for this page load. A
@@ -89,6 +96,10 @@ export function createRegistryLoader({ fetch, location, warn }) {
     return availabilityLoads.get(key);
   }
 
+  async function loadRecent(databaseBase) {
+    return validateRecent(await fetchJson(recentUrl(databaseBase)));
+  }
+
   async function loadEntry(id, requestedVersion) {
     const { databaseBase, renderBase, availabilityUrl } = dataSource();
     const availabilityPromise = loadAvailability(availabilityUrl);
@@ -106,7 +117,6 @@ export function createRegistryLoader({ fetch, location, warn }) {
     }
     const currentVersion = versions.length ? versions.at(-1).version : null;
     const version = requestedVersion ?? currentVersion;
-    if (version === null && requestedVersion === undefined) throw new Error("entry not found");
     const summary = versions.find((item) => item.version === version);
     if (!summary) {
       if (requestedVersion === null || requestedVersion === undefined) {
@@ -138,5 +148,5 @@ export function createRegistryLoader({ fetch, location, warn }) {
     };
   }
 
-  return { dataSource, fetchJson, loadAvailabilityBounded, loadEntry };
+  return { dataSource, fetchJson, loadAvailabilityBounded, loadRecent, loadEntry };
 }

--- a/assets/registry-loading.mjs
+++ b/assets/registry-loading.mjs
@@ -1,0 +1,142 @@
+import { loadSettledBounded } from "./loading.mjs";
+import {
+  databaseBaseFor,
+  entryRecordUrl,
+  selectAvailabilityUrl,
+  selectDatabaseUrl,
+  selectRenderBase,
+  tombstoneUrl,
+  validateAvailability,
+  validateEntry,
+  validateTombstone,
+  validateVersions,
+  versionsUrl,
+} from "./security.mjs";
+
+const AVAILABILITY_TIMEOUT_MS = 30_000;
+
+/**
+ * Bind registry transport and entry loading to the current page environment.
+ *
+ * Security owns endpoint and document validation, loading.mjs owns bounded
+ * concurrency, and entry-pages.mjs owns route state. This boundary composes
+ * those contracts into the reads shared by the app's page controllers.
+ */
+export function createRegistryLoader({ fetch, location, warn }) {
+  function dataSource() {
+    const databaseBase = databaseBaseFor(
+      selectDatabaseUrl(location.href, location.search),
+    );
+    const renderBase = selectRenderBase(location.href, location.search, databaseBase);
+    const availabilityUrl = selectAvailabilityUrl(
+      location.href,
+      location.search,
+      databaseBase,
+    );
+    return { databaseBase, renderBase, availabilityUrl };
+  }
+
+  async function fetchJson(url, { signal } = {}) {
+    const response = await fetch(url, { signal });
+    if (!response.ok) {
+      const error = new Error(`${response.status} ${response.statusText}`);
+      error.status = response.status;
+      throw error;
+    }
+    return response.json();
+  }
+
+  async function fetchAvailability(url, { signal } = {}) {
+    return validateAvailability(await fetchJson(url, { signal }));
+  }
+
+  async function loadAvailability(url, { signal } = {}) {
+    try {
+      return await fetchAvailability(url, { signal });
+    } catch (error) {
+      warn(`Source availability is unavailable: ${error.message}`);
+      return null;
+    }
+  }
+
+  // The landing and search controllers can need the same manifest. Share a
+  // successful bounded read, but never make one temporary failure or timeout
+  // the page's answer for the rest of its lifetime.
+  const availabilityLoads = new Map();
+  function loadAvailabilityBounded(url) {
+    const key = url.href;
+    if (!availabilityLoads.has(key)) {
+      const loading = loadSettledBounded(
+        [url],
+        (selected, signal) => fetchAvailability(selected, { signal }),
+        { concurrency: 1, timeoutMs: AVAILABILITY_TIMEOUT_MS },
+      ).then(([loaded]) => {
+        if (loaded.status === "fulfilled") return loaded.value;
+        // A missing manifest is a stable absence for this page load. A
+        // timeout, transport error, or invalid document may recover, so only
+        // those outcomes are evicted and retried by the next consumer.
+        if (loaded.reason?.status !== 404) {
+          availabilityLoads.delete(key);
+          warn(
+            `Source availability is unavailable: ` +
+              `${loaded.reason?.message || String(loaded.reason)}`,
+          );
+        }
+        return null;
+      });
+      availabilityLoads.set(key, loading);
+    }
+    return availabilityLoads.get(key);
+  }
+
+  async function loadEntry(id, requestedVersion) {
+    const { databaseBase, renderBase, availabilityUrl } = dataSource();
+    const availabilityPromise = loadAvailability(availabilityUrl);
+    // The versions of this one result, not the whole registry. Reading a
+    // whole-registry index here meant fetching every record ever registered to
+    // render one page, and paying for it again every time anyone else published.
+    let versions = [];
+    try {
+      versions = validateVersions(await fetchJson(versionsUrl(id, databaseBase)), id).entries;
+    } catch (error) {
+      // Absent means no active version of this result, which is either an
+      // unknown identifier or one withdrawn entirely. Both are answered below,
+      // by the tombstone if there is one and by "not found" if there is not.
+      if (error.status !== 404) throw error;
+    }
+    const currentVersion = versions.length ? versions.at(-1).version : null;
+    const version = requestedVersion ?? currentVersion;
+    if (version === null && requestedVersion === undefined) throw new Error("entry not found");
+    const summary = versions.find((item) => item.version === version);
+    if (!summary) {
+      if (requestedVersion === null || requestedVersion === undefined) {
+        throw new Error("entry not found");
+      }
+      try {
+        const tombstone = validateTombstone(
+          await fetchJson(tombstoneUrl(id, requestedVersion, databaseBase)),
+          id,
+          requestedVersion,
+        );
+        return { tombstone };
+      } catch (error) {
+        if (error.status === 404) throw new Error("entry not found");
+        throw error;
+      }
+    }
+    const canonicalUrl = entryRecordUrl(summary, databaseBase);
+    const entry = validateEntry(await fetchJson(canonicalUrl), summary);
+    const availability = await availabilityPromise;
+    return {
+      entry,
+      canonicalUrl,
+      renderBase,
+      versions,
+      currentVersion,
+      availability,
+      databaseBase,
+    };
+  }
+
+  return { dataSource, fetchJson, loadAvailabilityBounded, loadEntry };
+}

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -13,6 +13,7 @@ const browserModuleFiles = [
   "entry-pages.mjs",
   "formalization-presentation.mjs",
   "loading.mjs",
+  "registry-loading.mjs",
   "rendering.js",
   "searching.mjs",
   "security.mjs",

--- a/tests/build-site.test.js
+++ b/tests/build-site.test.js
@@ -43,6 +43,10 @@ test("deployment build versions coupled browser assets", async () => {
       path.join(destination, "assets", "rendering.js"),
       "utf8",
     );
+    const registryLoading = await readFile(
+      path.join(destination, "assets", "registry-loading.mjs"),
+      "utf8",
+    );
     const searching = await readFile(
       path.join(destination, "assets", "searching.mjs"),
       "utf8",
@@ -57,11 +61,13 @@ test("deployment build versions coupled browser assets", async () => {
     assert.match(app, /\.\/entry-pages\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/formalization-presentation\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/security\.mjs\?v=0123456789abcdef/);
-    assert.match(app, /\.\/loading\.mjs\?v=0123456789abcdef/);
+    assert.match(app, /\.\/registry-loading\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/searching\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/source-preservation\.mjs\?v=0123456789abcdef/);
     assert.match(preservation, /\.\/security\.mjs\?v=0123456789abcdef/);
     assert.match(rendering, /\.\/security\.mjs\?v=0123456789abcdef/);
+    assert.match(registryLoading, /\.\/loading\.mjs\?v=0123456789abcdef/);
+    assert.match(registryLoading, /\.\/security\.mjs\?v=0123456789abcdef/);
     assert.match(challengePresentation, /\.\/rendering\.js\?v=0123456789abcdef/);
     assert.match(challengePresentation, /\.\/security\.mjs\?v=0123456789abcdef/);
     assert.match(entryHistoryPresentation, /\.\/security\.mjs\?v=0123456789abcdef/);

--- a/tests/registry-loading.test.mjs
+++ b/tests/registry-loading.test.mjs
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createRegistryLoader } from "../assets/registry-loading.mjs";
+import {
+  availabilityManifest,
+  entry,
+  secondVersion,
+  summary,
+} from "./registry-fixture.mjs";
+
+const ID = "PALOMAR-2026-07-29-000123";
+
+function jsonResponse(value, status = 200, statusText = status === 404 ? "Not Found" : "OK") {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    async json() {
+      return structuredClone(value);
+    },
+  };
+}
+
+function productionLocation(page = "entry.html") {
+  return {
+    href: `https://palomar-registry.org/${page}`,
+    search: "",
+  };
+}
+
+function routedFetch(routes, calls = []) {
+  return async (value, options = {}) => {
+    const url = new URL(value);
+    calls.push({ url, signal: options.signal });
+    const route = routes.get(url.pathname);
+    if (!route) throw new Error(`unexpected fixture request: ${url.href}`);
+    return typeof route === "function" ? route(url, options) : route;
+  };
+}
+
+test("the loader composes every loopback endpoint through the security selectors", () => {
+  const search =
+    "?database=%2Ffixtures%2Fdatabase%2F&render-base=%2Ffixtures%2Frenders%2F" +
+    "&availability=%2Ffixtures%2Favailability.json";
+  const loader = createRegistryLoader({
+    fetch: assert.fail,
+    location: {
+      href: `http://127.0.0.1:4173/entry.html${search}`,
+      search,
+    },
+    warn: assert.fail,
+  });
+
+  const selected = loader.dataSource();
+  assert.equal(selected.databaseBase.href, "http://127.0.0.1:4173/fixtures/database/");
+  assert.equal(selected.renderBase.href, "http://127.0.0.1:4173/fixtures/renders/");
+  assert.equal(
+    selected.availabilityUrl.href,
+    "http://127.0.0.1:4173/fixtures/availability.json",
+  );
+});
+
+test("JSON transport preserves the abort signal and status of a failed response", async () => {
+  const signal = AbortSignal.abort(new Error("fixture abort"));
+  let receivedSignal;
+  const loader = createRegistryLoader({
+    fetch: async (_url, options) => {
+      receivedSignal = options.signal;
+      return jsonResponse({}, 503, "Service Unavailable");
+    },
+    location: productionLocation(),
+    warn: assert.fail,
+  });
+
+  await assert.rejects(
+    loader.fetchJson(new URL("https://data.example/record.json"), { signal }),
+    (error) => error.message === "503 Service Unavailable" && error.status === 503,
+  );
+  assert.equal(receivedSignal, signal);
+});
+
+test("bounded availability caches absence but retries a transient failure", async () => {
+  const url = new URL("https://data.palomar-registry.org/source-availability.json");
+  let transientReads = 0;
+  const warnings = [];
+  const fresh = new Date(Math.floor(Date.now() / 1_000) * 1_000)
+    .toISOString()
+    .replace(".000Z", "Z");
+  const transientLoader = createRegistryLoader({
+    fetch: async () => {
+      transientReads += 1;
+      return transientReads === 1
+        ? jsonResponse({}, 503, "Service Unavailable")
+        : jsonResponse(availabilityManifest([], { generated_at: fresh }));
+    },
+    location: productionLocation("index.html"),
+    warn: (message) => warnings.push(message),
+  });
+
+  assert.equal(await transientLoader.loadAvailabilityBounded(url), null);
+  const recovered = await transientLoader.loadAvailabilityBounded(url);
+  assert.equal(recovered.generated_at, fresh);
+  assert.equal(transientReads, 2);
+  assert.deepEqual(warnings, ["Source availability is unavailable: 503 Service Unavailable"]);
+
+  let absentReads = 0;
+  const absentLoader = createRegistryLoader({
+    fetch: async () => {
+      absentReads += 1;
+      return jsonResponse({}, 404);
+    },
+    location: productionLocation("index.html"),
+    warn: assert.fail,
+  });
+  assert.equal(await absentLoader.loadAvailabilityBounded(url), null);
+  assert.equal(await absentLoader.loadAvailabilityBounded(url), null);
+  assert.equal(absentReads, 1);
+});
+
+test("an unversioned entry read resolves and validates the current immutable record", async () => {
+  const record = secondVersion();
+  const versions = {
+    schema_version: 1,
+    id: ID,
+    entries: [
+      summary(),
+      summary({
+        version: 2,
+        title: record.title,
+        path: `entries/${ID}-v2.json`,
+      }),
+    ],
+  };
+  const calls = [];
+  const routes = new Map([
+    [`/versions/${ID}.json`, jsonResponse(versions)],
+    [`/entries/${ID}-v2.json`, jsonResponse(record)],
+    ["/source-availability.json", jsonResponse({}, 404)],
+  ]);
+  const warnings = [];
+  const loader = createRegistryLoader({
+    fetch: routedFetch(routes, calls),
+    location: productionLocation(),
+    warn: (message) => warnings.push(message),
+  });
+
+  const loaded = await loader.loadEntry(ID, null);
+
+  assert.equal(loaded.entry.version, 2);
+  assert.equal(loaded.currentVersion, 2);
+  assert.deepEqual(loaded.versions, versions.entries);
+  assert.equal(
+    loaded.canonicalUrl.href,
+    `https://data.palomar-registry.org/entries/${ID}-v2.json`,
+  );
+  assert.equal(loaded.databaseBase.href, "https://data.palomar-registry.org/");
+  assert.equal(loaded.renderBase.href, "https://data.palomar-registry.org/");
+  assert.equal(loaded.availability, null);
+  assert.deepEqual(warnings, ["Source availability is unavailable: 404 Not Found"]);
+  assert.deepEqual(calls.map(({ url }) => url.pathname).sort(), [
+    `/entries/${ID}-v2.json`,
+    "/source-availability.json",
+    `/versions/${ID}.json`,
+  ].sort());
+});
+
+test("an inactive exact version resolves only through its validated tombstone", async () => {
+  const versions = { schema_version: 1, id: ID, entries: [summary()] };
+  const tombstone = { id: ID, version: 2, taken_down_on: "2026-08-08" };
+  const calls = [];
+  const routes = new Map([
+    [`/versions/${ID}.json`, jsonResponse(versions)],
+    [`/tombstones/${ID}-v2.json`, jsonResponse(tombstone)],
+    ["/source-availability.json", jsonResponse({}, 404)],
+  ]);
+  const loader = createRegistryLoader({
+    fetch: routedFetch(routes, calls),
+    location: productionLocation(),
+    warn: () => {},
+  });
+
+  assert.deepEqual(await loader.loadEntry(ID, 2), { tombstone });
+  assert.equal(calls.some(({ url }) => url.pathname.startsWith("/entries/")), false);
+});
+
+test("an absent version index and tombstone produce the one public not-found error", async () => {
+  const routes = new Map([
+    [`/versions/${ID}.json`, jsonResponse({}, 404)],
+    [`/tombstones/${ID}-v9.json`, jsonResponse({}, 404)],
+    ["/source-availability.json", jsonResponse({}, 404)],
+  ]);
+  const loader = createRegistryLoader({
+    fetch: routedFetch(routes),
+    location: productionLocation(),
+    warn: () => {},
+  });
+
+  await assert.rejects(loader.loadEntry(ID, 9), /entry not found/);
+  await assert.rejects(loader.loadEntry(ID, null), /entry not found/);
+});

--- a/tests/registry-loading.test.mjs
+++ b/tests/registry-loading.test.mjs
@@ -5,6 +5,7 @@ import { createRegistryLoader } from "../assets/registry-loading.mjs";
 import {
   availabilityManifest,
   entry,
+  recent,
   secondVersion,
   summary,
 } from "./registry-fixture.mjs";
@@ -84,15 +85,13 @@ test("bounded availability caches absence but retries a transient failure", asyn
   const url = new URL("https://data.palomar-registry.org/source-availability.json");
   let transientReads = 0;
   const warnings = [];
-  const fresh = new Date(Math.floor(Date.now() / 1_000) * 1_000)
-    .toISOString()
-    .replace(".000Z", "Z");
+  const manifest = availabilityManifest([]);
   const transientLoader = createRegistryLoader({
     fetch: async () => {
       transientReads += 1;
       return transientReads === 1
         ? jsonResponse({}, 503, "Service Unavailable")
-        : jsonResponse(availabilityManifest([], { generated_at: fresh }));
+        : jsonResponse(manifest);
     },
     location: productionLocation("index.html"),
     warn: (message) => warnings.push(message),
@@ -100,7 +99,7 @@ test("bounded availability caches absence but retries a transient failure", asyn
 
   assert.equal(await transientLoader.loadAvailabilityBounded(url), null);
   const recovered = await transientLoader.loadAvailabilityBounded(url);
-  assert.equal(recovered.generated_at, fresh);
+  assert.equal(recovered.generated_at, manifest.generated_at);
   assert.equal(transientReads, 2);
   assert.deepEqual(warnings, ["Source availability is unavailable: 503 Service Unavailable"]);
 
@@ -116,6 +115,68 @@ test("bounded availability caches absence but retries a transient failure", asyn
   assert.equal(await absentLoader.loadAvailabilityBounded(url), null);
   assert.equal(await absentLoader.loadAvailabilityBounded(url), null);
   assert.equal(absentReads, 1);
+});
+
+test("bounded availability shares an in-flight read", async () => {
+  const url = new URL("https://data.palomar-registry.org/source-availability.json");
+  let reads = 0;
+  let release;
+  const pending = new Promise((resolve) => {
+    release = resolve;
+  });
+  const loader = createRegistryLoader({
+    fetch: async () => {
+      reads += 1;
+      return pending;
+    },
+    location: productionLocation("index.html"),
+  });
+
+  const first = loader.loadAvailabilityBounded(url);
+  const second = loader.loadAvailabilityBounded(url);
+  assert.equal(first, second);
+  assert.equal(reads, 0);
+  release(jsonResponse(availabilityManifest([])));
+  assert.equal((await first).schema_version, 1);
+  assert.equal((await second).schema_version, 1);
+  assert.equal(reads, 1);
+});
+
+test("bounded availability enforces its deadline and evicts a timed-out read", async () => {
+  const url = new URL("https://data.palomar-registry.org/source-availability.json");
+  let reads = 0;
+  const warnings = [];
+  const loader = createRegistryLoader({
+    fetch: async () => {
+      reads += 1;
+      if (reads === 1) return new Promise(() => {});
+      return jsonResponse({}, 404);
+    },
+    location: productionLocation("index.html"),
+    warn: (message) => warnings.push(message),
+    availabilityTimeoutMs: 5,
+  });
+
+  assert.equal(await loader.loadAvailabilityBounded(url), null);
+  assert.match(warnings[0], /load deadline of 5ms expired/);
+  assert.equal(await loader.loadAvailabilityBounded(url), null);
+  assert.equal(reads, 2);
+});
+
+test("the recent projection is fetched from the selected database and validated", async () => {
+  const document = recent();
+  const calls = [];
+  const routes = new Map([["/recent.json", jsonResponse(document)]]);
+  const loader = createRegistryLoader({
+    fetch: routedFetch(routes, calls),
+    location: productionLocation("index.html"),
+  });
+
+  const loaded = await loader.loadRecent(
+    new URL("https://data.palomar-registry.org/"),
+  );
+  assert.deepEqual(loaded, document);
+  assert.deepEqual(calls.map(({ url }) => url.pathname), ["/recent.json"]);
 });
 
 test("an unversioned entry read resolves and validates the current immutable record", async () => {
@@ -182,6 +243,64 @@ test("an inactive exact version resolves only through its validated tombstone", 
 
   assert.deepEqual(await loader.loadEntry(ID, 2), { tombstone });
   assert.equal(calls.some(({ url }) => url.pathname.startsWith("/entries/")), false);
+});
+
+test("an active exact version resolves through its immutable record", async () => {
+  const record = secondVersion();
+  const versions = {
+    schema_version: 1,
+    id: ID,
+    entries: [
+      summary(),
+      summary({ version: 2, title: record.title, path: `entries/${ID}-v2.json` }),
+    ],
+  };
+  const calls = [];
+  const routes = new Map([
+    [`/versions/${ID}.json`, jsonResponse(versions)],
+    [`/entries/${ID}-v1.json`, jsonResponse(entry())],
+    ["/source-availability.json", jsonResponse({}, 404)],
+  ]);
+  const loader = createRegistryLoader({
+    fetch: routedFetch(routes, calls),
+    location: productionLocation(),
+  });
+
+  const loaded = await loader.loadEntry(ID, 1);
+  assert.equal(loaded.entry.version, 1);
+  assert.equal(loaded.currentVersion, 2);
+  assert.equal(calls.some(({ url }) => url.pathname.startsWith("/tombstones/")), false);
+});
+
+test("non-absence failures from version indexes and tombstones propagate", async () => {
+  const versionFailure = createRegistryLoader({
+    fetch: routedFetch(new Map([
+      [`/versions/${ID}.json`, jsonResponse({}, 503, "Service Unavailable")],
+      ["/source-availability.json", jsonResponse({}, 404)],
+    ])),
+    location: productionLocation(),
+  });
+  await assert.rejects(
+    versionFailure.loadEntry(ID, 1),
+    (error) => error.status === 503 && error.message === "503 Service Unavailable",
+  );
+
+  const tombstoneFailure = createRegistryLoader({
+    fetch: routedFetch(new Map([
+      [`/versions/${ID}.json`, jsonResponse({
+        schema_version: 1,
+        id: ID,
+        entries: [summary()],
+      })],
+      [`/tombstones/${ID}-v2.json`, jsonResponse({}, 500, "Internal Server Error")],
+      ["/source-availability.json", jsonResponse({}, 404)],
+    ])),
+    location: productionLocation(),
+  });
+  await assert.rejects(
+    tombstoneFailure.loadEntry(ID, 2),
+    (error) => error.status === 500 && error.message === "500 Internal Server Error",
+  );
 });
 
 test("an absent version index and tombstone produce the one public not-found error", async () => {


### PR DESCRIPTION
## Summary

- move selected-endpoint composition, status-preserving JSON transport, the exact `recent.json` read, and exact version/entry/tombstone reads into `registry-loading.mjs`
- keep the bounded page-scoped landing/search source-availability cache/retry and the behavior-identical direct entry availability read in that same loading boundary
- reduce `assets/app.js` from 1,316 to 1,199 lines while leaving validation in `security.mjs`, bounded concurrency in `loading.mjs`, search traversal in `searching.mjs`, and route state in `entry-pages.mjs`
- retain every existing shared-module export and expose one small loader interface to the app controller
- add direct transport, endpoint, recent, in-flight cache, timeout eviction, current/exact-version, tombstone, failure-propagation, and not-found tests
- ship and version the complete new module graph and reconcile architecture documentation

The extraction keeps cached JavaScript from the adjacent deployment compatible with fresh shared modules: the previous app does not request the new module, and no export it imports was removed or changed.

## Evidence

Base: `3ab8cff2081c0dd70abf0e33aa78713f947f447e`

- `npm ci`: 0 vulnerabilities
- `npm test`: 147/147 passed against current Database `1350fad53e16e3e7a305ad20a9a78484248abb98`
- `npm run build -- --version 44af9392d55e4278792237fdfebec0727018e9ee --output .site-test-amended`: passed
- `node scripts/check-published.mjs --data https://data.palomar-registry.org`: all 1 active versions accepted
- `node scripts/check-published.mjs --links`: all 4 linked registry documents served
- Nix Chromium with `PALOMAR_PREVIOUS_REF=3ab8cff2081c0dd70abf0e33aa78713f947f447e npm run test:browser`: 55/55 passed, including cached-old landing and entry routes against fresh shared modules
- syntax and `git diff --check`: passed

## Cost and contracts

There are no registry document, validation, runtime data-request, retry-count, default timeout, or deployment-order changes. The browser graph gains one fixed cacheable module request on every page that loads `app.js`; all three such page types use this loading boundary. The module is 5,201 bytes uncompressed and 1,813 bytes with gzip, primarily relocated code. The bounded landing/search availability map remains linear in distinct selected availability URLs and is normally one entry; no term now grows with registry size beyond the existing bounded documents and exact per-entry history.
