### PR TITLE
Delegate axiom policy to its owner

### DIFF
--- a/.github/workflows/publish-health.yml
+++ b/.github/workflows/publish-health.yml
@@ -54,10 +54,9 @@ jobs:
           DATA: https://data.palomar-registry.org
 
       # The other direction: not whether the records the site reads are
-      # readable, but whether the documents it sends readers to are there at
-      # all. Seven links to `index.json` outlived its removal from the service
-      # because nothing ever asked.
-      - name: Does the registry still serve every document the site links to
+      # readable, but whether the registry documents and the Policy document
+      # selected for link health are still there at all.
+      - name: Do monitored linked documents still resolve
         run: node scripts/check-published.mjs --links
 
       # One attempt, with the traps that cost a day written into the guards.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,11 +58,10 @@ jobs:
         run: node scripts/check-published.mjs --data "$PUBLIC_DATA_ORIGIN"
         env:
           PUBLIC_DATA_ORIGIN: https://data.palomar-registry.org
-      # Against the live service, because the grammar of what it serves lives
-      # in the canonical database and this repository cannot see it. A link to
-      # a document the service has removed answers 404 to a reader, which is
-      # how seven links to `index.json` survived its removal.
-      - name: Does the registry still serve every document the site links to
+      # Against the live owners, because this repository cannot prove that a
+      # registry document or the one Policy document selected for link health
+      # still exists. A removed document answers 404 to a reader.
+      - name: Do monitored linked documents still resolve
         run: node scripts/check-published.mjs --links
       - run: npx playwright install --with-deps chromium
       - run: npm run test:browser

--- a/about.html
+++ b/about.html
@@ -67,8 +67,9 @@
             recorded formal proof proves the recorded formal statement using a
             specified version of
             <a href="https://github.com/leanprover-community/mathlib4">Mathlib</a>,
-            and that it depends on no axioms beyond <code>propext</code>,
-            <code>Quot.sound</code>, and <code>Classical.choice</code>. This
+            and that it uses only the axioms allowed by Palomar’s current
+            <a href="https://github.com/PalomarRegistry/PalomarPolicy/blob/main/CONTRIBUTING.md#23-comparator-configuration">Comparator
+            configuration policy</a>. This
             exported proof is replayed through both Lean’s kernel and the
             independent NanoDa kernel. The comparison is performed using the
             <a href="https://github.com/leanprover/comparator">Comparator</a>
@@ -262,14 +263,16 @@
         <p>
           Comparator also enforces that the compared theorems use no axioms
           beyond those listed in the configured Comparator JSON file.
-          Because that file is written by the submitter, Palomar separately
-          rejects any submission whose list extends beyond <code>propext</code>,
-          <code>Quot.sound</code>, and <code>Classical.choice</code>.
+          Because that file is written by the submitter, Palomar validates it
+          against the current
+          <a href="https://github.com/PalomarRegistry/PalomarPolicy/blob/main/CONTRIBUTING.md#23-comparator-configuration">Comparator
+          configuration policy</a>, including its axiom and independent-checker
+          requirements, before Comparator runs.
         </p>
         <p>
           Lean’s replay is a second pass rather than a second implementation: it
           guards against a proof that manipulated the elaborator, not against a
-          bug in Lean’s kernel itself. Palomar therefore always enables
+          bug in Lean’s kernel itself. Palomar therefore always requires
           <code>nanoda</code> as a genuinely independent check and publishes the
           exact NanoDa commit with every registry entry. We encourage readers to
           reproduce either check themselves:
@@ -393,9 +396,10 @@
           <code>sorryAx</code>, <code>Lean.ofReduceBool</code>, a custom axiom, or
           an unnamed missing definition. The compared declarations must have the
           same names and types. Comparator rebuilds and compares them, checks the
-          permitted axioms, and verifies the proof. Palomar currently permits only
-          <code>propext</code>, <code>Quot.sound</code>, and
-          <code>Classical.choice</code>.
+          permitted axioms, and verifies the proof. Palomar validates the submitted
+          configuration against Palomar’s current
+          <a href="https://github.com/PalomarRegistry/PalomarPolicy/blob/main/CONTRIBUTING.md#23-comparator-configuration">mechanical
+          requirements</a> before verification.
         </p>
         <p>
           Keep the Challenge source short and mathematically ordinary.

--- a/scripts/check-published.mjs
+++ b/scripts/check-published.mjs
@@ -249,21 +249,29 @@ export async function publicDataState(
 // Stops at the delimiters a URL is written between: quotes and angle brackets
 // in markup, a semicolon in the CSP's source list, a bracket in CSS.
 const DATA_URL = /https:\/\/data\.palomar-registry\.org[^\s"'`<>();,]*/g;
+const POLICY_DOCUMENT_URL =
+  /https:\/\/github\.com\/PalomarRegistry\/PalomarPolicy\/blob\/main\/CONTRIBUTING\.md(?:#[A-Za-z0-9._-]+)?/g;
 
 /**
- * Every registry document the shipped site sends a reader to.
+ * Every registry document the shipped site sends a reader to, plus the mutable
+ * Policy document to which About explicitly delegates mechanical requirements.
  *
  * A URL ending in `/` names a prefix the code builds a document out of rather
  * than a document, and the bare origin appears in each page's content policy;
- * neither is something to request.
+ * neither is something to request. A fragment names a section within a
+ * document; its exact value is pinned inside About by a unit test but cannot be
+ * validated by an HTTP request. Health checks the document once without it.
  */
-export function linkedDataDocuments(sources) {
+export function monitoredLinkedDocuments(sources) {
   const found = new Map();
   for (const [name, text] of sources) {
-    for (const [href] of String(text).matchAll(DATA_URL)) {
-      const { pathname } = new URL(href);
-      if (pathname === "/" || pathname.endsWith("/")) continue;
-      if (!found.has(href)) found.set(href, name);
+    for (const pattern of [DATA_URL, POLICY_DOCUMENT_URL]) {
+      for (const [href] of String(text).matchAll(pattern)) {
+        const target = new URL(href);
+        if (target.pathname === "/" || target.pathname.endsWith("/")) continue;
+        target.hash = "";
+        if (!found.has(target.href)) found.set(target.href, name);
+      }
     }
   }
   return found;
@@ -277,17 +285,19 @@ export async function shippedSources(root = new URL("..", import.meta.url)) {
 }
 
 /**
- * Does the registry still serve every document the site links to?
+ * Do the owners still serve every document selected for continuous link health?
  *
  * `index.json` was removed from the public data service, and seven links to it
  * survived the removal: the landing page's machine-readable index, both
  * noscript fallbacks and four footers, each answering 404 to whoever followed
  * it. Nothing noticed, because nothing had ever asked the service whether the
  * documents this site names are documents it will answer for. Asking it is the
- * only check that cannot drift from it.
+ * only check that cannot drift from it. The same check also proves that the
+ * selected Policy owner still serves the document to which About delegates its
+ * mutable Comparator rules.
  */
-export async function linkedDataState(sources, fetcher = fetch) {
-  const documents = linkedDataDocuments(sources);
+export async function linkedDocumentState(sources, fetcher = fetch) {
+  const documents = monitoredLinkedDocuments(sources);
   const dead = [];
   await Promise.all([...documents].map(async ([href, name]) => {
     try {
@@ -300,7 +310,7 @@ export async function linkedDataState(sources, fetcher = fetch) {
   if (dead.length) return { healthy: false, reason: dead.sort().join("; ") };
   return {
     healthy: true,
-    reason: `the registry serves all ${documents.size} documents the site links to`,
+    reason: `all ${documents.size} monitored linked documents resolve`,
   };
 }
 
@@ -318,7 +328,7 @@ async function main(argv) {
     return state.healthy ? 0 : 1;
   }
   if (options.has("links") && !url && !expected) {
-    const state = await linkedDataState(await shippedSources());
+    const state = await linkedDocumentState(await shippedSources());
     console.log(state.reason);
     return state.healthy ? 0 : 1;
   }

--- a/tests/check-published.test.js
+++ b/tests/check-published.test.js
@@ -406,29 +406,34 @@ test("live-data health checks recent publication time against the already fetche
   assert.match(state.reason, /does not match its entry registered_at/);
 });
 
-test("every registry document the site links to is one the registry still serves", async () => {
+test("every monitored linked document is requested exactly once from its owner", async () => {
   const {
-    linkedDataDocuments,
-    linkedDataState,
+    linkedDocumentState,
+    monitoredLinkedDocuments,
     shippedSources,
   } = await import("../scripts/check-published.mjs");
   const sources = await shippedSources();
-  const documents = linkedDataDocuments(sources);
+  const documents = monitoredLinkedDocuments(sources);
   for (const path of ["browse/index.json", "feed.xml", "recent.json", "source-availability.json"]) {
     assert.ok(
       documents.has(`https://data.palomar-registry.org/${path}`),
       `${path} is absent from the shipped document reconciliation`,
     );
   }
+  assert.deepEqual(
+    [...documents.keys()].filter((href) => href.includes("PalomarRegistry/PalomarPolicy")),
+    ["https://github.com/PalomarRegistry/PalomarPolicy/blob/main/CONTRIBUTING.md"],
+    "About's Policy links must collapse to one fragment-free request",
+  );
   const asked = [];
   const registry = async (url, options) => {
     asked.push([String(url), options]);
     return { ok: true, status: 200 };
   };
 
-  const state = await linkedDataState(sources, registry);
+  const state = await linkedDocumentState(sources, registry);
   assert.equal(state.healthy, true, state.reason);
-  assert.ok(documents.size, "the shipped site names no registry documents at all");
+  assert.ok(documents.size, "the shipped site names no monitored documents at all");
   assert.equal(asked.length, documents.size);
   assert.deepEqual(
     asked.map(([url]) => url).sort(),
@@ -440,8 +445,8 @@ test("every registry document the site links to is one the registry still serves
 });
 
 test("a missing current registry document is reported with the file that carries it", async () => {
-  const { linkedDataState } = await import("../scripts/check-published.mjs");
-  const state = await linkedDataState(
+  const { linkedDocumentState } = await import("../scripts/check-published.mjs");
+  const state = await linkedDocumentState(
     [["index.html", '<a href="https://data.palomar-registry.org/recent.json">Data</a>']],
     async () => ({ ok: false, status: 404 }),
   );
@@ -450,12 +455,12 @@ test("a missing current registry document is reported with the file that carries
 });
 
 test("a prefix the site builds documents out of is not itself requested", async () => {
-  const { linkedDataDocuments } = await import("../scripts/check-published.mjs");
+  const { monitoredLinkedDocuments } = await import("../scripts/check-published.mjs");
   // `connect-src https://data.palomar-registry.org` in every page's content
   // policy, and the render base the entry page resolves an artifact against.
   // Neither names a document, and requesting either would report a 404 that
   // means nothing.
-  const documents = linkedDataDocuments([
+  const documents = monitoredLinkedDocuments([
     ["index.html", "connect-src 'self' https://data.palomar-registry.org; frame-src 'self'"],
     ["assets/security.mjs", 'const base = "https://data.palomar-registry.org/";'],
   ]);

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -885,6 +885,15 @@ test("user documentation names current examples and iframe height units", async 
   assert.doesNotMatch(readme, /PALOMAR-2026-07-29-000001/);
 });
 
+test("About delegates the mutable axiom allowlist to the promoted Policy", async () => {
+  const about = await readFile(new URL("../about.html", import.meta.url), "utf8");
+  assert.match(
+    about,
+    /PalomarPolicy\/blob\/main\/CONTRIBUTING\.md#23-comparator-configuration/,
+  );
+  assert.doesNotMatch(about, /propext|Quot\.sound|Classical\.choice/);
+});
+
 test("About says what registration publishes, and what it does not", async () => {
   // About said the submitter's identity becomes public on registration. It
   // does not, the schema has no field for it, and that is the direction of


### PR DESCRIPTION
## What changed

- replace all three copies of the permitted-axiom allowlist in About with present-tense explanations linked to the promoted `PalomarPolicy` Comparator configuration requirements
- correct the adjacent NanoDa wording: Palomar requires an exact enabled setting and rejects misleading input; it does not silently enable or rewrite it
- extend the existing PR/hourly linked-document health check to the one mutable Policy document About now relies on, normalizing repeated anchored links to one document request

## Source of truth

The authoritative target is [`PalomarPolicy/CONTRIBUTING.md` §2.3 Comparator configuration](https://github.com/PalomarRegistry/PalomarPolicy/blob/main/CONTRIBUTING.md#23-comparator-configuration). The current promoted Policy main at `4e6e4e0e40f00309eadc460f54ebf3396b5cca27` defines the allowlist and mandatory exact `enable_nanoda: true` contract there. The URL returns HTTP 200 and GitHub's rendered table of contents names the exact `23-comparator-configuration` anchor.

HTTP does not transmit fragments, so the unit test pins the exact section link while live health proves that the owning document still resolves. The fragment is deliberately not claimed as remotely validated.

README and AGENTS do not copy the allowlist and therefore need no reconciliation.

## Cost and contract impact

No browser runtime, page-load request, build-time fetch, generator, cross-repository parser, public JSON contract, or deployment-order change. The already existing PR/hourly `--links` check makes exactly one additional unauthenticated `HEAD` request. Repeated links and fragments collapse to one private Map key, so this is a fixed `+1` per health invocation rather than a term that grows with page references.

## Validation

- `npm test` — 159 passed
- `npm run build -- --version axiom-policy-final --output .site-test-axiom-policy-final` — passed
- `PALOMAR_PREVIOUS_REF=f1ba865172f572bc60291ff3133410dc393fd28f npm run test:browser` with the repository's Nix Chromium path — 58 passed
- `node scripts/check-published.mjs --data https://data.palomar-registry.org` — all advertised live entry versions accepted
- `node scripts/check-published.mjs --links` — all 5 monitored documents resolved, including Policy
- exact Policy URL/anchor inspection and unauthenticated `HEAD` — passed
- `git diff --check` — passed
