### PR TITLE
Name Comparator files in registration assurance

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -675,9 +675,9 @@ const {
 } = createEntryHistoryPresentation({ document, localPageUrl, window });
 
 /** One kind of assurance, named so the two can be told apart at a glance. */
-function assurance(kind, sentence) {
+function assurance(kind, ...content) {
   const paragraph = el("p");
-  paragraph.append(el("strong", "", `${kind}: `), document.createTextNode(sentence));
+  paragraph.append(el("strong", "", `${kind}: `), ...content);
   return paragraph;
 }
 
@@ -742,11 +742,17 @@ function acceptanceCallout(entry, databaseBase) {
     el("strong", "", `Registered on ${displayDate(registrationDate(entry.registered_at))}`),
     assurance(
       "Mechanical assurance",
-      "Comparator checked that the recorded Solution proves the recorded formal Challenge under the listed axiom and dependency rules, and both Lean's kernel and NanoDa accepted the exported proof.",
+      "Comparator checked that the recorded ",
+      el("code", "", "Solution.lean"),
+      " proves the recorded formal ",
+      el("code", "", "Challenge.lean"),
+      " under the listed axiom and dependency rules, and both Lean's kernel and NanoDa accepted the exported proof.",
     ),
     assurance(
       "Editorial assurance",
-      "an AI-mediated review judged whether that formal Challenge matches the informal mathematical claim under the recorded policy. This is not human peer review or a novelty certificate.",
+      "an AI-mediated review judged whether that formal ",
+      el("code", "", "Challenge.lean"),
+      " matches the informal mathematical claim under the recorded policy. This is not human peer review or a novelty certificate.",
     ),
     evidenceLinks,
   );

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -870,6 +870,17 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
     "Editorial assurance",
   );
   await expect(page.locator(".acceptance-callout")).toContainText("AI-mediated review");
+  const mechanicalAssurance = page.locator(".acceptance-callout p", {
+    hasText: "Mechanical assurance",
+  });
+  await expect(mechanicalAssurance.locator("code")).toHaveText([
+    "Solution.lean",
+    "Challenge.lean",
+  ]);
+  const editorialAssurance = page.locator(".acceptance-callout p", {
+    hasText: "Editorial assurance",
+  });
+  await expect(editorialAssurance.locator("code")).toHaveText("Challenge.lean");
   await expect(page.getByRole("link", { name: "Archived mechanical report" })).toBeVisible();
   await expect(page.getByText("Verification workflow commit")).toBeVisible();
   await expect(page.getByRole("link", { name: "Archived editorial review" })).toBeVisible();


### PR DESCRIPTION
## Summary
- name the recorded files as `Solution.lean` and `Challenge.lean`
- render the filenames in fixed-width code styling in registration assurances
- verify the exact code elements in the browser suite

## Verification
- `npm test`
- `npm run build -- --version local-test --output .site`
- `npm run test:browser` with Nixpkgs Chromium