### PR TITLE
About: why there are no comments on entries, and what exists instead

### DIFF
--- a/about.html
+++ b/about.html
@@ -229,6 +229,24 @@
         </ol>
       </section>
 
+      <section id="commenting">
+        <h2>Is there a way to leave comments on a registry entry?</h2>
+        <p>
+          Not on Palomar, which does not have the resources to moderate
+          discussion.
+        </p>
+        <p>
+          The repository an entry points at is the natural home for technical
+          discussion, and most accept issues and pull requests. Beyond that, the
+          registry metadata is dedicated to the public domain under
+          <a href="https://data.palomar-registry.org/LICENSE">CC0</a> and
+          published with
+          <a href="https://data.palomar-registry.org/feed.xml">feeds</a>, so
+          anyone can build a commentary layer over Palomar. However, Palomar
+          does not run or endorse any such site.
+        </p>
+      </section>
+
       <section id="check-it-yourself">
         <h2>How can I check this myself?</h2>
         <p>


### PR DESCRIPTION
Answers whether a reader can comment on a registry entry. The answer is no, and the reason is that moderating discussion is not something Palomar has the resources to do — the same constraint that rules out appeals. Saying so keeps "no" from reading as indifference.

The second paragraph is the useful half. A third party wanting to discuss entries does not need permission, they need data, and Palomar already publishes it: the registry metadata is dedicated to the public domain under CC0, and the data host serves `/feed.xml` alongside per-subject feeds. Both links point at paths already in the data Worker's public allowlist.

Two framings deliberately avoided:

- **Not "Palomar allows third-party comment sites."** Palomar can neither grant nor withhold that, and the verb would imply an endorsement that is the opposite of the intent. The text says instead that Palomar does not run or endorse any such site.
- **Not a pointer to the Zulip channel.** Sending per-entry commentary there would relocate the moderation load rather than decline it. Zulip stays where the other section puts it: defects and objections to the standard.

Placed before "How can I check this myself?", which keeps it clear of the insertion points in #90, #92 and #94, so all four merge independently in any order.

Test suite unchanged at 151/154; the three failures are pre-existing and unrelated (two are `es-module-lexer` missing from `node_modules`, one is fixed by #91).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
