### PR TITLE
Reconcile Web documentation and dead surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Challenges link to a dedicated rendered view. The pinned GitHub source link is
 always present. Rendered HTML is loaded in an iframe with
 `sandbox="allow-scripts"` (deliberately without `allow-same-origin`) and no
 referrer. The frame sizes itself from a height the document posts back, clamped
-between 10rem and 42rem, so an untrusted render can ask for a sensible height
+between 160 and 672 pixels, so an untrusted render can ask for a sensible height
 without being able to take the page over.
 
 A record that arrives carrying review scores is refused rather than rendered.
@@ -175,10 +175,10 @@ their existing `schema_version: 1` protocols, as do independent render and
 evidence metadata formats. Only the accepted-entry contract is v2-only.
 
 The website is a presentation layer only. Public data and schemas live at the
-machine-readable data origin. A versioned ID
-such as `PALOMAR-2026-07-29-000001-v1` names one immutable record. An ID without
-a version means the latest record; later versions may change its theorem,
-source, authors, or subject, so stable citations must include the version.
+machine-readable data origin. A permanent ID paired with an explicit integer
+version names one immutable record. An ID without a version means the latest
+record; later versions may change its theorem, source, authors, or subject, so
+stable citations must include the version.
 
 ## RSS
 
@@ -199,7 +199,7 @@ active history when older snapshots exist.
 An entry URL with both `id` and `version` identifies one immutable snapshot:
 
 ```text
-https://palomar-registry.org/entry.html?id=PALOMAR-2026-07-29-000001&version=1
+https://palomar-registry.org/entry.html?id={permanent-ID}&version={integer-version}
 ```
 
 Its HTML canonical link points to that same official, explicit version,

--- a/about.html
+++ b/about.html
@@ -284,7 +284,7 @@
             it uses Lean’s own kernel.
           </li>
           <li>
-            <strong><a href="https://github.com/ammkrn/nanoda_lib">nanoda</a></strong>
+            <strong><a href="https://github.com/robsimmons/nanoda_lib">nanoda</a></strong>
             is an independent kernel implementation written in Rust. It does not
             share Lean’s kernel code, so it can catch a class of problem that
             neither Comparator’s replay nor <code>leanchecker</code> can.
@@ -341,10 +341,11 @@
           <a href="https://github.com/mathlib-initiative/formalization.yaml"><code>formalization.yaml</code></a> starting point.
         </p>
         <p>
-          For a complete public example, see the
-          <a href="https://github.com/kim-em/erdos-unit-distance-comparator">source repository</a>
-          for Palomar’s
-          <a href="https://palomar-registry.org/entry.html?id=PALOMAR-2026-07-29-000001&amp;version=2">first registered result</a>.
+          For a complete source-repository example, see
+          <a href="https://github.com/kim-em/erdos-unit-distance-comparator">Erdős
+          unit distance problem</a>. To inspect registered examples and their
+          exact recorded revisions, browse the
+          <a href="https://palomar-registry.org/">current registry</a>.
         </p>
         <p>
           The repository root is the default project directory, so the usual

--- a/assets/rendering.js
+++ b/assets/rendering.js
@@ -82,12 +82,4 @@ export function challengeArtifactUrl(entry, renderBase) {
 export function challengeMetadataUrl(entry, renderBase) {
   return new URL("../challenge-metadata.json", challengeArtifactUrl(entry, renderBase));
 }
-
-export function entryRecordPath(id, version, path) {
-  const expected = `entries/${id}-v${version}.json`;
-  if (!ID.test(id || "") || !Number.isInteger(version) || version < 1 || path !== expected) {
-    throw new Error("registry index contains an invalid entry path");
-  }
-  return expected;
-}
 import { pinnedRepositoryFileUrl, safeRepositoryPath } from "./security.mjs";

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -573,12 +573,11 @@ export function versionsUrl(id, databaseBase) {
 /**
  * The versions of one result, from `versions/<id>.json`.
  *
- * The rows are the ones `index.json` carries, so the row grammar and
- * `entryRecordUrl` apply unchanged. What is new is coverage and ordering: this
- * document claims to be *every* active version of one identifier, so a row
- * belonging to another identifier means it is not what it says it is, and
- * reading it as if it were would show one result's history under another
- * result's name.
+ * Each row uses the registry's exact entry-summary grammar and resolves through
+ * `entryRecordUrl`. The document claims to be *every* active version of one
+ * identifier, so a row belonging to another identifier means it is not what it
+ * says it is, and reading it as if it were would show one result's history
+ * under another result's name.
  */
 export function validateVersions(value, id) {
   const document = exactObject(value, ["schema_version", "id", "entries"], "version index");
@@ -1386,20 +1385,6 @@ export function validateEntry(entry, summary) {
   return entry;
 }
 
-export function pinnedSourceFileUrl(entry, path) {
-  safeRepositoryPath(path, "source file path");
-  const expectedRepository = `https://github.com/${entry.source.repository}`;
-  if (
-    !REPOSITORY_RE.test(entry.source.repository) ||
-    entry.source.repository_url !== expectedRepository ||
-    !COMMIT_RE.test(entry.source.commit)
-  ) {
-    fail("source file link lacks canonical repository evidence");
-  }
-  const encodedPath = encodedRepositoryPath(path);
-  return safeExternalUrl(`${expectedRepository}/blob/${entry.source.commit}/${encodedPath}`);
-}
-
 export function pinnedRepositoryFileUrl(repository, revision, path) {
   if (!REPOSITORY_RE.test(repository)) fail("source repository is malformed");
   commit(revision, "source commit");
@@ -1415,20 +1400,6 @@ export function pinnedRepositoryDirectoryUrl(repository, revision, path = ".") {
   safeDependencyPath(path, "source directory path");
   const suffix = path === "." ? "" : `/${encodedRepositoryPath(path)}`;
   return safeExternalUrl(`https://github.com/${repository}/tree/${revision}${suffix}`);
-}
-
-export function pinnedSourceDirectoryUrl(entry, path) {
-  safeDependencyPath(path, "source directory path");
-  const expectedRepository = `https://github.com/${entry.source.repository}`;
-  if (
-    !REPOSITORY_RE.test(entry.source.repository) ||
-    entry.source.repository_url !== expectedRepository ||
-    !COMMIT_RE.test(entry.source.commit)
-  ) {
-    fail("source directory link lacks canonical repository evidence");
-  }
-  const suffix = path === "." ? "" : `/${encodedRepositoryPath(path)}`;
-  return safeExternalUrl(`${expectedRepository}/tree/${entry.source.commit}${suffix}`);
 }
 
 export function workflowRunId(workflowUrl) {

--- a/assets/style.css
+++ b/assets/style.css
@@ -849,8 +849,7 @@ pre {
 }
 
 .plain-list,
-.reason-list,
-.warning-list {
+.reason-list {
   margin: .4rem 0;
   padding-left: 1.5rem;
 }
@@ -859,12 +858,6 @@ pre {
   padding: .65rem .75rem .65rem 2rem;
   border-left: 2px solid var(--caution);
   background: var(--shade);
-}
-
-.warning-list {
-  padding: .65rem .75rem .65rem 2rem;
-  border-left: 4px solid var(--warning);
-  background: #fff8f2;
 }
 
 .decision {

--- a/tests/rendering.test.js
+++ b/tests/rendering.test.js
@@ -5,7 +5,6 @@ import {
   challengeArtifactUrl,
   challengeMetadataUrl,
   challengeSourceUrl,
-  entryRecordPath,
   isInlineChallenge,
 } from "../assets/rendering.js";
 
@@ -103,15 +102,4 @@ test("source URL is always the immutable canonical GitHub file", () => {
   const controlCharacter = entry();
   controlCharacter.formalization.challenge_path = "project/Task\n.lean";
   assert.throws(() => challengeSourceUrl(controlCharacter), /canonical/);
-});
-
-test("index paths cannot redirect entry fetching", () => {
-  assert.equal(
-    entryRecordPath("PALOMAR-2026-07-29-000123", 1, "entries/PALOMAR-2026-07-29-000123-v1.json"),
-    "entries/PALOMAR-2026-07-29-000123-v1.json",
-  );
-  assert.throws(
-    () => entryRecordPath("PALOMAR-2026-07-29-000123", 1, "https://attacker.invalid/entry.json"),
-    /invalid entry path/,
-  );
 });

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -33,8 +33,6 @@ import {
   VERSIONS_SCHEMA_VERSION,
   entryRecordUrl,
   isLoopbackHostname,
-  pinnedSourceDirectoryUrl,
-  pinnedSourceFileUrl,
   safeDataUrl,
   safeExternalUrl,
   safeInternalUrl,
@@ -405,10 +403,6 @@ test("active-content and insecure data-derived links are never allowed", () => {
 
 test("a canonical accepted record validates", () => {
   assert.equal(validateEntry(entry(), summary()).id, "PALOMAR-2026-07-29-000123");
-  assert.equal(
-    pinnedSourceFileUrl(entry(), "Challenge.lean").href,
-    `https://github.com/example/challenge/blob/${COMMIT}/Challenge.lean`,
-  );
 });
 
 test("preservation must cover every immutable source", () => {
@@ -868,6 +862,27 @@ test("About describes the current review and version contracts", async () => {
   assert.doesNotMatch(about, /durable-evidence schema \(version 5\)/);
   assert.match(about, /review-failed/);
   assert.match(about, /operational fault, not a decision/);
+});
+
+test("user documentation names current examples and iframe height units", async () => {
+  const about = await readFile(new URL("../about.html", import.meta.url), "utf8");
+  assert.match(about, /https:\/\/github\.com\/robsimmons\/nanoda_lib/);
+  assert.doesNotMatch(about, /github\.com\/ammkrn\/nanoda_lib/);
+  assert.match(about, /href="https:\/\/palomar-registry\.org\/"/);
+  assert.match(about, /current registry/);
+  assert.doesNotMatch(about, /first registered result/);
+  assert.doesNotMatch(about, /entry\.html\?id=PALOMAR-2026-07-29-000001/);
+
+  const readme = await readFile(new URL("../README.md", import.meta.url), "utf8");
+  const presentation = await readFile(
+    new URL("../assets/challenge-presentation.mjs", import.meta.url),
+    "utf8",
+  );
+  const bounds = /Math\.max\((\d+), Math\.min\((\d+),/.exec(presentation);
+  assert.notEqual(bounds, null, "iframe height policy must remain explicit");
+  assert.match(readme, new RegExp(`clamped\\s+between ${bounds[1]} and ${bounds[2]} pixels`));
+  assert.doesNotMatch(readme, /between 10rem and 42rem/);
+  assert.doesNotMatch(readme, /PALOMAR-2026-07-29-000001/);
 });
 
 test("About says what registration publishes, and what it does not", async () => {


### PR DESCRIPTION
## Summary

- point the NanoDa documentation at the promoted `robsimmons/nanoda_lib` repository
- replace vanished result permalinks with the live example repository, current registry, and a stable generic entry-URL form
- describe the iframe height clamp in the pixels the implementation uses and bind the documentation regression to those implementation bounds
- rewrite version-index comments in present-tense terms
- remove three test-only browser exports and their tests after whole-tree and adjacent-deployment reachability checks
- remove the unreferenced `.warning-list` style

## Impact

This changes documentation and removes unreachable code/CSS only. Public JSON contracts, URLs emitted by the application, request behavior, rendering, focus, freshness, and the shipped module graph are unchanged. The deleted exports had no production import in the current tree; the exact previous deployment imports only retained exports from the current shared modules. The diff removes 40 net lines and adds no runtime, network, storage, or financial cost.

## Validation

- `PALOMAR_DATABASE_CHECKOUT=/tmp/palomar-web-cleanup.AspVaF/PalomarDatabase npm test` — 158 passed against PalomarDatabase `acc0577d2ad0c5bdf0a14875be9a4d227e032370`
- `PALOMAR_PREVIOUS_REF=c6ebdee9b452d71fed0acbd6d3d2b1094731a4ab ... npm run test:browser` — 58 passed against the exact previous deployment
- `npm run build -- --version local-doc-cleanup-reviewed --output .site`
- `node scripts/check-published.mjs --data https://data.palomar-registry.org`
- `node scripts/check-published.mjs --links`
- live repository checks: `robsimmons/nanoda_lib` and `kim-em/erdos-unit-distance-comparator` both exist, are unarchived, and return HTTP 200; the canonical registry returns HTTP 200
- `git diff --check`

The preceding #85 merge deployed successfully in Pages run `31288269015`; both public domains served `assets/app.js` and its imports stamped with exact merge `c6ebdee9b452d71fed0acbd6d3d2b1094731a4ab` before this branch was cut.
