### PR TITLE
Stop the producer-contract test blaming the checkout for its own bugs

### DIFF
--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { htmlFiles } from "../scripts/build-site.mjs";
 import {
@@ -63,6 +64,42 @@ import {
 // The website's own origin, for the cross-origin assertion below.
 const CANONICAL_WEB_BASE_FOR_TEST = "https://palomar-registry.org/";
 const AVAILABILITY_PRODUCER_COMMIT = "7e446fda08d26b5c1290a9e3ec0947ece0c4994e";
+
+/**
+ * The sibling PalomarDatabase checkout, as a filesystem path.
+ *
+ * `new URL(...).pathname` is a URL component, not a path: on Windows it is
+ * `/c:/Users/...`, which git rejects outright. That reached `git -C` at the
+ * source-availability contract below, and its catch reported a stale checkout
+ * for what was a malformed argument -- a confident wrong diagnosis that only
+ * ever appears off CI, since CI is Linux and the two spellings agree there.
+ */
+function databaseCheckout() {
+  return (
+    process.env.PALOMAR_DATABASE_CHECKOUT
+    ?? fileURLToPath(new URL("../../PalomarDatabase/", import.meta.url))
+  );
+}
+
+/**
+ * The Python that can run the producer's contract module.
+ *
+ * `python3` is the name on CI and on a developer's Linux or macOS machine, and
+ * is not a name Windows has: there the interpreter is `python`, and the stub
+ * Windows ships under the other name answers by advertising the Store. Trying
+ * both keeps the contract exercised rather than reported as broken.
+ */
+function pythonInterpreter() {
+  for (const candidate of ["python3", "python"]) {
+    try {
+      execFileSync(candidate, ["-c", ""], { stdio: "ignore" });
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+  assert.fail("no Python interpreter is available to run the producer contract");
+}
 
 test("production ignores every database query override", () => {
   for (const override of [
@@ -182,8 +219,7 @@ test("recent validation accepts the Database-owned landing-card fixture", async 
   // This is the same mandatory cross-repository contract mechanism used for
   // canonical schemas below. Locally it reads PalomarDatabase's checked
   // fixture; CI supplies the published producer output at the same path.
-  const checkout = process.env.PALOMAR_DATABASE_CHECKOUT
-    ?? new URL("../../PalomarDatabase/", import.meta.url).pathname;
+  const checkout = databaseCheckout();
   const fixture = JSON.parse(
     await readFile(new URL("tests/fixtures/recent.json", `file://${checkout}/`), "utf8"),
   );
@@ -591,8 +627,7 @@ test("availability keeps whole-document freshness inclusive and fail-closed", ()
 });
 
 test("availability agrees with the Database producer contract", async () => {
-  const checkout = process.env.PALOMAR_DATABASE_CHECKOUT
-    ?? new URL("../../PalomarDatabase/", import.meta.url).pathname;
+  const checkout = databaseCheckout();
   const executable = new URL("tools/source_availability_contract.py", `file://${checkout}/`);
   try {
     await readFile(executable, "utf8");
@@ -645,7 +680,7 @@ test("availability agrees with the Database producer contract", async () => {
     "value = normalize_manifest(json.load(sys.stdin), as_of=dt.datetime(2026, 8, 8, 12, tzinfo=dt.UTC))",
     "json.dump(value, sys.stdout, sort_keys=True)",
   ].join("; ");
-  const produced = JSON.parse(execFileSync("python3", ["-c", script], {
+  const produced = JSON.parse(execFileSync(pythonInterpreter(), ["-c", script], {
     encoding: "utf8",
     input: JSON.stringify(raw),
   }));
@@ -967,8 +1002,7 @@ test("every provenance value the schema allows has an explicit label", async () 
   // sets PALOMAR_DATABASE_CHECKOUT; locally a sibling clone is assumed. This
   // test exists because the site drifting from the schema is what took the
   // registry down, so an unavailable schema is a failure, not a skip.
-  const checkout = process.env.PALOMAR_DATABASE_CHECKOUT
-    ?? new URL("../../PalomarDatabase/", import.meta.url).pathname;
+  const checkout = databaseCheckout();
   const schema = JSON.parse(
     await readFile(new URL("schema-v2.json", `file://${checkout}/`), "utf8"),
   );
@@ -986,8 +1020,7 @@ test("every provenance value the schema allows has an explicit label", async () 
 });
 
 test("the site requires the Database entry version and exact preservation shape", async () => {
-  const checkout = process.env.PALOMAR_DATABASE_CHECKOUT
-    ?? new URL("../../PalomarDatabase/", import.meta.url).pathname;
+  const checkout = databaseCheckout();
   const schema = JSON.parse(
     await readFile(new URL("schema-v2.json", `file://${checkout}/`), "utf8"),
   );

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
@@ -221,7 +222,7 @@ test("recent validation accepts the Database-owned landing-card fixture", async 
   // fixture; CI supplies the published producer output at the same path.
   const checkout = databaseCheckout();
   const fixture = JSON.parse(
-    await readFile(new URL("tests/fixtures/recent.json", `file://${checkout}/`), "utf8"),
+    await readFile(join(checkout, "tests", "fixtures", "recent.json"), "utf8"),
   );
   assert.ok(fixture.entries.length > 0, "the external contract fixture must exercise a row");
   assert.equal(validateRecent(fixture), fixture);
@@ -628,7 +629,7 @@ test("availability keeps whole-document freshness inclusive and fail-closed", ()
 
 test("availability agrees with the Database producer contract", async () => {
   const checkout = databaseCheckout();
-  const executable = new URL("tools/source_availability_contract.py", `file://${checkout}/`);
+  const executable = join(checkout, "tools", "source_availability_contract.py");
   try {
     await readFile(executable, "utf8");
   } catch (error) {
@@ -638,7 +639,7 @@ test("availability agrees with the Database producer contract", async () => {
     // the same checkout root. This remains a mandatory exercised contract,
     // not a skip; local development invokes the exact executable below.
     const fixture = JSON.parse(await readFile(
-      new URL("tests/fixtures/source-availability.json", `file://${checkout}/`),
+      join(checkout, "tests", "fixtures", "source-availability.json"),
       "utf8",
     ));
     assert.ok(fixture.repositories.length > 0, "the deployed contract must exercise a row");
@@ -1004,7 +1005,7 @@ test("every provenance value the schema allows has an explicit label", async () 
   // registry down, so an unavailable schema is a failure, not a skip.
   const checkout = databaseCheckout();
   const schema = JSON.parse(
-    await readFile(new URL("schema-v2.json", `file://${checkout}/`), "utf8"),
+    await readFile(join(checkout, "schema-v2.json"), "utf8"),
   );
   const provenance = schema.properties.provenance.properties;
   for (const [field, labels] of [
@@ -1022,7 +1023,7 @@ test("every provenance value the schema allows has an explicit label", async () 
 test("the site requires the Database entry version and exact preservation shape", async () => {
   const checkout = databaseCheckout();
   const schema = JSON.parse(
-    await readFile(new URL("schema-v2.json", `file://${checkout}/`), "utf8"),
+    await readFile(join(checkout, "schema-v2.json"), "utf8"),
   );
   assert.strictEqual(schema.properties.schema_version.const, ENTRY_SCHEMA_VERSION);
   assert.ok(schema.required.includes("preservation"));


### PR DESCRIPTION
`tests/security.test.mjs` fails on Windows for two reasons, and reports the first one as something it isn't.

**The checkout path.** It resolved the sibling repository with `new URL("../../PalomarDatabase/", import.meta.url).pathname`. A URL `pathname` is not a filesystem path: on Windows it is `/c:/Users/...`, which git rejects with *"Invalid argument"*. The `catch` around `git merge-base` then reported

> PalomarDatabase checkout … is older than the required source-availability contract …; fetch current main

The contract was satisfied the whole time — `7e446fd` is an ancestor of `HEAD`. A catch that turns every failure mode into one confident diagnosis is worse than no message at all, and this one only ever misleads off CI, since CI is Linux and the two spellings agree there.

**The interpreter.** With the path fixed the test reaches `execFileSync("python3", ...)`, which is not a name Windows has; the stub it ships under that name answers by advertising the Microsoft Store.

Both are the same bug in different clothes: a cross-repository contract that can only be exercised on one platform is a contract nobody can check before pushing.

The fix adds two small helpers — `databaseCheckout()` using `fileURLToPath`, and `pythonInterpreter()` trying `python3` then `python` — and replaces the four duplicated copies of the checkout expression with the first of them. CI behaviour is unchanged: both workflows set `PALOMAR_DATABASE_CHECKOUT`, so that branch is taken there exactly as before.

Locally this takes the suite from 151/154 to 152/154. The two that remain are `es-module-lexer` missing from `node_modules` — a stale install that `npm ci` fixes, not a code problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
