### PR TITLE
About: what a submitter can do when they disagree with the review

### DIFF
--- a/about.html
+++ b/about.html
@@ -137,6 +137,25 @@
         </p>
       </section>
 
+      <section id="disagreeing-with-the-review">
+        <h2>I disagree with the review’s assessment of my result. What can I do?</h2>
+        <p>
+          There is no appeal for an individual result: reopening a few decisions
+          for whoever writes in would make the outcome depend on who complained.
+          A rejected submission leaves no public record, and it can be revised
+          and resubmitted after a waiting period. Repeated submissions lengthen
+          that wait steeply, but carry no other penalty.
+        </p>
+        <p>
+          If you think the <a href="#editorial-floor">editorial floor</a> itself
+          is wrong, or you have run into anything else that looks like a defect
+          in Palomar rather than a disagreement about one result, please raise it
+          in the
+          <a href="https://leanprover.zulipchat.com/#narrow/channel/621638-Palomar">Palomar
+          channel on the Lean Zulip</a>.
+        </p>
+      </section>
+
       <section id="licences">
         <h2>What does the licence check cover?</h2>
         <p>


### PR DESCRIPTION
Answers a question the page did not, and which the editorial floor makes inevitable: what recourse a submitter has when the review judges their result below the research-interest bar.

The policy is that there is no appeal for an individual result. A bare statement of that reads as arbitrary, so the section gives the reason — reopening a few decisions for whoever writes in would make the outcome depend on who complained, which is worse than a floor applied uniformly, including to the people who would have argued well. That is also the more honest reason than capacity, which invites "so you would appeal if you had time?"

Three things it is careful to say:

- **A rejection leaves no public record.** This is the fact somebody in that position is most likely to be worried about, and it costs a clause.
- **The wait lengthens steeply.** Without this, "carries no other penalty" reads as an invitation to resubmit unchanged. The admission interval doubles on every start and only a completed registration resets it, so the throttle is what makes rerolling impractical — worth signalling without accusing anyone.
- **Zulip is for the standard and for defects, not for one result.** Phrased so that a verification bug or a rendering problem is clearly in scope too, and so that nobody reads it as an appeals channel by the back door.

Placed after "What does acceptance by Palomar mean?", which is where the editorial floor is defined and which this section links back to. That keeps it clear of the insertion points in #90 and #92, so all three merge independently.

Test suite unchanged at 151/154; the three failures are pre-existing and unrelated (two are `es-module-lexer` missing from `node_modules`, one is fixed by #91).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
