### PR TITLE
Render entries before source availability settles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,9 +76,11 @@
   supersession notice, and immutable version-history section, while consuming
   validated records and the existing confined local-entry URL builder;
   `assets/registry-loading.mjs` composes the selected endpoints, JSON
-  transport, the bounded landing/search source-availability cache/retry policy,
-  the direct entry source-availability read, and exact recent/version/entry/
-  tombstone reads without taking validation or route ownership;
+  transport, the one bounded page-scoped source-availability cache/retry
+  policy, and exact recent/version/entry/tombstone reads without taking
+  validation or route ownership. Entry and render content must consume that
+  availability result progressively through `source-preservation.mjs`; an
+  ancillary health request must never delay a verified record or render;
   `assets/app.js` owns remaining page composition and controller wiring. Do not
   duplicate registry-document validation, source resolution, or route
   orchestration across those modules; the route module still rejects malformed

--- a/README.md
+++ b/README.md
@@ -75,21 +75,29 @@ Landing and verified search cards render before the source-availability
 manifest; if it arrives, their existing source controls are decorated in place.
 A linked `?q=` search does not also load the hidden recent listing; clearing the
 search starts one landing attempt, and a failed attempt can be retried.
+Entry and named-declarations pages follow the same rule: verified content and
+its recorded source links render immediately, then a validated availability
+result updates only those source controls in place. Each active entry or
+named-declarations page makes exactly one availability attempt; an unknown or
+withdrawn record makes none. Landing and search consumers share one
+in-flight/settled read. Each attempt has one 30-second deadline. A 404 is a
+stable page-scoped absence, while a timeout, transport failure, or invalid
+document is evicted so a later explicit consumer attempt can issue one retry.
 
 The browser code keeps the data boundary separate from presentation:
 `security.mjs` validates registry and availability documents and owns endpoint
 freshness, `source-preservation.mjs` matches validated manifest observations to
-the preservation receipt before resolving repository locations and decorating
-existing cards, `entry-pages.mjs` owns entry-route input and page-state
+the preservation receipt before resolving repository locations, publishing the
+progressive entry result, and decorating existing source controls,
+`entry-pages.mjs` owns entry-route input and page-state
 transitions, `challenge-presentation.mjs` owns the named-declarations artifact's
 entry correspondence and presentation states, `formalization-presentation.mjs`
 owns statement trust labels and the statement/proof dependency presentation,
 `entry-history-presentation.mjs` owns the entry page's canonical link,
 supersession notice, and immutable version-history section;
-`registry-loading.mjs` composes selected endpoints, JSON transport, the bounded
-landing/search source-availability cache, the direct entry source-availability
-read, and exact recent/entry-history/record/tombstone loading; and `app.js`
-composes the remaining page-level views.
+`registry-loading.mjs` composes selected endpoints, JSON transport, the one
+bounded page-scoped source-availability cache, and exact recent/entry-history/
+record/tombstone loading; and `app.js` composes the remaining page-level views.
 
 Runtime reads use the browser's normal HTTP cache behavior. The public data
 service gives successful documents a 60-second browser/shared-cache lifetime,

--- a/assets/app.js
+++ b/assets/app.js
@@ -18,6 +18,9 @@ import { createEntryHistoryPresentation } from "./entry-history-presentation.mjs
 import { createFormalizationPresentation } from "./formalization-presentation.mjs";
 import { createRegistryLoader } from "./registry-loading.mjs";
 import {
+  bindSourceControl,
+  createSourceAvailabilityBinding,
+  createSourceAvailabilityNotice,
   decorateCardSet,
   sourceFileUrl,
   sourceLocation,
@@ -608,6 +611,30 @@ function externalDetailRow(labelText, text, href, note) {
   return row;
 }
 
+function sourceLink(text, sourceAvailability, urlForAvailability, className) {
+  return bindSourceControl(
+    externalLink(text, urlForAvailability(sourceAvailability.current), className),
+    sourceAvailability,
+    (availability) => ({ url: urlForAvailability(availability) }),
+  );
+}
+
+function sourceDetailRow(
+  labelText,
+  text,
+  sourceAvailability,
+  urlForAvailability,
+  note,
+) {
+  const row = el("div", "detail-row");
+  row.append(el("dt", "", labelText));
+  const value = el("dd");
+  value.append(sourceLink(text, sourceAvailability, urlForAvailability));
+  if (note) value.append(" ", note);
+  row.append(value);
+  return row;
+}
+
 function dataDetailRow(labelText, text, href) {
   const row = el("div", "detail-row");
   row.append(el("dt", "", labelText));
@@ -662,7 +689,7 @@ function assurance(kind, sentence) {
  * ordinary case; the interesting case is when they disagree, and that is the
  * one worth spelling out.
  */
-function licenceRow(entry, availability) {
+function licenceRow(entry, sourceAvailability) {
   const licence = entry.source.license;
   const declared = licence.declared_identifier;
   const detected = licence.detected_identifier;
@@ -675,7 +702,11 @@ function licenceRow(entry, availability) {
       ? el("span", "", String(declared))
       : el("span", "licence-disagreement", `declared ${declared}, detected ${detected}`),
     " ",
-    externalLink(licence.path, sourceFileUrl(entry, licence.path, availability)),
+    sourceLink(
+      licence.path,
+      sourceAvailability,
+      (availability) => sourceFileUrl(entry, licence.path, availability),
+    ),
     " ",
     digestNote(licence.sha256),
   );
@@ -751,66 +782,6 @@ function classificationSearchUrl(scheme, code) {
   return url;
 }
 
-function sourceAvailabilityNotice(entry, availability) {
-  const location = topSourceLocation(entry, availability);
-  const notice = el("section", "source-availability");
-  const original = pinnedRepositoryDirectoryUrl(
-    location.originalRepository,
-    location.commit,
-    entry.source.project_path || ".",
-  );
-  const archived = pinnedRepositoryDirectoryUrl(
-    location.archiveRepository,
-    location.commit,
-    entry.source.project_path || ".",
-  );
-  if (location.originalStatus === "missing" && location.archiveStatus === "missing") {
-    notice.classList.add("unrecoverable");
-    notice.append(
-      el("strong", "", "No working preserved source location"),
-      el("p", "", "Both the recorded original and Palomar's preserved copy are currently unavailable."),
-      externalLink("Recorded original location", original),
-      " · ",
-      externalLink("Recorded Palomar copy", archived),
-    );
-  } else if (location.originalStatus === "missing") {
-    notice.classList.add("original-missing");
-    const checked = location.checkedAt ? ` (checked ${location.checkedAt})` : "";
-    notice.append(
-      el("strong", "", "Original source unavailable"),
-      el("p", "", `Source links on this page now use Palomar's preserved copy${checked}.`),
-      externalLink("Palomar preserved copy", archived),
-      " · ",
-      externalLink("Recorded original location", original),
-    );
-  } else if (location.archiveStatus === "missing") {
-    notice.classList.add("archive-missing");
-    const originalConfirmed = location.originalStatus === "available";
-    notice.append(
-      el("strong", "", "Source preservation degraded"),
-      el(
-        "p",
-        "",
-        originalConfirmed
-          ? "The original source still works, but Palomar's preserved copy is unavailable."
-          : "Palomar's preserved copy is unavailable. The recorded original location remains " +
-            "linked, but its current availability has not been confirmed.",
-      ),
-      externalLink(originalConfirmed ? "Original source" : "Recorded original location", original),
-      " · ",
-      externalLink("Recorded Palomar copy", archived),
-    );
-  } else {
-    notice.classList.add("preserved");
-    notice.append(
-      el("strong", "", "Source preserved by Palomar"),
-      " ",
-      externalLink("Palomar preserved copy", archived),
-    );
-  }
-  return notice;
-}
-
 function classificationSection(entry) {
   const categories = classification(entry);
   const section = el("section", "entry-classification");
@@ -865,7 +836,7 @@ function classificationSection(entry) {
   return section;
 }
 
-function provenanceSection(entry, availability) {
+function provenanceSection(entry, sourceAvailability) {
   const provenance = entry.provenance;
   const section = el("section", "entry-provenance");
   const heading = el("div", "section-heading");
@@ -880,17 +851,20 @@ function provenanceSection(entry, availability) {
   // below the repository role that exists to announce it.
   if (provenance.repository_role === "thin-wrapper") {
     const substantive = provenance.substantive_formalization;
-    const location = sourceLocation(
-      entry,
-      availability,
-      substantive.repository,
-      substantive.commit,
-    );
     details.append(
-      externalDetailRow(
+      sourceDetailRow(
         "Substantive formalization",
         `${substantive.repository}@${substantive.commit.slice(0, 12)}`,
-        pinnedRepositoryDirectoryUrl(location.repository, substantive.commit),
+        sourceAvailability,
+        (availability) => {
+          const location = sourceLocation(
+            entry,
+            availability,
+            substantive.repository,
+            substantive.commit,
+          );
+          return pinnedRepositoryDirectoryUrl(location.repository, substantive.commit);
+        },
       ),
     );
   }
@@ -964,9 +938,10 @@ async function renderEntry(
   renderBase,
   versions,
   currentVersion,
-  availability,
+  availabilityPromise,
   databaseBase,
 ) {
+  const sourceAvailability = createSourceAvailabilityBinding(availabilityPromise);
   document.title = `${entry.title} — Palomar`;
   setCanonicalEntryPage(entry);
   const heading = el("header", "entry-heading");
@@ -983,27 +958,31 @@ async function renderEntry(
   evidenceTitle.append(titleBlock);
   evidence.append(evidenceTitle, acceptanceCallout(entry, databaseBase));
   const details = el("dl", "details");
-  const location = topSourceLocation(entry, availability);
   details.append(
     // One date, not two. Acceptance and Lean verification have always been the
     // same day, so the second row said nothing the first did not; what it cost
     // was the time of day, which is now here.
     detailRow("Verified and accepted", displayTimestamp(entry.verification.verified_at)),
-    externalDetailRow(
+    sourceDetailRow(
       "Fixed source version",
       `${entry.source.repository}@${entry.source.commit.slice(0, 12)}`,
-      pinnedRepositoryDirectoryUrl(location.repository, entry.source.commit),
+      sourceAvailability,
+      (availability) => pinnedRepositoryDirectoryUrl(
+        topSourceLocation(entry, availability).repository,
+        entry.source.commit,
+      ),
     ),
   );
   // Only worth a row when it is somewhere. At the repository root it is the
   // absence of a fact, and the fixed source version above already links there.
   if (entry.source.project_path) {
     details.append(
-      externalDetailRow(
+      sourceDetailRow(
         "Project directory",
         entry.source.project_path,
-        pinnedRepositoryDirectoryUrl(
-          location.repository,
+        sourceAvailability,
+        (availability) => pinnedRepositoryDirectoryUrl(
+          topSourceLocation(entry, availability).repository,
           entry.source.commit,
           entry.source.project_path,
         ),
@@ -1013,22 +992,37 @@ async function renderEntry(
   details.append(
     // The digest belongs to the file, so it sits with the file rather than in
     // a row of its own two lines further down.
-    externalDetailRow(
+    sourceDetailRow(
       "Statement file",
       entry.formalization.challenge_path,
-      sourceFileUrl(entry, entry.formalization.challenge_path, availability),
+      sourceAvailability,
+      (availability) => sourceFileUrl(
+        entry,
+        entry.formalization.challenge_path,
+        availability,
+      ),
       digestNote(entry.verification.challenge_sha256),
     ),
-    externalDetailRow(
+    sourceDetailRow(
       "Proof file",
       entry.formalization.solution_path,
-      sourceFileUrl(entry, entry.formalization.solution_path, availability),
+      sourceAvailability,
+      (availability) => sourceFileUrl(
+        entry,
+        entry.formalization.solution_path,
+        availability,
+      ),
       digestNote(entry.verification.solution_sha256),
     ),
-    externalDetailRow(
+    sourceDetailRow(
       "Formalization metadata",
       entry.formalization.formalization_metadata_path,
-      sourceFileUrl(entry, entry.formalization.formalization_metadata_path, availability),
+      sourceAvailability,
+      (availability) => sourceFileUrl(
+        entry,
+        entry.formalization.formalization_metadata_path,
+        availability,
+      ),
     ),
     detailRow("Lean version", entry.formalization.lean_toolchain),
     detailRow("Theorems checked", theoremNames(entry)),
@@ -1048,10 +1042,15 @@ async function renderEntry(
   );
   {
     details.append(
-      externalDetailRow(
+      sourceDetailRow(
         "Lakefile",
         entry.formalization.lakefile_path,
-        sourceFileUrl(entry, entry.formalization.lakefile_path, availability),
+        sourceAvailability,
+        (availability) => sourceFileUrl(
+          entry,
+          entry.formalization.lakefile_path,
+          availability,
+        ),
       ),
     );
   }
@@ -1065,7 +1064,7 @@ async function renderEntry(
       ),
       detailRow("Verification workflow commit", entry.verification.workflow_commit),
       detailRow("Workflow run attempt", String(entry.verification.workflow_run_attempt)),
-      licenceRow(entry, availability),
+      licenceRow(entry, sourceAvailability),
     );
   }
   evidence.append(details);
@@ -1118,16 +1117,21 @@ async function renderEntry(
 
   const challenge = await challengePresentation(entry, renderBase, {
     dependenciesOnThisPage: true,
-    availability,
+    sourceAvailability,
   });
-  const sourceNotice = sourceAvailabilityNotice(entry, availability);
+  const sourceNotice = createSourceAvailabilityNotice(entry, sourceAvailability, {
+    el,
+    externalLink,
+  });
+  const versionNoticeNode = versionNotice(entry, currentVersion);
+  const history = versionHistory(entry, versions, currentVersion);
   content.append(heading);
   // A broken or degraded source affects every link on the page and remains a
   // warning at the top. The ordinary preservation confirmation is provenance,
-  // not an alert, so keep it with the registry history near the bottom.
-  if (!sourceNotice.classList.contains("preserved")) content.append(sourceNotice);
-  const notice = versionNotice(entry, currentVersion);
-  if (notice) content.append(notice);
+  // not an alert, so keep it with the registry history near the bottom. The
+  // ancillary observation decides that placement only after it settles; until
+  // then there is no availability claim or placeholder in the document.
+  if (versionNoticeNode) content.append(versionNoticeNode);
   // The statement first, then what was checked about it, then what it rests
   // on. A registry entry is about a theorem, and the theorem should not be
   // below the paperwork that certifies it; these three used to be the sixth,
@@ -1136,13 +1140,19 @@ async function renderEntry(
     challenge.section,
     evidence,
     trust,
-    solutionMetadata(entry, challenge.metadata, availability),
-    provenanceSection(entry, availability),
+    solutionMetadata(entry, challenge.metadata, sourceAvailability),
+    provenanceSection(entry, sourceAvailability),
     classificationSection(entry),
     editorial,
-    ...(sourceNotice.classList.contains("preserved") ? [sourceNotice] : []),
-    versionHistory(entry, versions, currentVersion),
+    history,
   );
+  sourceAvailability.whenReady(() => {
+    if (sourceNotice.classList.contains("preserved")) {
+      content.insertBefore(sourceNotice, history);
+    } else {
+      content.insertBefore(sourceNotice, versionNoticeNode || challenge.section);
+    }
+  });
 }
 
 function renderExactTombstone(tombstone, content) {
@@ -1181,7 +1191,7 @@ if (document.body.dataset.page === "entry") {
       loaded.renderBase,
       loaded.versions,
       loaded.currentVersion,
-      loaded.availability,
+      loaded.availabilityPromise,
       loaded.databaseBase,
     ),
     renderExactTombstone,

--- a/assets/challenge-presentation.mjs
+++ b/assets/challenge-presentation.mjs
@@ -10,6 +10,8 @@ import {
   safeInternalUrl,
 } from "./security.mjs";
 import {
+  bindSourceControl,
+  createSourceAvailabilityBinding,
   sourceFileUrl,
   topSourceLocation,
 } from "./source-preservation.mjs";
@@ -72,6 +74,14 @@ export function createChallengePresentation({ fetchJson, document, window, local
     return anchor(text, safeInternalUrl(href, window.location.href), className);
   }
 
+  function sourceLink(text, sourceAvailability, urlForAvailability, className) {
+    return bindSourceControl(
+      externalLink(text, urlForAvailability(sourceAvailability.current), className),
+      sourceAvailability,
+      (availability) => ({ url: urlForAvailability(availability) }),
+    );
+  }
+
   function challengeFrame(entry, renderBase) {
     const frame = el("iframe", "challenge-frame");
     frame.src = safeDataUrl(
@@ -122,8 +132,15 @@ export function createChallengePresentation({ fetchJson, document, window, local
   return async function challengePresentation(
     entry,
     renderBase,
-    { forceFrame = false, dependenciesOnThisPage = false, availability = null } = {},
+    {
+      forceFrame = false,
+      dependenciesOnThisPage = false,
+      sourceAvailability = null,
+      availabilityPromise = null,
+    } = {},
   ) {
+    const availability = sourceAvailability ??
+      createSourceAvailabilityBinding(availabilityPromise);
     const section = el("section", "challenge-presentation");
     const heading = el("div", "section-heading");
     const titleBlock = el("div");
@@ -145,19 +162,23 @@ export function createChallengePresentation({ fetchJson, document, window, local
     const comparatorPath = entry.formalization.comparator_config_path;
     const challengePath = entry.formalization.challenge_path;
     const challengeFilename = challengePath.split("/").at(-1);
-    const location = topSourceLocation(entry, availability);
     links.append(
-      externalLink(
+      sourceLink(
         `View full pinned statement file (${challengeFilename})`,
-        challengeSourceUrl(entry, location.repository),
+        availability,
+        (manifest) => challengeSourceUrl(
+          entry,
+          topSourceLocation(entry, manifest).repository,
+        ),
         "challenge-source",
       ),
       " · ",
       internalLink("Inspect statement dependencies", dependencyRecordUrl),
       " · ",
-      externalLink(
+      sourceLink(
         `View comparator configuration (${comparatorPath.split("/").at(-1)})`,
-        sourceFileUrl(entry, comparatorPath, availability),
+        availability,
+        (manifest) => sourceFileUrl(entry, comparatorPath, manifest),
         "comparator-source",
       ),
     );

--- a/assets/entry-pages.mjs
+++ b/assets/entry-pages.mjs
@@ -88,7 +88,7 @@ export async function renderChallengePage({
       renderExactTombstone(loaded.tombstone, content);
       return;
     }
-    const { entry, renderBase, availability } = loaded;
+    const { entry, renderBase, availabilityPromise } = loaded;
     document.title = `Named compared declarations — ${entry.title} — Palomar`;
     const heading = el("header", "entry-heading");
     heading.append(
@@ -98,7 +98,7 @@ export async function renderChallengePage({
     const challenge = await challengePresentation(
       entry,
       renderBase,
-      { forceFrame: true, availability },
+      { forceFrame: true, availabilityPromise },
     );
     content.append(heading, challenge.section);
     status.hidden = true;

--- a/assets/formalization-presentation.mjs
+++ b/assets/formalization-presentation.mjs
@@ -3,6 +3,7 @@ import {
   safeExternalUrl,
 } from "./security.mjs";
 import {
+  bindSourceControl,
   sourceDirectoryUrl,
   sourceFileUrl,
   sourceLocation,
@@ -28,6 +29,21 @@ export function createFormalizationPresentation({ document }) {
     const node = el("a", "", text);
     node.href = safeExternalUrl(href).href;
     return node;
+  }
+
+  function sourceLink(text, sourceAvailability, urlForAvailability, textForAvailability) {
+    const current = sourceAvailability?.current ?? null;
+    return bindSourceControl(
+      externalLink(
+        textForAvailability ? textForAvailability(current) : text,
+        urlForAvailability(current),
+      ),
+      sourceAvailability,
+      (availability) => ({
+        url: urlForAvailability(availability),
+        ...(textForAvailability ? { text: textForAvailability(availability) } : {}),
+      }),
+    );
   }
 
   function detailRow(label, value) {
@@ -82,7 +98,7 @@ export function createFormalizationPresentation({ document }) {
     return section;
   }
 
-  function solutionMetadata(entry, renderMetadata, availability) {
+  function solutionMetadata(entry, renderMetadata, sourceAvailability = null) {
     const section = el("section", "entry-solution");
     const heading = el("div", "section-heading");
     const title = el("div");
@@ -102,9 +118,14 @@ export function createFormalizationPresentation({ document }) {
     proofRow.append(el("dt", "", "Proof file"));
     const proofValue = el("dd");
     proofValue.append(
-      externalLink(
+      sourceLink(
         entry.formalization.solution_path,
-        sourceFileUrl(entry, entry.formalization.solution_path, availability),
+        sourceAvailability,
+        (availability) => sourceFileUrl(
+          entry,
+          entry.formalization.solution_path,
+          availability,
+        ),
       ),
     );
     proofRow.append(proofValue);
@@ -136,37 +157,53 @@ export function createFormalizationPresentation({ document }) {
       const item = el("li");
       if (dependency.path !== undefined) {
         item.append(
-          externalLink(
+          sourceLink(
             dependency.name,
-            sourceDirectoryUrl(entry, dependency.path, availability),
+            sourceAvailability,
+            (availability) => sourceDirectoryUrl(entry, dependency.path, availability),
           ),
           el("code", "", dependency.path),
         );
       } else {
-        const location = sourceLocation(
+        const locationFor = (availability) => sourceLocation(
           entry,
           availability,
           dependency.repository,
           dependency.revision,
         );
+        const location = locationFor(sourceAvailability?.current ?? null);
+        const primary = externalLink(
+          dependency.repository,
+          pinnedRepositoryDirectoryUrl(location.repository, dependency.revision),
+        );
+        const archive = externalLink(
+          "Palomar preserved copy",
+          pinnedRepositoryDirectoryUrl(location.archiveRepository, dependency.revision),
+        );
+        const archiveSeparator = el("span", "source-archive-separator", " · ");
+        const applyAvailability = (availability) => {
+          const selected = locationFor(availability);
+          const useArchive = selected.useArchive;
+          primary.href = safeExternalUrl(
+            pinnedRepositoryDirectoryUrl(selected.repository, dependency.revision),
+          ).href;
+          primary.textContent = useArchive
+            ? `${dependency.repository} (Palomar copy)`
+            : dependency.repository;
+          const archiveWasFocused = document.activeElement === archive;
+          archive.hidden = useArchive;
+          archiveSeparator.hidden = useArchive;
+          if (archiveWasFocused && useArchive && typeof primary.focus === "function") {
+            primary.focus();
+          }
+        };
+        applyAvailability(sourceAvailability?.current ?? null);
+        sourceAvailability?.whenReady(applyAvailability);
         item.append(
-          externalLink(
-            location.useArchive
-              ? `${dependency.repository} (Palomar copy)`
-              : dependency.repository,
-            pinnedRepositoryDirectoryUrl(location.repository, dependency.revision),
-          ),
+          primary,
           el("code", "", dependency.revision.slice(0, 12)),
         );
-        if (!location.useArchive) {
-          item.append(
-            " · ",
-            externalLink(
-              "Palomar preserved copy",
-              pinnedRepositoryDirectoryUrl(location.archiveRepository, dependency.revision),
-            ),
-          );
-        }
+        item.append(archiveSeparator, archive);
       }
       list.append(item);
     }

--- a/assets/registry-loading.mjs
+++ b/assets/registry-loading.mjs
@@ -57,18 +57,9 @@ export function createRegistryLoader({
     return validateAvailability(await fetchJson(url, { signal }));
   }
 
-  async function loadAvailability(url) {
-    try {
-      return await fetchAvailability(url);
-    } catch (error) {
-      warn(`Source availability is unavailable: ${error.message}`);
-      return null;
-    }
-  }
-
-  // The landing and search controllers can need the same manifest. Share a
-  // successful bounded read, but never make one temporary failure or timeout
-  // the page's answer for the rest of its lifetime.
+  // Page controllers can need the same manifest. Share a successful bounded
+  // read, but never make one temporary failure or timeout the page's answer
+  // for the rest of its lifetime.
   const availabilityLoads = new Map();
   function loadAvailabilityBounded(url) {
     const key = url.href;
@@ -102,7 +93,6 @@ export function createRegistryLoader({
 
   async function loadEntry(id, requestedVersion) {
     const { databaseBase, renderBase, availabilityUrl } = dataSource();
-    const availabilityPromise = loadAvailability(availabilityUrl);
     // The versions of this one result, not the whole registry. Reading a
     // whole-registry index here meant fetching every record ever registered to
     // render one page, and paying for it again every time anyone else published.
@@ -134,16 +124,20 @@ export function createRegistryLoader({
         throw error;
       }
     }
+    // Availability is ancillary health information for active content. Start
+    // its bounded read in parallel with the immutable entry record, but return
+    // that verified record without awaiting it. Unknown and withdrawn records
+    // make no availability request because they have no source controls.
+    const availabilityPromise = loadAvailabilityBounded(availabilityUrl);
     const canonicalUrl = entryRecordUrl(summary, databaseBase);
     const entry = validateEntry(await fetchJson(canonicalUrl), summary);
-    const availability = await availabilityPromise;
     return {
       entry,
       canonicalUrl,
       renderBase,
       versions,
       currentVersion,
-      availability,
+      availabilityPromise,
       databaseBase,
     };
   }

--- a/assets/source-preservation.mjs
+++ b/assets/source-preservation.mjs
@@ -2,7 +2,168 @@ import {
   availabilityRecord,
   pinnedRepositoryDirectoryUrl,
   pinnedRepositoryFileUrl,
+  safeExternalUrl,
 } from "./security.mjs";
+
+/**
+ * Publish one fail-soft availability result to source controls as it arrives.
+ *
+ * Entry content is correct with the canonical preservation receipt alone, so
+ * consumers render against `current === null` immediately and subscribe only
+ * their source controls. A slow health document can then update those controls
+ * in place without holding verified registry content behind an ancillary read.
+ */
+export function createSourceAvailabilityBinding(
+  availabilityPromise,
+  warn = (message) => console.warn(message),
+) {
+  let current = null;
+  let listeners = [];
+
+  function report(error) {
+    const message = error instanceof Error ? error.message : String(error);
+    warn(`Entry source availability could not be applied: ${message}`);
+  }
+
+  function settle(value) {
+    current = value;
+    const pending = listeners;
+    listeners = null;
+    for (const listener of pending) {
+      try {
+        listener(value);
+      } catch (error) {
+        report(error);
+      }
+    }
+    return value;
+  }
+
+  const ready = Promise.resolve(availabilityPromise).then(
+    settle,
+    (error) => {
+      report(error);
+      return settle(null);
+    },
+  );
+
+  return {
+    get current() {
+      return current;
+    },
+    ready,
+    whenReady(listener) {
+      if (typeof listener !== "function") throw new TypeError("listener must be a function");
+      if (listeners !== null) {
+        listeners.push(listener);
+        return;
+      }
+      try {
+        listener(current);
+      } catch (error) {
+        report(error);
+      }
+    },
+  };
+}
+
+/** Update one existing source link when the ancillary availability read settles. */
+export function bindSourceControl(link, sourceAvailability, resolve) {
+  if (typeof resolve !== "function") throw new TypeError("resolve must be a function");
+  const apply = (availability) => {
+    const reference = resolve(availability);
+    link.href = safeExternalUrl(reference.url).href;
+    if (reference.text !== undefined) link.textContent = reference.text;
+  };
+  apply(sourceAvailability?.current ?? null);
+  sourceAvailability?.whenReady(apply);
+  return link;
+}
+
+/** Build the one entry-level source notice and update that node in place. */
+export function createSourceAvailabilityNotice(
+  entry,
+  sourceAvailability,
+  { el, externalLink },
+) {
+  const notice = el("section", "source-availability");
+  notice.hidden = true;
+  notice.setAttribute("role", "status");
+
+  function apply(availability) {
+    const location = topSourceLocation(entry, availability);
+    const original = externalLink(
+      "Recorded original location",
+      pinnedRepositoryDirectoryUrl(
+        location.originalRepository,
+        location.commit,
+        entry.source.project_path || ".",
+      ),
+    );
+    original.dataset.sourceLocation = "original";
+    const archived = externalLink(
+      "Recorded Palomar copy",
+      pinnedRepositoryDirectoryUrl(
+        location.archiveRepository,
+        location.commit,
+        entry.source.project_path || ".",
+      ),
+    );
+    archived.dataset.sourceLocation = "archive";
+    notice.className = "source-availability";
+    notice.hidden = false;
+    if (location.originalStatus === "missing" && location.archiveStatus === "missing") {
+      notice.classList.add("unrecoverable");
+      notice.replaceChildren(
+        el("strong", "", "No working preserved source location"),
+        el("p", "", "Both the recorded original and Palomar's preserved copy are currently unavailable."),
+        original,
+        " · ",
+        archived,
+      );
+    } else if (location.originalStatus === "missing") {
+      notice.classList.add("original-missing");
+      const checked = location.checkedAt ? ` (checked ${location.checkedAt})` : "";
+      archived.textContent = "Palomar preserved copy";
+      notice.replaceChildren(
+        el("strong", "", "Original source unavailable"),
+        el("p", "", `Source links on this page now use Palomar's preserved copy${checked}.`),
+        archived,
+        " · ",
+        original,
+      );
+    } else if (location.archiveStatus === "missing") {
+      notice.classList.add("archive-missing");
+      const originalConfirmed = location.originalStatus === "available";
+      original.textContent = originalConfirmed ? "Original source" : "Recorded original location";
+      notice.replaceChildren(
+        el("strong", "", "Source preservation degraded"),
+        el(
+          "p",
+          "",
+          originalConfirmed
+            ? "The original source still works, but Palomar's preserved copy is unavailable."
+            : "Palomar's preserved copy is unavailable. The recorded original location remains " +
+              "linked, but its current availability has not been confirmed.",
+        ),
+        original,
+        " · ",
+        archived,
+      );
+    } else {
+      notice.classList.add("preserved");
+      archived.textContent = "Palomar preserved copy";
+      notice.replaceChildren(
+        el("strong", "", "Source preserved by Palomar"),
+        " ",
+        archived,
+      );
+    }
+  }
+
+  sourceAvailability.whenReady(apply);
+  return notice;
+}
 
 /** Resolve one immutable repository revision to its recorded or preserved copy. */
 export function sourceLocation(entry, availability, repository, commit) {

--- a/tests/challenge-presentation.test.mjs
+++ b/tests/challenge-presentation.test.mjs
@@ -5,7 +5,14 @@ import {
   createChallengePresentation,
   validateChallengeMetadata,
 } from "../assets/challenge-presentation.mjs";
-import { entry } from "./registry-fixture.mjs";
+import { createSourceAvailabilityBinding } from "../assets/source-preservation.mjs";
+import { validateAvailability } from "../assets/security.mjs";
+import {
+  availabilityEndpoint,
+  availabilityManifest,
+  availabilityRow,
+  entry,
+} from "./registry-fixture.mjs";
 
 function renderMetadata(overrides = {}) {
   return {
@@ -153,6 +160,45 @@ test("an inline presentation keeps links confined and accepts height only from i
   assert.equal(frame.dataset.heightAdjusted, "true");
   onMessage({ source: frame.contentWindow, data: { type: "palomar-render-height", height: 1_000 } });
   assert.equal(frame.style.height, "672px");
+});
+
+test("late availability updates statement source controls in place", async () => {
+  const browser = fakeBrowser();
+  const record = entry();
+  let releaseAvailability;
+  const sourceAvailability = createSourceAvailabilityBinding(new Promise((resolve) => {
+    releaseAvailability = resolve;
+  }));
+  const present = createChallengePresentation({
+    ...browser,
+    fetchJson: async () => renderMetadata(),
+    localPageUrl: () => assert.fail("the inline entry view should not build another page URL"),
+  });
+
+  const result = await present(
+    record,
+    new URL("http://127.0.0.1:4173/database/"),
+    { dependenciesOnThisPage: true, sourceAvailability },
+  );
+  const [source] = byClass(result.section, "challenge-source");
+  const [comparator] = byClass(result.section, "comparator-source");
+  assert.match(source.href, /github\.com\/example\/challenge\/blob\//);
+  assert.match(comparator.href, /github\.com\/example\/challenge\/blob\//);
+
+  const checkedAt = new Date(Math.floor(Date.now() / 1_000) * 1_000)
+    .toISOString()
+    .replace(".000Z", "Z");
+  const missing = availabilityEndpoint({ status: "missing", checked_at: checkedAt });
+  releaseAvailability(validateAvailability(availabilityManifest([
+    availabilityRow({ original: missing }),
+  ], { generated_at: checkedAt })));
+  await sourceAvailability.ready;
+
+  assert.match(source.href, /github\.com\/PalomarArchive\/example--challenge--fixture\/blob\//);
+  assert.match(
+    comparator.href,
+    /github\.com\/PalomarArchive\/example--challenge--fixture\/blob\//,
+  );
 });
 
 test("a missing large entry render keeps its source controls and uses the missing-artifact fallback", async () => {

--- a/tests/entry-pages.test.js
+++ b/tests/entry-pages.test.js
@@ -203,14 +203,15 @@ test("named-declaration routes validate before loading and reveal only completed
     loadEntry: async () => ({
       entry,
       renderBase: new URL("https://render.example/"),
-      availability: { repositories: [] },
+      availabilityPromise: Promise.resolve({ repositories: [] }),
     }),
     renderExactTombstone: () => assert.fail("unexpected tombstone"),
     el: (tag, className, text = "") => ({ ...node(), tag, className, textContent: text }),
     challengePresentation: async (selected, renderBase, options) => {
       assert.equal(selected, entry);
       assert.equal(renderBase.href, "https://render.example/");
-      assert.deepEqual(options, { forceFrame: true, availability: { repositories: [] } });
+      assert.equal(options.forceFrame, true);
+      assert.deepEqual(await options.availabilityPromise, { repositories: [] });
       challengeStarted();
       await challenging;
       return { section };

--- a/tests/formalization-presentation.test.mjs
+++ b/tests/formalization-presentation.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { createFormalizationPresentation } from "../assets/formalization-presentation.mjs";
+import { createSourceAvailabilityBinding } from "../assets/source-preservation.mjs";
 import { validateAvailability } from "../assets/security.mjs";
 import {
   COMMIT,
@@ -16,21 +17,27 @@ const CHECKED_AT = new Date(Math.floor(Date.now() / 1_000) * 1_000)
   .replace(".000Z", "Z");
 
 function fakeDocument() {
-  return {
+  const document = {
+    activeElement: null,
     createElement(tag) {
       return {
         children: [],
         className: "",
         href: "",
+        hidden: false,
         id: "",
         tagName: tag.toUpperCase(),
         textContent: "",
         append(...children) {
           this.children.push(...children);
         },
+        focus() {
+          document.activeElement = this;
+        },
       };
     },
   };
+  return document;
 }
 
 function descendants(root) {
@@ -131,8 +138,9 @@ test("the proof section presents imports and every preserved dependency kind", (
   );
 });
 
-test("confirmed missing originals switch the proof and dependency links to their copies", () => {
-  const { solutionMetadata } = createFormalizationPresentation({ document: fakeDocument() });
+test("confirmed missing originals switch the proof and dependency links to their copies", async () => {
+  const document = fakeDocument();
+  const { solutionMetadata } = createFormalizationPresentation({ document });
   const record = entry();
   const missing = availabilityEndpoint({ status: "missing", checked_at: CHECKED_AT });
   const availability = validateAvailability(availabilityManifest([
@@ -143,8 +151,22 @@ test("confirmed missing originals switch the proof and dependency links to their
       original: missing,
     }),
   ], { generated_at: CHECKED_AT }));
-  const section = solutionMetadata(record, { schema_version: 1 }, availability);
-  const links = byTag(section, "a");
+  let releaseAvailability;
+  const sourceAvailability = createSourceAvailabilityBinding(new Promise((resolve) => {
+    releaseAvailability = resolve;
+  }));
+  const section = solutionMetadata(record, { schema_version: 1 }, sourceAvailability);
+  const initialLinks = byTag(section, "a");
+  assert.deepEqual(initialLinks.map((link) => link.textContent), [
+    "Solution.lean",
+    "leanprover-community/mathlib4",
+    "Palomar preserved copy",
+  ]);
+  initialLinks.at(-1).focus();
+
+  releaseAvailability(availability);
+  await sourceAvailability.ready;
+  const links = byTag(section, "a").filter((link) => !link.hidden);
 
   assert.deepEqual(texts(section, "code"), [COMMIT.slice(0, 12)]);
   assert.deepEqual(links.map((link) => link.textContent), [
@@ -159,4 +181,6 @@ test("confirmed missing originals switch the proof and dependency links to their
     links[1].href,
     `https://github.com/PalomarArchive/mathlib4--fixture/tree/${COMMIT}`,
   );
+  assert.equal(document.activeElement, links[1]);
+  assert.equal(byClass(section, "source-archive-separator")[0].hidden, true);
 });

--- a/tests/registry-loading.test.mjs
+++ b/tests/registry-loading.test.mjs
@@ -217,13 +217,52 @@ test("an unversioned entry read resolves and validates the current immutable rec
   );
   assert.equal(loaded.databaseBase.href, "https://data.palomar-registry.org/");
   assert.equal(loaded.renderBase.href, "https://data.palomar-registry.org/");
-  assert.equal(loaded.availability, null);
-  assert.deepEqual(warnings, ["Source availability is unavailable: 404 Not Found"]);
+  assert.equal(
+    loaded.availabilityPromise,
+    loader.loadAvailabilityBounded(
+      new URL("https://data.palomar-registry.org/source-availability.json"),
+    ),
+  );
+  assert.equal(await loaded.availabilityPromise, null);
+  assert.deepEqual(warnings, []);
   assert.deepEqual(calls.map(({ url }) => url.pathname).sort(), [
     `/entries/${ID}-v2.json`,
     "/source-availability.json",
     `/versions/${ID}.json`,
   ].sort());
+});
+
+test("verified entry loading does not await a never-settling availability read", async () => {
+  let releaseAvailability;
+  const blockedAvailability = new Promise((resolve) => {
+    releaseAvailability = resolve;
+  });
+  const routes = new Map([
+    [`/versions/${ID}.json`, jsonResponse({
+      schema_version: 1,
+      id: ID,
+      entries: [summary()],
+    })],
+    [`/entries/${ID}-v1.json`, jsonResponse(entry())],
+    ["/source-availability.json", () => blockedAvailability],
+  ]);
+  const loader = createRegistryLoader({
+    fetch: routedFetch(routes),
+    location: productionLocation(),
+  });
+
+  const loaded = await loader.loadEntry(ID, 1);
+  assert.equal(loaded.entry.id, ID);
+  assert.equal(loaded.entry.version, 1);
+  let availabilitySettled = false;
+  void loaded.availabilityPromise.then(() => {
+    availabilitySettled = true;
+  });
+  await Promise.resolve();
+  assert.equal(availabilitySettled, false);
+
+  releaseAvailability(jsonResponse({}, 404));
+  assert.equal(await loaded.availabilityPromise, null);
 });
 
 test("an inactive exact version resolves only through its validated tombstone", async () => {
@@ -243,6 +282,7 @@ test("an inactive exact version resolves only through its validated tombstone", 
 
   assert.deepEqual(await loader.loadEntry(ID, 2), { tombstone });
   assert.equal(calls.some(({ url }) => url.pathname.startsWith("/entries/")), false);
+  assert.equal(calls.some(({ url }) => url.pathname === "/source-availability.json"), false);
 });
 
 test("an active exact version resolves through its immutable record", async () => {
@@ -304,17 +344,19 @@ test("non-absence failures from version indexes and tombstones propagate", async
 });
 
 test("an absent version index and tombstone produce the one public not-found error", async () => {
+  const calls = [];
   const routes = new Map([
     [`/versions/${ID}.json`, jsonResponse({}, 404)],
     [`/tombstones/${ID}-v9.json`, jsonResponse({}, 404)],
     ["/source-availability.json", jsonResponse({}, 404)],
   ]);
   const loader = createRegistryLoader({
-    fetch: routedFetch(routes),
+    fetch: routedFetch(routes, calls),
     location: productionLocation(),
     warn: () => {},
   });
 
   await assert.rejects(loader.loadEntry(ID, 9), /entry not found/);
   await assert.rejects(loader.loadEntry(ID, null), /entry not found/);
+  assert.equal(calls.some(({ url }) => url.pathname === "/source-availability.json"), false);
 });

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -363,6 +363,104 @@ test("a thin wrapper says where the mathematics is before anything else", async 
   }
 });
 
+test("entry and render content do not wait for a never-settling availability read", async ({ page }) => {
+  const pending = [];
+  await page.route("**/database/source-availability.json", async (route) => {
+    let release;
+    const blocked = new Promise((resolve) => {
+      release = resolve;
+    });
+    pending.push({ release });
+    await blocked;
+    await route.abort("failed");
+  });
+
+  await page.goto(
+    `/entry.html?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`,
+  );
+  await expect(page.locator(".entry-heading h1")).toBeVisible();
+  await expect(page.locator(".entry-evidence")).toBeVisible();
+  await expect(page.locator(".source-availability")).toBeHidden();
+  await expect(page.locator("#status")).toBeHidden();
+  await expect.poll(() => pending.length).toBe(1);
+  pending[0].release();
+
+  await page.goto(
+    `/render.html?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`,
+  );
+  await expect(page.locator(".entry-heading h1")).toBeVisible();
+  await expect(page.locator(".challenge-metadata")).toBeVisible();
+  await expect(page.locator("#status")).toBeHidden();
+  await expect.poll(() => pending.length).toBe(2);
+  pending[1].release();
+});
+
+test("late availability updates source links in place without taking focus", async ({ page }) => {
+  let releaseAvailability;
+  let availabilityRequested;
+  const requested = new Promise((resolve) => {
+    availabilityRequested = resolve;
+  });
+  await page.route("**/database/source-availability-missing.json", async (route) => {
+    const response = await route.fetch();
+    availabilityRequested();
+    await new Promise((resolve) => {
+      releaseAvailability = resolve;
+    });
+    await route.fulfill({ response });
+  });
+
+  await page.goto(
+    `/entry.html?id=PALOMAR-2026-07-29-000123&version=1&database=${database}` +
+      `&availability=${missingAvailability}`,
+  );
+  await requested;
+  const source = page.getByRole("link", { name: /View full pinned statement file/ });
+  await expect(source).toHaveAttribute(
+    "href",
+    /github\.com\/example\/challenge\/blob\/1{40}\//,
+  );
+  await source.focus();
+  await expect(source).toBeFocused();
+
+  releaseAvailability();
+  await expect(source).toHaveAttribute(
+    "href",
+    /github\.com\/PalomarArchive\/example--challenge\/blob\/1{40}\//,
+  );
+  await expect(source).toBeFocused();
+  await expect(page.locator(".source-availability.original-missing")).toBeVisible();
+});
+
+test("a settled manifest reports two unavailable source copies without delaying content", async ({ page }) => {
+  await page.route("**/database/source-availability-missing.json", async (route) => {
+    const response = await route.fetch();
+    const availability = await response.json();
+    const fresh = new Date().toISOString().replace(/\.[0-9]{3}Z$/, "Z");
+    availability.generated_at = fresh;
+    for (const row of availability.repositories) {
+      row.original.status = "missing";
+      row.original.checked_at = fresh;
+      row.original.last_attempt_at = fresh;
+      row.archive.status = "missing";
+      row.archive.checked_at = fresh;
+      row.archive.last_attempt_at = fresh;
+    }
+    await route.fulfill({ response, json: availability });
+  });
+
+  await page.goto(
+    `/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}` +
+      `&availability=${missingAvailability}`,
+  );
+
+  await expect(page.locator(".entry-heading h1")).toBeVisible();
+  const notice = page.getByRole("status").filter({ hasText: "No working preserved source location" });
+  await expect(notice).toHaveClass(/unrecoverable/);
+  await expect(notice.getByRole("link", { name: "Recorded original location" })).toBeVisible();
+  await expect(notice.getByRole("link", { name: "Recorded Palomar copy" })).toBeVisible();
+});
+
 test("a missing original automatically switches source links to the Palomar copy", async ({ page }) => {
   await page.goto(
     `/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}` +

--- a/tests/source-preservation.test.mjs
+++ b/tests/source-preservation.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  createSourceAvailabilityBinding,
   decorateCardSet,
   sourceDirectoryUrl,
   sourceFileUrl,
@@ -121,6 +122,53 @@ test("source location switches only from a confirmed missing original to its rec
     sourceDirectoryUrl(record, "Palomar", availability).href,
     `https://github.com/PalomarArchive/example--challenge--fixture/tree/${COMMIT}/Palomar`,
   );
+});
+
+test("availability bindings publish once to current and late source controls", async () => {
+  let release;
+  const warnings = [];
+  const binding = createSourceAvailabilityBinding(
+    new Promise((resolve) => {
+      release = resolve;
+    }),
+    (message) => warnings.push(message),
+  );
+  const published = [];
+  binding.whenReady((value) => published.push(value));
+  assert.equal(binding.current, null);
+
+  const availability = manifest();
+  release(availability);
+  assert.equal(await binding.ready, availability);
+  assert.equal(binding.current, availability);
+  assert.deepEqual(published, [availability]);
+  let late = null;
+  binding.whenReady((value) => {
+    late = value;
+  });
+  assert.equal(late, availability);
+  assert.deepEqual(warnings, []);
+});
+
+test("one broken availability control cannot block its siblings", async () => {
+  const warnings = [];
+  const binding = createSourceAvailabilityBinding(
+    Promise.resolve(manifest()),
+    (message) => warnings.push(message),
+  );
+  let siblingUpdated = false;
+  binding.whenReady(() => {
+    throw new Error("broken control");
+  });
+  binding.whenReady(() => {
+    siblingUpdated = true;
+  });
+
+  await binding.ready;
+  assert.equal(siblingUpdated, true);
+  assert.deepEqual(warnings, [
+    "Entry source availability could not be applied: broken control",
+  ]);
 });
 
 test("source location does not switch when both original and archive are missing", () => {


### PR DESCRIPTION
## Summary

- remove source availability from the critical path for entry and named-declarations pages
- publish one fail-soft page-scoped availability result to existing source controls, preserving canonical links until a validated observation settles
- keep pending notices out of the document, then insert one live status in its stable warning/provenance position after settlement
- avoid ancillary availability requests for unknown and withdrawn records
- document the exact timeout, cache, retry, and request-count contract

## Behavior and cost

An active entry or named-declarations page issues exactly one bounded availability attempt, the same request count as before. Its verified record and render no longer wait for that attempt; the ancillary read retains the existing 30-second deadline, page-scoped in-flight/settled cache, stable 404 caching, and transient/timeout/invalid eviction. Unknown and withdrawn records now issue zero availability requests instead of one. Settlement updates a fixed number of entry source controls plus O(D) dependency controls once, without repainting the page or changing focus.

The existing `availabilityRecord` lookup is linear in manifest rows R and is called for the entry and its D source dependencies, so source decoration remains O(DR). This PR does not increase that asymptotic work, but indexing the validated manifest by repository+commit would be a separate performance cleanup if the manifest grows materially. There is no additional network, Worker, or storage cost.

## Deployment compatibility

This is a Web-only behavior change. It adds no schema or producer dependency and removes no browser-module export. Browser tests load current HTML with JavaScript from exact previous deployment `a831159ac95a416c44275fa6d64d39f5941b043a` and current JavaScript with that deployment's HTML.

## Verification

- `PALOMAR_DATABASE_CHECKOUT=/tmp/palomar-web-availability.hnhSJL/PalomarDatabase npm test` (151 passed; Database `1350fad53e16e3e7a305ad20a9a78484248abb98`)
- `PALOMAR_PREVIOUS_REF=a831159ac95a416c44275fa6d64d39f5941b043a npm run test:browser` (58 passed)
- `node scripts/check-published.mjs --data https://data.palomar-registry.org` (all 1 active versions across 1 result)
- `node scripts/check-published.mjs --links` (all 4 linked documents served)
- `npm run build -- --version local-progressive-availability --output .site`
- `git diff --check`

The browser regressions prove that never-settling availability cannot delay either route, pending availability makes no optimistic claim, one late result updates links without stealing focus, and the two-copies-missing result remains explicit and accessible.