### PR TITLE
Index validated source mappings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,9 +60,17 @@
   requires the producer's declared freshness maximum to equal the consumer's.
 
 - Keep availability parsing and endpoint-freshness authority in
-  `assets/security.mjs`. `assets/source-preservation.mjs` consumes that
-  validated contract, matches manifest observations to preservation-receipt
-  mappings, and owns repository resolution plus in-place card decoration;
+  `assets/security.mjs`. It builds the private, non-serializing availability
+  index only while accepting a validated document; lookup must refuse a raw
+  object rather than scan its repositories. `assets/source-preservation.mjs`
+  consumes that validated contract, builds one private receipt index only for
+  a source record accepted by the entry or recent validator, matches manifest
+  observations, and owns repository resolution plus in-place card decoration.
+  These indexes keep total source-decoration work `O(R + D)` for `R` manifest
+  rows and `D` preservation rows; do not restore a scan for each dependency.
+  `rendering.js` deliberately re-derives the single Challenge source mapping
+  from the accepted receipt as an independent URL check; its one `O(D)` scan is
+  not a per-dependency multiplier and remains inside the stated total bound;
   `assets/entry-pages.mjs` owns entry-route parameter validation, progressive
   visibility, immutable-URL replacement, fragment scrolling, tombstone
   dispatch, and route-level errors. `assets/challenge-presentation.mjs` owns the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,15 +62,18 @@
 - Keep availability parsing and endpoint-freshness authority in
   `assets/security.mjs`. It builds the private, non-serializing availability
   index only while accepting a validated document; lookup must refuse a raw
-  object rather than scan its repositories. `assets/source-preservation.mjs`
-  consumes that validated contract, builds one private receipt index only for
-  a source record accepted by the entry or recent validator, matches manifest
-  observations, and owns repository resolution plus in-place card decoration.
+  object rather than scan its repositories. Both availability freshness and
+  the fields lookup consumes are captured by value at validation, not reread
+  from a mutable public row. `assets/source-preservation.mjs` consumes the
+  private receipt index captured by the entry or recent validator, matches
+  manifest observations, and owns repository resolution plus in-place card
+  decoration.
   These indexes keep total source-decoration work `O(R + D)` for `R` manifest
   rows and `D` preservation rows; do not restore a scan for each dependency.
   `rendering.js` deliberately re-derives the single Challenge source mapping
-  from the accepted receipt as an independent URL check; its one `O(D)` scan is
-  not a per-dependency multiplier and remains inside the stated total bound;
+  from the accepted receipt as an independent URL check; its `O(D)` scan runs a
+  fixed number of times per page, not once per dependency, and remains inside
+  the stated total bound;
   `assets/entry-pages.mjs` owns entry-route parameter validation, progressive
   visibility, immutable-URL replacement, fragment scrolling, tombstone
   dispatch, and route-level errors. `assets/challenge-presentation.mjs` owns the

--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ presentation builds one private lookup for each accepted record's preservation
 rows—`D` rows in total across the page. Decorating its source controls therefore
 takes `O(R + D)` work for the page, with constant-time repository/revision
 lookups afterward, rather than rescanning both arrays for every dependency.
-These lookups live in `WeakMap`s, do not alter the public JSON, and are available
+These lookups and the exact fields they consume are captured in private
+`WeakMap` receipts at successful validation, so later mutation cannot change
+accepted presentation data. They do not alter the public JSON and are available
 only to documents that passed the current validators.
 
 The browser code keeps the data boundary separate from presentation:

--- a/README.md
+++ b/README.md
@@ -83,12 +83,20 @@ withdrawn record makes none. Landing and search consumers share one
 in-flight/settled read. Each attempt has one 30-second deadline. A 404 is a
 stable page-scoped absence, while a timeout, transport failure, or invalid
 document is evicted so a later explicit consumer attempt can issue one retry.
+Validation builds a private lookup for the `R` availability rows, and source
+presentation builds one private lookup for each accepted record's preservation
+rows—`D` rows in total across the page. Decorating its source controls therefore
+takes `O(R + D)` work for the page, with constant-time repository/revision
+lookups afterward, rather than rescanning both arrays for every dependency.
+These lookups live in `WeakMap`s, do not alter the public JSON, and are available
+only to documents that passed the current validators.
 
 The browser code keeps the data boundary separate from presentation:
-`security.mjs` validates registry and availability documents and owns endpoint
-freshness, `source-preservation.mjs` matches validated manifest observations to
-the preservation receipt before resolving repository locations, publishing the
-progressive entry result, and decorating existing source controls,
+`security.mjs` validates registry and availability documents, owns endpoint
+freshness, and privately indexes accepted availability rows;
+`source-preservation.mjs` privately indexes each accepted preservation receipt,
+matches its manifest observations, resolves repository locations, publishes the
+progressive entry result, and decorates existing source controls,
 `entry-pages.mjs` owns entry-route input and page-state
 transitions, `challenge-presentation.mjs` owns the named-declarations artifact's
 entry correspondence and presentation states, `formalization-presentation.mjs`

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -60,12 +60,21 @@ function fail(message) {
   throw new Error(`invalid registry data: ${message}`);
 }
 
-export function assertValidatedSourceRecord(record) {
+export function validatedSourceMapping(record, repository, revision) {
   const repositories = record?.preservation?.repositories;
-  if (!Array.isArray(repositories) ||
-      validatedSourceRecords.get(record) !== repositories) {
+  const receipt = validatedSourceRecords.get(record);
+  if (!Array.isArray(repositories) || receipt?.repositories !== repositories) {
     fail("source record was not validated or its preservation receipt changed");
   }
+  return receipt.index.get(`${repository.toLowerCase()}\0${revision}`) || null;
+}
+
+function sourceMappingSnapshot(row) {
+  return Object.freeze({
+    source_repository: row.source_repository,
+    commit: row.commit,
+    fork_repository: row.fork_repository,
+  });
 }
 
 function object(value, field) {
@@ -254,6 +263,7 @@ export function validateRecent(value) {
   const entries = array(document.entries, "recent.entries");
   if (entries.length > RECENT_ITEMS) fail("recent carries more rows than it may");
   const seen = new Set();
+  const sourceReceipts = [];
   let previous = null;
   for (const [position, value] of entries.entries()) {
     const field = `recent.entries[${position}]`;
@@ -372,11 +382,17 @@ export function validateRecent(value) {
         !mapping.fork_repository.startsWith("PalomarArchive/")) {
       fail(`${field}.preservation does not match source`);
     }
+    const key = `${mapping.source_repository.toLowerCase()}\0${mapping.commit}`;
+    sourceReceipts.push({
+      record: summary,
+      repositories,
+      index: new Map([[key, sourceMappingSnapshot(mapping)]]),
+    });
   }
   // Mark rows only after the complete projection succeeds. A reference to an
   // early row from a later-rejected document must not become presentation data.
-  for (const summary of entries) {
-    validatedSourceRecords.set(summary, summary.preservation.repositories);
+  for (const receipt of sourceReceipts) {
+    validatedSourceRecords.set(receipt.record, receipt);
   }
   return document;
 }
@@ -421,7 +437,8 @@ function availabilityEndpoint(value, field) {
 export function validateAvailability(manifest) {
   const document = object(manifest, "availability");
   if (document.schema_version !== 1) fail("availability schema_version is unsupported");
-  if (availabilityTimestamp(document.generated_at) === null) {
+  const generatedAt = availabilityTimestamp(document.generated_at);
+  if (generatedAt === null) {
     fail("availability.generated_at is malformed");
   }
   if (document.database_commit !== undefined) {
@@ -462,23 +479,30 @@ export function validateAvailability(manifest) {
       ),
     };
     repositories.push(accepted);
-    index.set(key, accepted);
+    // The private consequence of validation must not point back at mutable
+    // public rows. Capture exactly the fields lookup can later return/use.
+    index.set(key, Object.freeze({
+      source_repository: accepted.source_repository,
+      commit: accepted.commit,
+      fork_repository: accepted.fork_repository,
+      original: Object.freeze({ ...accepted.original }),
+      archive: Object.freeze({ ...accepted.archive }),
+    }));
   }
   const accepted = { ...document, repositories };
-  availabilityIndexes.set(accepted, index);
+  availabilityIndexes.set(accepted, { generatedAt, index });
   return accepted;
 }
 
 export function availabilityRecord(manifest, repository, revision, now = Date.now()) {
   if (!manifest) return null;
-  const index = availabilityIndexes.get(manifest);
-  if (!index) fail("availability document was not validated");
-  const generated = availabilityTimestamp(manifest.generated_at);
-  if (generated === null || generated > now + AVAILABILITY_MAX_CLOCK_SKEW_MS ||
-      now - generated > AVAILABILITY_MAX_AGE_MS) {
+  const receipt = availabilityIndexes.get(manifest);
+  if (!receipt) fail("availability document was not validated");
+  if (receipt.generatedAt > now + AVAILABILITY_MAX_CLOCK_SKEW_MS ||
+      now - receipt.generatedAt > AVAILABILITY_MAX_AGE_MS) {
     return null;
   }
-  const record = index.get(`${repository.toLowerCase()}\0${revision}`) || null;
+  const record = receipt.index.get(`${repository.toLowerCase()}\0${revision}`) || null;
   if (record === null) return null;
 
   // generated_at describes the publication, not the age of every observation
@@ -486,9 +510,12 @@ export function availabilityRecord(manifest, repository, revision, now = Date.no
   // endpoint at the point all landing, search, and entry links consume it.
   const authoritativeEndpoint = (endpoint) => {
     const checked = availabilityTimestamp(endpoint.checked_at);
-    const normalized = checked === null && endpoint.checked_at !== null
-      ? { ...endpoint, checked_at: null }
-      : endpoint;
+    const normalized = {
+      ...endpoint,
+      checked_at: checked === null && endpoint.checked_at !== null
+        ? null
+        : endpoint.checked_at,
+    };
     if (!["available", "missing"].includes(endpoint.status)) return normalized;
     const age = checked === null ? null : now - checked;
     if (age !== null && age >= -AVAILABILITY_MAX_CLOCK_SKEW_MS &&
@@ -1234,6 +1261,7 @@ export function validateEntry(entry, summary) {
   });
   const actualRows = [];
   const seen = new Set();
+  const preservationIndex = new Map();
   for (const [position, value] of array(
     preservation.repositories,
     "entry.preservation.repositories",
@@ -1255,6 +1283,7 @@ export function validateEntry(entry, summary) {
       fail(`entry.preservation.repositories[${position}].ref is not canonical`);
     }
     actualRows.push([row.source_repository, row.commit]);
+    preservationIndex.set(key, sourceMappingSnapshot(row));
   }
   if (JSON.stringify(actualRows) !== JSON.stringify(expectedRows)) {
     fail("entry.preservation.repositories does not exactly cover the source graph");
@@ -1350,7 +1379,10 @@ export function validateEntry(entry, summary) {
   string(render.rendered_at, "entry.challenge_render.rendered_at");
 
   validateCanonicalRecordLinks(entry);
-  validatedSourceRecords.set(entry, entry.preservation.repositories);
+  validatedSourceRecords.set(entry, {
+    repositories: entry.preservation.repositories,
+    index: preservationIndex,
+  });
   return entry;
 }
 

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -50,8 +50,22 @@ const TIMESTAMP_RE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/;
 export const AVAILABILITY_MAX_AGE_MS = 18 * 60 * 60 * 1000;
 export const AVAILABILITY_MAX_CLOCK_SKEW_MS = 5 * 60 * 1000;
 
+// These indexes and validation receipts are deliberately out-of-band. Public
+// registry objects retain their exact JSON shape, while consumers can refuse
+// raw lookalikes instead of falling back to repeated array scans.
+const availabilityIndexes = new WeakMap();
+const validatedSourceRecords = new WeakMap();
+
 function fail(message) {
   throw new Error(`invalid registry data: ${message}`);
+}
+
+export function assertValidatedSourceRecord(record) {
+  const repositories = record?.preservation?.repositories;
+  if (!Array.isArray(repositories) ||
+      validatedSourceRecords.get(record) !== repositories) {
+    fail("source record was not validated or its preservation receipt changed");
+  }
 }
 
 function object(value, field) {
@@ -359,6 +373,11 @@ export function validateRecent(value) {
       fail(`${field}.preservation does not match source`);
     }
   }
+  // Mark rows only after the complete projection succeeds. A reference to an
+  // early row from a later-rejected document must not become presentation data.
+  for (const summary of entries) {
+    validatedSourceRecords.set(summary, summary.preservation.repositories);
+  }
   return document;
 }
 
@@ -414,6 +433,7 @@ export function validateAvailability(manifest) {
   }
   const seen = new Set();
   const repositories = [];
+  const index = new Map();
   for (const [position, value] of array(
     document.repositories,
     "availability.repositories",
@@ -430,7 +450,7 @@ export function validateAvailability(manifest) {
     const key = `${row.source_repository.toLowerCase()}\0${row.commit}`;
     if (seen.has(key)) fail(`availability.repositories[${position}] is duplicated`);
     seen.add(key);
-    repositories.push({
+    const accepted = {
       ...row,
       original: availabilityEndpoint(
         row.original,
@@ -440,22 +460,25 @@ export function validateAvailability(manifest) {
         row.archive,
         `availability.repositories[${position}].archive`,
       ),
-    });
+    };
+    repositories.push(accepted);
+    index.set(key, accepted);
   }
-  return { ...document, repositories };
+  const accepted = { ...document, repositories };
+  availabilityIndexes.set(accepted, index);
+  return accepted;
 }
 
 export function availabilityRecord(manifest, repository, revision, now = Date.now()) {
   if (!manifest) return null;
+  const index = availabilityIndexes.get(manifest);
+  if (!index) fail("availability document was not validated");
   const generated = availabilityTimestamp(manifest.generated_at);
   if (generated === null || generated > now + AVAILABILITY_MAX_CLOCK_SKEW_MS ||
       now - generated > AVAILABILITY_MAX_AGE_MS) {
     return null;
   }
-  const record = manifest.repositories.find(
-    (row) => row.source_repository.toLowerCase() === repository.toLowerCase() &&
-      row.commit === revision,
-  ) || null;
+  const record = index.get(`${repository.toLowerCase()}\0${revision}`) || null;
   if (record === null) return null;
 
   // generated_at describes the publication, not the age of every observation
@@ -1327,6 +1350,7 @@ export function validateEntry(entry, summary) {
   string(render.rendered_at, "entry.challenge_render.rendered_at");
 
   validateCanonicalRecordLinks(entry);
+  validatedSourceRecords.set(entry, entry.preservation.repositories);
   return entry;
 }
 

--- a/assets/source-preservation.mjs
+++ b/assets/source-preservation.mjs
@@ -1,40 +1,10 @@
 import {
-  assertValidatedSourceRecord,
   availabilityRecord,
   pinnedRepositoryDirectoryUrl,
   pinnedRepositoryFileUrl,
   safeExternalUrl,
+  validatedSourceMapping,
 } from "./security.mjs";
-
-const receiptIndexes = new WeakMap();
-
-function receiptIndex(entry) {
-  assertValidatedSourceRecord(entry);
-  if (receiptIndexes.has(entry)) return receiptIndexes.get(entry);
-
-  const index = new Map();
-  for (const row of entry.preservation.repositories) {
-    const key = `${row.source_repository.toLowerCase()}\0${row.commit}`;
-    // Validation already rejects duplicates. Keep this last check because an
-    // in-place mutation before first presentation must not make Map insertion
-    // silently choose one of two receipts.
-    if (index.has(key)) {
-      throw new Error(
-        `entry has an ambiguous source preservation receipt for ` +
-          `${row.source_repository}@${row.commit}`,
-      );
-    }
-    // Copy the three consumed fields so later presentation never observes an
-    // in-place mutation of the accepted receipt row.
-    index.set(key, {
-      source_repository: row.source_repository,
-      commit: row.commit,
-      fork_repository: row.fork_repository,
-    });
-  }
-  receiptIndexes.set(entry, index);
-  return index;
-}
 
 /**
  * Publish one fail-soft availability result to source controls as it arrives.
@@ -198,7 +168,7 @@ export function createSourceAvailabilityNotice(
 
 /** Resolve one immutable repository revision to its recorded or preserved copy. */
 export function sourceLocation(entry, availability, repository, commit) {
-  const mapping = receiptIndex(entry).get(`${repository.toLowerCase()}\0${commit}`);
+  const mapping = validatedSourceMapping(entry, repository, commit);
   if (!mapping) throw new Error(`entry has no preserved copy of ${repository}@${commit}`);
   const observed = availabilityRecord(availability, repository, commit);
   const status = observed &&
@@ -226,12 +196,12 @@ export function topSourceLocation(entry, availability) {
 
 export function sourceFileUrl(entry, path, availability) {
   const location = topSourceLocation(entry, availability);
-  return pinnedRepositoryFileUrl(location.repository, entry.source.commit, path);
+  return pinnedRepositoryFileUrl(location.repository, location.commit, path);
 }
 
 export function sourceDirectoryUrl(entry, path, availability) {
   const location = topSourceLocation(entry, availability);
-  return pinnedRepositoryDirectoryUrl(location.repository, entry.source.commit, path);
+  return pinnedRepositoryDirectoryUrl(location.repository, location.commit, path);
 }
 
 function decorateCardAvailability(card, entry, availability) {
@@ -240,10 +210,10 @@ function decorateCardAvailability(card, entry, availability) {
   if (!repositoryLink) throw new Error("card has no repository link");
   repositoryLink.textContent = location.useArchive
     ? "Palomar preserved copy"
-    : entry.source.repository;
+    : location.originalRepository;
   repositoryLink.href = pinnedRepositoryDirectoryUrl(
     location.repository,
-    entry.source.commit,
+    location.commit,
   ).href;
 
   const archiveLink = card.querySelector(".archive-link");
@@ -251,7 +221,7 @@ function decorateCardAvailability(card, entry, availability) {
   const archiveWasFocused = document.activeElement === archiveLink;
   archiveLink.href = pinnedRepositoryDirectoryUrl(
     location.archiveRepository,
-    entry.source.commit,
+    location.commit,
   ).href;
   archiveLink.hidden = location.useArchive;
   let missing = card.querySelector(".source-status.missing");

--- a/assets/source-preservation.mjs
+++ b/assets/source-preservation.mjs
@@ -1,9 +1,40 @@
 import {
+  assertValidatedSourceRecord,
   availabilityRecord,
   pinnedRepositoryDirectoryUrl,
   pinnedRepositoryFileUrl,
   safeExternalUrl,
 } from "./security.mjs";
+
+const receiptIndexes = new WeakMap();
+
+function receiptIndex(entry) {
+  assertValidatedSourceRecord(entry);
+  if (receiptIndexes.has(entry)) return receiptIndexes.get(entry);
+
+  const index = new Map();
+  for (const row of entry.preservation.repositories) {
+    const key = `${row.source_repository.toLowerCase()}\0${row.commit}`;
+    // Validation already rejects duplicates. Keep this last check because an
+    // in-place mutation before first presentation must not make Map insertion
+    // silently choose one of two receipts.
+    if (index.has(key)) {
+      throw new Error(
+        `entry has an ambiguous source preservation receipt for ` +
+          `${row.source_repository}@${row.commit}`,
+      );
+    }
+    // Copy the three consumed fields so later presentation never observes an
+    // in-place mutation of the accepted receipt row.
+    index.set(key, {
+      source_repository: row.source_repository,
+      commit: row.commit,
+      fork_repository: row.fork_repository,
+    });
+  }
+  receiptIndexes.set(entry, index);
+  return index;
+}
 
 /**
  * Publish one fail-soft availability result to source controls as it arrives.
@@ -167,14 +198,7 @@ export function createSourceAvailabilityNotice(
 
 /** Resolve one immutable repository revision to its recorded or preserved copy. */
 export function sourceLocation(entry, availability, repository, commit) {
-  const repositories = entry?.preservation?.repositories;
-  if (!Array.isArray(repositories)) {
-    throw new Error("entry has no canonical source preservation receipt");
-  }
-  const mapping = repositories.find(
-    (row) => row.source_repository.toLowerCase() === repository.toLowerCase() &&
-      row.commit === commit,
-  );
+  const mapping = receiptIndex(entry).get(`${repository.toLowerCase()}\0${commit}`);
   if (!mapping) throw new Error(`entry has no preserved copy of ${repository}@${commit}`);
   const observed = availabilityRecord(availability, repository, commit);
   const status = observed &&

--- a/tests/challenge-presentation.test.mjs
+++ b/tests/challenge-presentation.test.mjs
@@ -6,13 +6,18 @@ import {
   validateChallengeMetadata,
 } from "../assets/challenge-presentation.mjs";
 import { createSourceAvailabilityBinding } from "../assets/source-preservation.mjs";
-import { validateAvailability } from "../assets/security.mjs";
+import { validateAvailability, validateEntry } from "../assets/security.mjs";
 import {
   availabilityEndpoint,
   availabilityManifest,
   availabilityRow,
   entry,
+  summary,
 } from "./registry-fixture.mjs";
+
+function acceptedEntry() {
+  return validateEntry(entry(), summary());
+}
 
 function renderMetadata(overrides = {}) {
   return {
@@ -80,7 +85,7 @@ function byClass(root, className) {
 }
 
 test("render metadata must correspond exactly to the accepted entry", async (t) => {
-  const record = entry();
+  const record = acceptedEntry();
   const current = renderMetadata();
   assert.equal(validateChallengeMetadata(record, current), current);
   const versionOne = renderMetadata({ schema_version: 1 });
@@ -106,7 +111,7 @@ test("render metadata must correspond exactly to the accepted entry", async (t) 
 
 test("an inline presentation keeps links confined and accepts height only from its frame", async () => {
   const browser = fakeBrowser();
-  const record = entry();
+  const record = acceptedEntry();
   const metadata = renderMetadata({ module_doc: null });
   let fetched = null;
   const present = createChallengePresentation({
@@ -164,7 +169,7 @@ test("an inline presentation keeps links confined and accepts height only from i
 
 test("late availability updates statement source controls in place", async () => {
   const browser = fakeBrowser();
-  const record = entry();
+  const record = acceptedEntry();
   let releaseAvailability;
   const sourceAvailability = createSourceAvailabilityBinding(new Promise((resolve) => {
     releaseAvailability = resolve;
@@ -203,7 +208,7 @@ test("late availability updates statement source controls in place", async () =>
 
 test("a missing large entry render keeps its source controls and uses the missing-artifact fallback", async () => {
   const browser = fakeBrowser();
-  const record = entry();
+  const record = acceptedEntry();
   record.trust.challenge_lines = 101;
   const pageCalls = [];
   const missing = new Error("404 Not Found");
@@ -229,7 +234,7 @@ test("a missing large entry render keeps its source controls and uses the missin
 });
 
 test("transport and correspondence failures remain fatal to the containing route", async (t) => {
-  const record = entry();
+  const record = acceptedEntry();
   for (const [name, failure] of [
     ["transport", Object.assign(new Error("503 Unavailable"), { status: 503 })],
     ["correspondence", renderMetadata({ declarations: ["Other.theorem"] })],

--- a/tests/formalization-presentation.test.mjs
+++ b/tests/formalization-presentation.test.mjs
@@ -3,18 +3,25 @@ import test from "node:test";
 
 import { createFormalizationPresentation } from "../assets/formalization-presentation.mjs";
 import { createSourceAvailabilityBinding } from "../assets/source-preservation.mjs";
-import { validateAvailability } from "../assets/security.mjs";
+import { validateAvailability, validateEntry } from "../assets/security.mjs";
 import {
   COMMIT,
   availabilityEndpoint,
   availabilityManifest,
   availabilityRow,
   entry,
+  summary,
 } from "./registry-fixture.mjs";
 
 const CHECKED_AT = new Date(Math.floor(Date.now() / 1_000) * 1_000)
   .toISOString()
   .replace(".000Z", "Z");
+
+function acceptedEntry(mutate = () => {}) {
+  const record = entry();
+  mutate(record);
+  return validateEntry(record, summary());
+}
 
 function fakeDocument() {
   const document = {
@@ -102,8 +109,9 @@ test("the trust badge and statement dependency section present the accepted trus
 
 test("the proof section presents imports and every preserved dependency kind", () => {
   const { solutionMetadata } = createFormalizationPresentation({ document: fakeDocument() });
-  const record = entry();
-  record.formalization.project_dependencies.unshift({ name: "shared", path: "shared" });
+  const record = acceptedEntry((value) => {
+    value.formalization.project_dependencies.unshift({ name: "shared", path: "shared" });
+  });
   const section = solutionMetadata(
     record,
     { schema_version: 2, solution_imports: ["ExampleDependency"] },
@@ -141,7 +149,7 @@ test("the proof section presents imports and every preserved dependency kind", (
 test("confirmed missing originals switch the proof and dependency links to their copies", async () => {
   const document = fakeDocument();
   const { solutionMetadata } = createFormalizationPresentation({ document });
-  const record = entry();
+  const record = acceptedEntry();
   const missing = availabilityEndpoint({ status: "missing", checked_at: CHECKED_AT });
   const availability = validateAvailability(availabilityManifest([
     availabilityRow({ original: missing }),

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -473,6 +473,36 @@ test("validated availability uses one private index for every later lookup", () 
   assert.equal(JSON.stringify(manifest), serialized, "the private index does not alter JSON");
 });
 
+test("availability lookup uses the accepted snapshot rather than later row mutation", () => {
+  const now = Date.parse("2026-08-08T12:00:00Z");
+  const manifest = validateAvailability(availabilityManifest([
+    availabilityRow({
+      original: availabilityEndpoint({
+        status: "missing",
+        checked_at: "2026-08-08T12:00:00Z",
+      }),
+    }),
+  ], { generated_at: "2026-08-08T12:00:00Z" }));
+  const acceptedFork = manifest.repositories[0].fork_repository;
+
+  manifest.generated_at = "2026-08-08T13:00:00Z";
+  manifest.repositories[0].fork_repository = "PalomarArchive/example--changed";
+  manifest.repositories[0].original.status = "available";
+  manifest.repositories[0].original.checked_at = "2026-08-08T11:30:00Z";
+
+  const first = availabilityRecord(manifest, "example/challenge", COMMIT, now);
+  assert.equal(first.fork_repository, acceptedFork);
+  assert.equal(first.original.status, "missing");
+  assert.equal(first.original.checked_at, "2026-08-08T12:00:00Z");
+
+  // Lookup also must not expose its private endpoint snapshot for mutation.
+  first.original.status = "available";
+  assert.equal(
+    availabilityRecord(manifest, "example/challenge", COMMIT, now).original.status,
+    "missing",
+  );
+});
+
 test("availability lookup refuses raw and ambiguous documents", () => {
   assert.throws(
     () => availabilityRecord(availabilityManifest([availabilityRow()]), "example/challenge", COMMIT),

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -442,6 +442,48 @@ test("availability applies the inclusive freshness boundaries to each endpoint",
   assert.equal(recordAt(stamp(AVAILABILITY_MAX_CLOCK_SKEW_MS + 1_000)).status, "unknown");
 });
 
+test("validated availability uses one private index for every later lookup", () => {
+  const rows = Array.from({ length: 12 }, (_, position) => availabilityRow({
+    source_repository: `example/repository-${position}`,
+    fork_repository: `PalomarArchive/example--repository-${position}`,
+  }));
+  const manifest = validateAvailability(availabilityManifest(rows));
+  const serialized = JSON.stringify(manifest);
+  let rowReads = 0;
+  manifest.repositories = new Proxy(manifest.repositories, {
+    get(target, property, receiver) {
+      if (typeof property === "string" && /^[0-9]+$/.test(property)) rowReads += 1;
+      return Reflect.get(target, property, receiver);
+    },
+  });
+
+  for (let repetition = 0; repetition < 50; repetition += 1) {
+    assert.equal(
+      availabilityRecord(
+        manifest,
+        "EXAMPLE/repository-11",
+        COMMIT,
+        Date.parse("2026-08-08T12:00:00Z"),
+      ).source_repository,
+      "example/repository-11",
+    );
+  }
+
+  assert.equal(rowReads, 0, "accepted availability rows are never traversed by lookup");
+  assert.equal(JSON.stringify(manifest), serialized, "the private index does not alter JSON");
+});
+
+test("availability lookup refuses raw and ambiguous documents", () => {
+  assert.throws(
+    () => availabilityRecord(availabilityManifest([availabilityRow()]), "example/challenge", COMMIT),
+    /availability document was not validated/,
+  );
+  assert.throws(
+    () => validateAvailability(availabilityManifest([availabilityRow(), availabilityRow()])),
+    /is duplicated/,
+  );
+});
+
 test("one malformed endpoint cannot hide its fresh sibling or unrelated rows", () => {
   const now = Date.parse("2026-08-08T12:00:00Z");
   const manifest = validateAvailability(availabilityManifest([

--- a/tests/source-preservation.test.mjs
+++ b/tests/source-preservation.test.mjs
@@ -9,13 +9,14 @@ import {
   sourceLocation,
   topSourceLocation,
 } from "../assets/source-preservation.mjs";
-import { validateAvailability } from "../assets/security.mjs";
+import { validateAvailability, validateEntry } from "../assets/security.mjs";
 import {
   COMMIT,
   availabilityEndpoint,
   availabilityManifest,
   availabilityRow,
   entry,
+  summary,
 } from "./registry-fixture.mjs";
 
 const CHECKED_AT = new Date(Math.floor(Date.now() / 1_000) * 1_000)
@@ -34,6 +35,12 @@ function manifest({
       archive: availabilityEndpoint({ status: archive, checked_at: CHECKED_AT }),
     }),
   ], { generated_at: CHECKED_AT }));
+}
+
+function acceptedEntry(mutate = () => {}) {
+  const record = entry();
+  mutate(record);
+  return validateEntry(record, summary());
 }
 
 function fakeCard() {
@@ -95,7 +102,7 @@ function withFakeDocument(run) {
 }
 
 test("source location switches only from a confirmed missing original to its recorded archive", () => {
-  const record = entry();
+  const record = acceptedEntry();
   const availability = manifest({ original: "missing", archive: "available" });
   const location = sourceLocation(
     record,
@@ -173,7 +180,7 @@ test("one broken availability control cannot block its siblings", async () => {
 
 test("source location does not switch when both original and archive are missing", () => {
   const location = topSourceLocation(
-    entry(),
+    acceptedEntry(),
     manifest({ original: "missing", archive: "missing" }),
   );
   assert.equal(location.repository, "example/challenge");
@@ -184,7 +191,7 @@ test("source location does not switch when both original and archive are missing
 
 test("source location ignores availability for a different preserved fork", () => {
   const location = topSourceLocation(
-    entry(),
+    acceptedEntry(),
     manifest({
       original: "missing",
       forkRepository: "PalomarArchive/example--challenge--other",
@@ -198,23 +205,75 @@ test("source location ignores availability for a different preserved fork", () =
 
 test("source location rejects a repository revision absent from the preservation receipt", () => {
   assert.throws(
-    () => sourceLocation(entry(), null, "example/other", COMMIT),
+    () => sourceLocation(acceptedEntry(), null, "example/other", COMMIT),
     /entry has no preserved copy of example\/other@/,
   );
 });
 
-test("source location rejects a missing preservation receipt instead of falling back", () => {
+test("source location rejects raw records and receipts changed after validation", () => {
+  assert.throws(
+    () => topSourceLocation(entry(), null),
+    /source record was not validated/,
+  );
+
+  const missing = acceptedEntry();
+  delete missing.preservation;
+  assert.throws(
+    () => topSourceLocation(missing, null),
+    /preservation receipt changed/,
+  );
+
+  const replaced = acceptedEntry();
+  replaced.preservation = {
+    ...replaced.preservation,
+    repositories: [...replaced.preservation.repositories],
+  };
+  assert.throws(
+    () => topSourceLocation(replaced, null),
+    /preservation receipt changed/,
+  );
+});
+
+test("one accepted receipt traversal serves every later source lookup", () => {
   const record = entry();
-  delete record.preservation;
+  const rows = record.preservation.repositories;
+  let rowReads = 0;
+  record.preservation.repositories = new Proxy(rows, {
+    get(target, property, receiver) {
+      if (typeof property === "string" && /^[0-9]+$/.test(property)) rowReads += 1;
+      return Reflect.get(target, property, receiver);
+    },
+  });
+  validateEntry(record, summary());
+  const serialized = JSON.stringify(record);
+  rowReads = 0;
+
+  for (let repetition = 0; repetition < 25; repetition += 1) {
+    sourceLocation(record, null, record.source.repository, record.source.commit);
+    sourceLocation(
+      record,
+      null,
+      record.formalization.project_dependencies[0].repository,
+      record.formalization.project_dependencies[0].revision,
+    );
+  }
+
+  assert.equal(rowReads, rows.length, "the receipt is traversed exactly once to build its index");
+  assert.equal(JSON.stringify(record), serialized, "the private index does not alter serialized data");
+});
+
+test("a post-validation ambiguous receipt fails closed before it is cached", () => {
+  const record = acceptedEntry();
+  record.preservation.repositories.push({ ...record.preservation.repositories[0] });
   assert.throws(
     () => topSourceLocation(record, null),
-    /no canonical source preservation receipt/,
+    /ambiguous source preservation receipt/,
   );
 });
 
 test("card decoration isolates a malformed entry and still decorates its peer", () => {
   withFakeDocument((warnings) => {
-    const bad = entry();
+    const bad = acceptedEntry();
     bad.source = {
       ...bad.source,
       repository: "example/unpreserved",
@@ -224,7 +283,7 @@ test("card decoration isolates a malformed entry and still decorates its peer", 
 
     decorateCardSet(
       cards.map((card) => card.element),
-      [bad, entry()],
+      [bad, acceptedEntry()],
       manifest({ original: "missing", archive: "available" }),
       "Fixture card",
     );
@@ -243,7 +302,7 @@ test("card decoration reports length mismatches without throwing in its error ha
     const cards = [fakeCard(), fakeCard()];
     assert.doesNotThrow(() => decorateCardSet(
       cards.map((card) => card.element),
-      [entry()],
+      [acceptedEntry()],
       manifest({ original: "missing", archive: "available" }),
       "Fixture card",
     ));
@@ -262,7 +321,7 @@ test("card decoration transfers focus before hiding the archive link", () => {
 
     decorateCardSet(
       [card.element],
-      [entry()],
+      [acceptedEntry()],
       manifest({ original: "missing", archive: "available" }),
       "Fixture card",
     );

--- a/tests/source-preservation.test.mjs
+++ b/tests/source-preservation.test.mjs
@@ -9,13 +9,15 @@ import {
   sourceLocation,
   topSourceLocation,
 } from "../assets/source-preservation.mjs";
-import { validateAvailability, validateEntry } from "../assets/security.mjs";
+import { validateAvailability, validateEntry, validateRecent } from "../assets/security.mjs";
 import {
   COMMIT,
   availabilityEndpoint,
   availabilityManifest,
   availabilityRow,
   entry,
+  recent,
+  recentRow,
   summary,
 } from "./registry-fixture.mjs";
 
@@ -234,7 +236,7 @@ test("source location rejects raw records and receipts changed after validation"
   );
 });
 
-test("one accepted receipt traversal serves every later source lookup", () => {
+test("validation's one receipt traversal serves every later source lookup", () => {
   const record = entry();
   const rows = record.preservation.repositories;
   let rowReads = 0;
@@ -245,6 +247,7 @@ test("one accepted receipt traversal serves every later source lookup", () => {
     },
   });
   validateEntry(record, summary());
+  assert.equal(rowReads, rows.length, "validation traverses the receipt exactly once");
   const serialized = JSON.stringify(record);
   rowReads = 0;
 
@@ -258,16 +261,43 @@ test("one accepted receipt traversal serves every later source lookup", () => {
     );
   }
 
-  assert.equal(rowReads, rows.length, "the receipt is traversed exactly once to build its index");
+  assert.equal(rowReads, 0, "presentation never traverses the receipt after validation");
   assert.equal(JSON.stringify(record), serialized, "the private index does not alter serialized data");
 });
 
-test("a post-validation ambiguous receipt fails closed before it is cached", () => {
+test("post-validation receipt-row mutation cannot change the accepted mapping", () => {
   const record = acceptedEntry();
+  const acceptedFork = record.preservation.repositories[0].fork_repository;
+  record.preservation.repositories[0].source_repository = "example/changed";
+  record.preservation.repositories[0].commit = "b".repeat(40);
+  record.preservation.repositories[0].fork_repository = "PalomarArchive/example--changed";
   record.preservation.repositories.push({ ...record.preservation.repositories[0] });
+
+  assert.equal(topSourceLocation(record, null).archiveRepository, acceptedFork);
   assert.throws(
-    () => topSourceLocation(record, null),
-    /ambiguous source preservation receipt/,
+    () => sourceLocation(record, null, "example/changed", "b".repeat(40)),
+    /has no preserved copy/,
+  );
+});
+
+test("recent presentation also uses the mapping captured by validation", () => {
+  const projection = validateRecent(recent([recentRow()]));
+  const record = projection.entries[0];
+  const acceptedFork = record.preservation.repositories[0].fork_repository;
+  record.preservation.repositories[0].fork_repository = "PalomarArchive/example--changed";
+
+  assert.equal(topSourceLocation(record, null).archiveRepository, acceptedFork);
+});
+
+test("a rejected recent document leaves its earlier rows unusable", () => {
+  const first = recentRow();
+  assert.throws(
+    () => validateRecent(recent([first, recentRow()])),
+    /more than once/,
+  );
+  assert.throws(
+    () => topSourceLocation(first, null),
+    /was not validated/,
   );
 });
 


### PR DESCRIPTION
## Summary

- build a private availability index only when `validateAvailability` accepts a document
- capture a private preservation-receipt index by value when entry/recent validation succeeds
- reject raw availability lookalikes, raw entry records, replaced receipt arrays, and initially ambiguous receipt mappings instead of restoring an array-scan fallback; later in-place row mutation cannot change the accepted snapshot
- add deterministic traversal-count regressions and document the cost/ownership boundary

The public JSON schemas, serialized shapes, URLs, request count, freshness rules, progressive DOM/focus behavior, and exported shared-module surface are unchanged.

## Cost model

Before this change, decorating `D` source controls could scan `R` availability rows per control and scan `D` preservation rows per dependency: `O(DR + D²)`. Validation now traverses and snapshots the `R` availability rows and `D` preservation rows once; presentation performs zero receipt-array reads and uses constant-time matching afterward, for `O(R + D)` total source-decoration work.

The indexes are module-private `WeakMap` state and do not serialize. Landing-page rows can each create a small one-row receipt `Map`, which is modest linear allocation and slightly more fixed work than a one-element scan, but it removes the general multiplier and remains reclaimable with the accepted record. The independent Challenge URL check in `rendering.js` performs a fixed number of `O(D)` re-derivations per entry page, not one scan per dependency, so it remains within the total linear bound. This change adds no network request, storage operation, Worker execution, or public-contract field.

## Validation

- `PALOMAR_DATABASE_CHECKOUT=/tmp/palomar-web-source-index.brTbFT/PalomarDatabase npm test` — 158 passed against PalomarDatabase `34ee4aac6b5f3e9fb73d438fa1e5cfbda733e2cf`
- `PALOMAR_PREVIOUS_REF=1df850b52b6315e0a16c7b76fb0e4a250c69b5c0 ... npm run test:browser` — 58 passed, including the exact adjacent deployment
- `npm run build -- --version local-source-index-reviewed --output .site`
- `node scripts/check-published.mjs --data https://data.palomar-registry.org`
- `node scripts/check-published.mjs --links`
- `git diff --check origin/main...HEAD`

Deterministic Proxy regressions prove validation makes its one linear receipt traversal, repeated presentation makes zero later receipt-array reads, and repeated availability lookups make zero later manifest-row reads. Mutation regressions cover entry, recent, availability rows/endpoints, the captured availability publication time, and returned endpoint copies.

This is a Web-only deployment. It neither removes nor adds a versioned module-graph edge, and the adjacent-deployment gate uses the currently deployed merge `1df850b52b6315e0a16c7b76fb0e4a250c69b5c0`.
