### PR TITLE
Add browser-driven light and dark themes

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#101216" media="(prefers-color-scheme: dark)">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Not found — Palomar</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">

--- a/about.html
+++ b/about.html
@@ -4,7 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="About Palomar and submitting machine-checked formal mathematics.">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#101216" media="(prefers-color-scheme: dark)">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>About — Palomar</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,19 +1,66 @@
 :root {
-  color-scheme: light;
+  color-scheme: light dark;
   --ink: #111;
   --muted: #555;
   --faint: #666;
   --paper: #fff;
   --shade: #f2f2f2;
+  --control: #e8e8e8;
+  --control-hover: #ddd;
   --line: #aaa;
+  --field: #777;
   --link: #0000cc;
   --visited: #551a8b;
+  --hover: #b00000;
   --caution: #5d4b00;
   --warning: #8b0000;
+  --notice-paper: #fffbea;
+  --copied: #176f2c;
+  --success: #145c24;
+  --success-mark: #19712b;
+  --success-line: #77a67b;
+  --success-paper: #eef8ef;
+  --token-line: #bbb;
+  --available: #52714f;
+  --missing: #9a6700;
+  --missing-paper: #fff8df;
+  --unrecoverable: #b42318;
+  --unrecoverable-paper: #fff1f0;
   --max: 64rem;
   --serif: Georgia, "Times New Roman", Times, serif;
   --sans: Arial, Helvetica, sans-serif;
   --mono: "Courier New", Courier, monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ink: #e8eaee;
+    --muted: #b5bbc5;
+    --faint: #a4abb7;
+    --paper: #101216;
+    --shade: #1c2027;
+    --control: #242933;
+    --control-hover: #2b303a;
+    --line: #686f7c;
+    --field: #8e96a3;
+    --link: #8ab4f8;
+    --visited: #d7aefb;
+    --hover: #ff9e91;
+    --caution: #f0c66a;
+    --warning: #ff9e91;
+    --notice-paper: #2b260f;
+    --copied: #91d69b;
+    --success: #91d69b;
+    --success-mark: #72c17d;
+    --success-line: #668f6c;
+    --success-paper: #16251a;
+    --token-line: #686f7c;
+    --available: #8fbd8a;
+    --missing: #f0c66a;
+    --missing-paper: #2b260f;
+    --unrecoverable: #ff9e91;
+    --unrecoverable-paper: #301918;
+  }
 }
 
 * {
@@ -43,7 +90,7 @@ a:visited {
 
 a:hover,
 a:focus-visible {
-  color: #b00000;
+  color: var(--hover);
 }
 
 .skip-link {
@@ -190,7 +237,7 @@ h3 {
   max-width: 34rem;
   min-height: 2.1rem;
   padding: .3rem .45rem;
-  border: 1px solid #777;
+  border: 1px solid var(--field);
   border-radius: 0;
   background: var(--paper);
   color: var(--ink);
@@ -235,7 +282,7 @@ body.registry-searching #entry-grid {
   width: 100%;
   min-height: 2rem;
   padding: .25rem .4rem;
-  border: 1px solid #777;
+  border: 1px solid var(--field);
   border-radius: 0;
   background: var(--paper);
   color: var(--ink);
@@ -272,7 +319,7 @@ button:focus-visible {
   min-height: 2rem;
   width: 9rem;
   padding: .25rem .4rem;
-  border: 1px solid #777;
+  border: 1px solid var(--field);
   border-radius: 0;
   background: var(--paper);
   color: var(--ink);
@@ -296,16 +343,16 @@ button:focus-visible {
 .filter {
   min-height: 2rem;
   padding: .25rem .5rem;
-  border: 1px solid #777;
+  border: 1px solid var(--field);
   border-radius: 0;
-  background: #e8e8e8;
+  background: var(--control);
   color: var(--ink);
   cursor: pointer;
   font: .8rem var(--sans);
 }
 
 .filter:hover {
-  background: #ddd;
+  background: var(--control-hover);
 }
 
 .filter.active {
@@ -485,7 +532,7 @@ footer {
 }
 
 .heading-anchor.copied {
-  color: #176f2c;
+  color: var(--copied);
   opacity: 1;
 }
 
@@ -597,7 +644,7 @@ footer {
   margin-bottom: 1.5rem;
   padding: .85rem 1rem;
   border: 2px solid var(--caution);
-  background: #fffbea;
+  background: var(--notice-paper);
 }
 
 .version-notice h2 {
@@ -642,8 +689,8 @@ footer {
 }
 
 .version-state.current {
-  border-color: #77a67b;
-  color: #145c24;
+  border-color: var(--success-line);
+  color: var(--success);
 }
 
 .version-state.superseded {
@@ -724,8 +771,8 @@ footer {
   gap: .8rem;
   margin-bottom: 1rem;
   padding: .8rem;
-  border: 1px solid #77a67b;
-  background: #eef8ef;
+  border: 1px solid var(--success-line);
+  background: var(--success-paper);
 }
 
 .acceptance-check {
@@ -735,13 +782,13 @@ footer {
   height: 2rem;
   place-items: center;
   border-radius: 50%;
-  background: #19712b;
-  color: #fff;
+  background: var(--success-mark);
+  color: var(--paper);
   font: bold 1.25rem/1 var(--sans);
 }
 
 .acceptance-callout strong {
-  color: #145c24;
+  color: var(--success);
   font: bold 1rem/1.3 var(--sans);
 }
 
@@ -761,7 +808,7 @@ footer {
 }
 
 .accepted-decision {
-  color: #19712b;
+  color: var(--success);
 }
 
 .solution-dependencies {
@@ -843,7 +890,7 @@ pre {
 
 .token-list code {
   padding: .15rem .3rem;
-  border: 1px solid #bbb;
+  border: 1px solid var(--token-line);
   background: var(--shade);
   font-size: .8rem;
 }
@@ -1000,9 +1047,9 @@ pre {
 
 }
 .entry-page .source-availability {
-  border: 1px solid var(--line, #d9d6cc);
-  border-left: 0.35rem solid #52714f;
-  border-radius: 0.45rem;
+  border: 1px solid var(--line);
+  border-left: 0.35rem solid var(--available);
+  border-radius: 0;
   margin: 1rem 0 1.5rem;
   padding: 1rem 1.25rem;
 }
@@ -1013,17 +1060,17 @@ pre {
 
 .source-availability.original-missing,
 .source-availability.archive-missing {
-  border-left-color: #9a6700;
-  background: #fff8df;
+  border-left-color: var(--missing);
+  background: var(--missing-paper);
 }
 
 .source-availability.unrecoverable {
-  border-left-color: #b42318;
-  background: #fff1f0;
+  border-left-color: var(--unrecoverable);
+  background: var(--unrecoverable-paper);
 }
 
 .source-status.missing {
-  color: #9a6700;
+  color: var(--missing);
   font-size: 0.85rem;
   font-weight: 700;
 }

--- a/entry.html
+++ b/entry.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#101216" media="(prefers-color-scheme: dark)">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Registry entry — Palomar</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">

--- a/favicon.svg
+++ b/favicon.svg
@@ -3,9 +3,9 @@
   <style>
     /* Dark blue vanishes against a dark tab strip, so the mark follows the
        same pairing as the rest of the site. */
-    path, circle { fill: #123a6b; }
+    path, circle { fill: #0000cc; }
     @media (prefers-color-scheme: dark) {
-      path, circle { fill: #7fb2f0; }
+      path, circle { fill: #8ab4f8; }
     }
   </style>
   <!-- One continuous taper, rather than a tube and a separate objective,

--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="A public registry of Lean-verified mathematical results.">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#101216" media="(prefers-color-scheme: dark)">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Palomar — Lean-verified mathematics</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">

--- a/render.html
+++ b/render.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#101216" media="(prefers-color-scheme: dark)">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Named compared declarations — Palomar</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">

--- a/tests/appearance.test.js
+++ b/tests/appearance.test.js
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+
+function expandHex(hex) {
+  const raw = hex.slice(1);
+  if (raw.length === 3) return [...raw].map((channel) => channel.repeat(2)).join("");
+  if (raw.length === 6) return raw;
+  throw new Error(`unsupported colour ${hex}`);
+}
+
+function luminance(hex) {
+  const channels = expandHex(hex).match(/../g).map((pair) => {
+    const value = parseInt(pair, 16) / 255;
+    return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrast(a, b) {
+  const [high, low] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (high + 0.05) / (low + 0.05);
+}
+
+function palette(css, index) {
+  const blocks = [...css.matchAll(/:root\s*\{([^}]*)\}/g)];
+  const values = {};
+  for (const [, name, value] of blocks[index][1].matchAll(/(--[a-z-]+):\s*(#[^;\s]+)/gi)) {
+    if (!/^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i.test(value)) {
+      throw new Error(`${name} uses unsupported colour ${value}`);
+    }
+    values[name] = value;
+  }
+  return values;
+}
+
+const css = await readFile(new URL("../assets/style.css", import.meta.url), "utf8");
+const light = palette(css, 0);
+const dark = { ...light, ...palette(css, 1) };
+
+for (const [mode, colours] of [["light", light], ["dark", dark]]) {
+  test(`${mode} text colours meet WCAG AA`, () => {
+    for (const [foreground, background] of [
+      ["--ink", "--paper"], ["--muted", "--paper"], ["--faint", "--paper"],
+      ["--link", "--paper"], ["--visited", "--paper"], ["--hover", "--paper"],
+      ["--caution", "--notice-paper"], ["--warning", "--paper"],
+      ["--copied", "--paper"], ["--success", "--success-paper"],
+      ["--missing", "--missing-paper"], ["--unrecoverable", "--unrecoverable-paper"],
+      ["--ink", "--shade"], ["--ink", "--notice-paper"],
+    ]) {
+      const ratio = contrast(colours[foreground], colours[background]);
+      assert.ok(
+        ratio >= 4.5,
+        `${mode} ${foreground} on ${background} is ${ratio.toFixed(2)}:1, needs 4.5`,
+      );
+    }
+  });
+
+  test(`${mode} non-text indicators retain contrast`, () => {
+    for (const token of ["--field", "--available"]) {
+      const ratio = contrast(colours[token], colours["--paper"]);
+      assert.ok(ratio >= 3, `${mode} ${token} is ${ratio.toFixed(2)}:1 on paper, needs 3`);
+    }
+  });
+
+  test(`${mode} acceptance mark meets text contrast`, () => {
+    const ratio = contrast(colours["--paper"], colours["--success-mark"]);
+    assert.ok(ratio >= 4.5, `${mode} acceptance mark is ${ratio.toFixed(2)}:1, needs 4.5`);
+  });
+
+  test(`${mode} filter states retain text contrast`, () => {
+    for (const background of ["--control", "--control-hover", "--paper"]) {
+      const ratio = contrast(colours["--ink"], colours[background]);
+      assert.ok(ratio >= 4.5, `${mode} filter on ${background} is ${ratio.toFixed(2)}:1, needs 4.5`);
+    }
+  });
+}
+
+test("all page colours are palette variables", () => {
+  const rules = css.slice(css.indexOf("* {"));
+  const literals = [...rules.matchAll(/#[0-9a-f]{3,8}\b/gi)].map((match) => match[0]);
+  assert.deepEqual(literals, []);
+});
+
+for (const file of ["index.html", "entry.html", "about.html", "render.html", "404.html"]) {
+  test(`${file} advertises browser-selected light and dark chrome colours`, async () => {
+    const html = await readFile(new URL(`../${file}`, import.meta.url), "utf8");
+    assert.match(html, /name="theme-color" content="#ffffff" media="\(prefers-color-scheme: light\)"/);
+    assert.match(html, /name="theme-color" content="#101216" media="\(prefers-color-scheme: dark\)"/);
+  });
+}

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -38,6 +38,27 @@ const currentEntrySchema = Number(
   )[1],
 );
 
+test("the registry follows the browser's light and dark preference", async ({ page }) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  await page.goto(`/?database=${database}`);
+  await expect(page.locator("html")).toHaveCSS("background-color", "rgb(16, 18, 22)");
+  await expect(page.locator("body")).toHaveCSS("color", "rgb(232, 234, 238)");
+  await expect(page.locator(".toolbar")).toHaveCSS("background-color", "rgb(28, 32, 39)");
+  await expect(page.locator(".filter:not(.active)").first()).toHaveCSS(
+    "background-color", "rgb(36, 41, 51)",
+  );
+  await expect(page.locator(".filter.active")).toHaveCSS("background-color", "rgb(16, 18, 22)");
+
+  await page.emulateMedia({ colorScheme: "light" });
+  await expect(page.locator("html")).toHaveCSS("background-color", "rgb(255, 255, 255)");
+  await expect(page.locator("body")).toHaveCSS("color", "rgb(17, 17, 17)");
+  await expect(page.locator(".toolbar")).toHaveCSS("background-color", "rgb(242, 242, 242)");
+  await expect(page.locator(".filter:not(.active)").first()).toHaveCSS(
+    "background-color", "rgb(232, 232, 232)",
+  );
+  await expect(page.locator(".filter.active")).toHaveCSS("background-color", "rgb(255, 255, 255)");
+});
+
 test("about headings expose hoverable links that copy their section URL", async ({ context, page }) => {
   await context.grantPermissions(["clipboard-read", "clipboard-write"]);
   await page.goto("/about.html");


### PR DESCRIPTION
## Summary

- Add a browser-following light/dark palette across registry pages and browser chrome.
- Preserve the Web 1.0 visual language while making semantic surfaces and status states mode-aware.
- Add contrast and browser regressions, and align the favicon with the active theme.

## Coordinated change

- Companion submission-page PR: https://github.com/PalomarRegistry/PalomarServer/pull/111
- The PRs can merge independently; together they align the public surfaces.

## Verification

- PALOMAR_DATABASE_CHECKOUT=/home/kim/palomar/PalomarDatabase npm test (174 passed)
- PALOMAR_ASSET_VERSION=align-aesthetic-dark-mode npm run build
- Playwright with Chromium (57 passed, 2 skipped)

## Notes

- Installed-app splash color remains a single light manifest color because Web App Manifest colors do not support media queries; loaded pages follow the browser preference immediately.
- Challenge iframe rendering remains owned by the rendered artifact pipeline.