### PR TITLE
Make Web regressions prove their claims

### DIFF
--- a/tests/check-published.test.js
+++ b/tests/check-published.test.js
@@ -407,36 +407,46 @@ test("live-data health checks recent publication time against the already fetche
 });
 
 test("every registry document the site links to is one the registry still serves", async () => {
-  // Seven links pointed at `index.json` for weeks after it stopped being
-  // served: the landing page's machine-readable index, both noscript
-  // fallbacks, and four footers. Each answered 404 to whoever followed it, and
-  // nothing noticed, because nothing had ever asked the registry whether the
-  // documents this site names are ones it will answer for.
-  //
-  // Offline, that question is answered by the one document whose removal is
-  // already history. Against the live registry it is answered in full, by
-  // `check-published.mjs --links` in the published-site health workflow.
-  const { shippedSources, linkedDataState } = await import("../scripts/check-published.mjs");
+  const {
+    linkedDataDocuments,
+    linkedDataState,
+    shippedSources,
+  } = await import("../scripts/check-published.mjs");
+  const sources = await shippedSources();
+  const documents = linkedDataDocuments(sources);
+  for (const path of ["browse/index.json", "feed.xml", "recent.json", "source-availability.json"]) {
+    assert.ok(
+      documents.has(`https://data.palomar-registry.org/${path}`),
+      `${path} is absent from the shipped document reconciliation`,
+    );
+  }
   const asked = [];
   const registry = async (url, options) => {
-    asked.push([String(url), options.method]);
-    return { ok: new URL(url).pathname !== "/index.json", status: 404 };
+    asked.push([String(url), options]);
+    return { ok: true, status: 200 };
   };
 
-  const state = await linkedDataState(await shippedSources(), registry);
+  const state = await linkedDataState(sources, registry);
   assert.equal(state.healthy, true, state.reason);
-  assert.ok(asked.length, "the shipped site names no registry documents at all");
-  assert.deepEqual([...new Set(asked.map(([, method]) => method))], ["HEAD"]);
+  assert.ok(documents.size, "the shipped site names no registry documents at all");
+  assert.equal(asked.length, documents.size);
+  assert.deepEqual(
+    asked.map(([url]) => url).sort(),
+    [...documents.keys()].sort(),
+  );
+  for (const [, options] of asked) {
+    assert.deepEqual(options, { method: "HEAD", cache: "no-store" });
+  }
 });
 
-test("a link to a document the registry has removed is reported with the file that carries it", async () => {
+test("a missing current registry document is reported with the file that carries it", async () => {
   const { linkedDataState } = await import("../scripts/check-published.mjs");
   const state = await linkedDataState(
-    [["index.html", '<a href="https://data.palomar-registry.org/index.json">Data</a>']],
+    [["index.html", '<a href="https://data.palomar-registry.org/recent.json">Data</a>']],
     async () => ({ ok: false, status: 404 }),
   );
   assert.equal(state.healthy, false);
-  assert.match(state.reason, /index\.html links .*\/index\.json, which responded 404/);
+  assert.match(state.reason, /index\.html links .*\/recent\.json, which responded 404/);
 });
 
 test("a prefix the site builds documents out of is not itself requested", async () => {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -355,12 +355,31 @@ test("an entry answers its reader's first three questions first", async ({ page 
 });
 
 test("a thin wrapper says where the mathematics is before anything else", async ({ page }) => {
+  // validateEntry requires the substantive formalization to be one of the
+  // immutable sources already covered by the record's preservation receipt.
+  const repository = "example/dependency";
+  const commit = "3".repeat(40);
+  await page.route(
+    "**/database/entries/PALOMAR-2026-07-29-000123-v2.json",
+    async (route) => {
+      const response = await route.fetch();
+      const entry = await response.json();
+      entry.provenance.repository_role = "thin-wrapper";
+      entry.provenance.substantive_formalization = {
+        repository,
+        repository_url: `https://github.com/${repository}`,
+        commit,
+        tree_url: `https://github.com/${repository}/tree/${commit}`,
+      };
+      await route.fulfill({ response, json: entry });
+    },
+  );
+
   await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}`);
   const rows = page.locator(".entry-provenance .provenance-details .detail-row dt");
-  const labels = await rows.allTextContents();
-  if (labels.includes("Substantive formalization")) {
-    expect(labels[0]).toBe("Substantive formalization");
-  }
+  await expect(rows.first()).toHaveText("Substantive formalization");
+  await expect(page.getByRole("link", { name: `${repository}@${commit.slice(0, 12)}` }))
+    .toHaveAttribute("href", `https://github.com/${repository}/tree/${commit}`);
 });
 
 test("entry and render content do not wait for a never-settling availability read", async ({ page }) => {
@@ -970,21 +989,6 @@ test("current HTML remains compatible with cached JavaScript from the previous d
   test.skip(
     entrySchemaAtPreviousDeployment() !== currentEntrySchema,
     "the published entry schema changed, so cached JavaScript cannot read current records",
-  );
-  // The same reasoning, one level up: a bundle that reads a document the
-  // registry no longer serves cannot render whatever else it gets right. The
-  // landing page moved off `index.json` and onto `recent.json`, and the
-  // published `index.json` is gone, so the deployment before that one is
-  // reading something that answers 404.
-  //
-  // This is a deliberate one-time break, taken pre-launch and worth naming.
-  // Assets are versioned, so fresh HTML always fetches fresh JavaScript; what
-  // breaks is a tab left open across the deployment, until it is reloaded. The
-  // skip clears itself once a deployment carrying this change is the previous
-  // one, which is the same way the schema guard above clears.
-  test.skip(
-    fileAtPreviousDeployment("assets/app.js").includes("index.json"),
-    "the previous deployment reads index.json, which is no longer served",
   );
   await page.route("**/assets/app.js", (route) => route.fulfill({
     body: fileAtPreviousDeployment("assets/app.js"),


### PR DESCRIPTION
## What changed

- make the thin-wrapper browser regression construct a valid current-contract thin wrapper and unconditionally assert that its substantive formalization is first and canonically linked
- remove the expired one-deployment `index.json` skip so adjacent-deployment coverage cannot silently disappear because of an unrelated source string
- make linked-document tests prove that every discovered shipped URL receives exactly one uncached `HEAD`, anchor the reconciliation to the four documents the current site names, and exercise failure with current `recent.json`

## Audit reconciliation

The audit finding was partly current and partly stale. The thin-wrapper assertion was genuinely vacuous because the fixture was `substantive-development`. The linked-document test only established that at least one `HEAD` happened while its fake failure depended on retired `/index.json`. The cached-bundle guard had already stopped matching current and previous deployed `app.js`; removing it now retires the one-time transition logic and prevents future false skips. The missing-original full-source assertion already had a `toHaveAttribute("href", ...)` matcher on current main (introduced in ebbdbf2), so no replacement assertion was invented.

## Impact

Test-only. No shipped asset, public JSON contract, network request, cache policy, or browser runtime path changes.

## Validation

- `npm test` — 158 passed
- `npm run build -- --version test-quality-final --output .site-test-quality-final` — passed
- `PALOMAR_PREVIOUS_REF=75d782e92c435b716618ceadfc121ef219706729 npm run test:browser` with the repository's Nix Chromium path — 58 passed, including adjacent-deployment coverage
- `node scripts/check-published.mjs --links` — all 4 linked documents served
- `node scripts/check-published.mjs --data https://data.palomar-registry.org` — all advertised live entry versions accepted
- `git diff --check` — passed
