### PR TITLE
feat: simplify main page and entry pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,14 @@ future, or one second older is treated as unknown without discarding fresh
 sibling rows; a stale or unavailable whole manifest is likewise never believed.
 `last_attempt_at` may be null when the bounded producer has never attempted that
 endpoint.
-Registry cards display arXiv and MSC2020 classifications, and the toolbar can
-filter the rows the landing page holds by either taxonomy. The classification
-fields suggest codes represented by those rows but also accept any exact code,
-so a deep link such as `?arxiv=math.AG` produces a useful empty result even
+Registry cards lead with the identifier, registration date, title, abstract, and
+source links; the arXiv and MSC2020 classifications sit with the other entry
+details behind an "Entry details" toggle on each card. The toolbar filters the
+rows the landing page holds by text or trust, with the arXiv and MSC2020
+subject inputs tucked behind a "Subject filters" disclosure until a deep link
+such as `?arxiv=math.AG` opens it. The classification fields suggest codes
+represented by those rows but also accept any exact code, so a deep link such
+as `?arxiv=math.AG` produces a useful empty result even
 before that classification has an entry. The filter is over `recent.json`, which
 is the newest 200 current versions and not the registry, so it narrows what is
 on the page rather than searching everything; the search box does the latter,
@@ -212,6 +216,10 @@ Entry pages list all active versions. Older pages display a prominent link
 to the current version. Each page renders the selected version's own authorship,
 statement, proof, trust information, and review comments; information is never
 borrowed from a newer record. The site provides links, not computed diffs.
+The statement and the acceptance callout come first; the verification table,
+statement dependencies, proof, provenance, and review comments sit behind
+section disclosures that open when their heading is selected, and a fragment
+link into one (such as `#statement-dependencies`) opens it before scrolling.
 The registry does not define change summaries or major/minor versions, so the
 website does not infer them. If a richer version
 scheme is adopted later, it will require a new URL contract; existing integer

--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ future, or one second older is treated as unknown without discarding fresh
 sibling rows; a stale or unavailable whole manifest is likewise never believed.
 `last_attempt_at` may be null when the bounded producer has never attempted that
 endpoint.
-Registry cards lead with the identifier, registration date, title, abstract, and
-source links; the arXiv and MSC2020 classifications sit with the other entry
-details behind an "Entry details" toggle on each card. The toolbar filters the
+Registry cards display the identifier, registration date, title, abstract,
+authors, theorems, arXiv and MSC2020 classifications, and source links, all
+without opening anything: a title here is a repository name, so the authors and
+the theorem are what identify a row while scanning. The toolbar filters the
 rows the landing page holds by text or trust, with the arXiv and MSC2020
 subject inputs tucked behind a "Subject filters" disclosure until a deep link
-such as `?arxiv=math.AG` opens it. The classification fields suggest codes
+such as `?arxiv=math.AG` opens it; the opened inputs take room in the toolbar
+rather than floating over the rows below. The classification fields suggest codes
 represented by those rows but also accept any exact code, so a deep link such
 as `?arxiv=math.AG` produces a useful empty result even
 before that classification has an entry. The filter is over `recent.json`, which
@@ -219,7 +221,11 @@ borrowed from a newer record. The site provides links, not computed diffs.
 The statement and the acceptance callout come first; the verification table,
 statement dependencies, proof, provenance, and review comments sit behind
 section disclosures that open when their heading is selected, and a fragment
-link into one (such as `#statement-dependencies`) opens it before scrolling.
+link into one (such as `#statement-dependencies`) opens it before scrolling,
+whether the fragment arrives from a link, from the address bar, or from the
+history buttons. Each collapsed section is named by its own heading, so it is
+reachable as a landmark on a browser that folds a summary's contents into the
+disclosure's name rather than exposing the heading inside it.
 The registry does not define change summaries or major/minor versions, so the
 website does not infer them. If a richer version
 scheme is adopted later, it will require a new URL contract; existing integer

--- a/assets/app.js
+++ b/assets/app.js
@@ -203,8 +203,6 @@ function entryCard(
     );
     meta.append(project);
   }
-  const details = el("details", "card-details");
-  details.append(el("summary", "", "Entry details"), meta);
   const footer = el("div", "card-footer");
   const location = topSourceLocation(entry, null);
   const historyUrl = new URL(localPageUrl("entry.html", entry));
@@ -233,7 +231,7 @@ function entryCard(
     historyLink.setAttribute("aria-label", `${versionCount} versions of ${entry.id}`);
     footer.append(historyLink);
   }
-  card.append(top, title, abstract, details, footer);
+  card.append(top, title, abstract, meta, footer);
   return card;
 }
 
@@ -859,7 +857,15 @@ function provenanceSection(entry, sourceAvailability) {
   const disclosure = el("details", "section-collapse");
   const heading = el("div", "section-heading");
   const title = el("div");
-  title.append(el("div", "eyebrow", "Provenance"), el("h2", "", "Mathematical origin"));
+  // A heading inside a summary is exposed as a heading by Chromium, but the
+  // engines that flatten a summary's contents into its own accessible name
+  // would leave the section with no way to find it. Naming the section from
+  // the same text makes it a landmark, which is a second route to it that does
+  // not depend on how the disclosure treats what is inside the summary.
+  const sectionHeading = el("h2", "", "Mathematical origin");
+  sectionHeading.id = "provenance-heading";
+  section.setAttribute("aria-labelledby", sectionHeading.id);
+  title.append(el("div", "eyebrow", "Provenance"), sectionHeading);
   heading.append(title);
   const summary = el("summary");
   summary.append(heading);
@@ -1092,7 +1098,10 @@ async function renderEntry(
   }
   evidenceDetails.append(details);
   {
-    evidence.append(
+    // The sentence qualifies the licence row of the table above it, so it
+    // lives inside the same disclosure. Outside it, a collapsed page carries a
+    // caveat about licence evidence that is nowhere on the page.
+    evidenceDetails.append(
       el(
         "p",
         "licence-boundary",
@@ -1107,7 +1116,10 @@ async function renderEntry(
   const editorialDisclosure = el("details", "section-collapse");
   const editorialTitle = el("div", "section-heading");
   const editorialBlock = el("div");
-  editorialBlock.append(el("div", "eyebrow", "Editorial record"), el("h2", "", "Automated review"));
+  const editorialHeading = el("h2", "", "Automated review");
+  editorialHeading.id = "review-heading";
+  editorial.setAttribute("aria-labelledby", editorialHeading.id);
+  editorialBlock.append(el("div", "eyebrow", "Editorial record"), editorialHeading);
   editorialTitle.append(editorialBlock, el("span", "decision", "Accepted"));
   const editorialSummary = el("summary");
   editorialSummary.append(editorialTitle);
@@ -1219,6 +1231,19 @@ if (document.body.dataset.page === "entry") {
     if (fragment === "#") return;
     const target = document.getElementById(decodeURIComponent(fragment.slice(1)));
     if (target) expandDetailsForTarget(target);
+  });
+  // The click above covers links on this page and the initial render covers a
+  // fragment the page was opened with. A hash that arrives any other way, from
+  // the address bar or from history navigation, gets the same treatment: the
+  // browser has already scrolled to a collapsed heading, so the section is
+  // opened and the target brought back into view.
+  window.addEventListener("hashchange", () => {
+    const fragment = window.location.hash.slice(1);
+    if (!fragment) return;
+    const target = document.getElementById(decodeURIComponent(fragment));
+    if (!target) return;
+    expandDetailsForTarget(target);
+    target.scrollIntoView();
   });
   renderEntryPage({
     params,

--- a/assets/app.js
+++ b/assets/app.js
@@ -10,6 +10,7 @@ import {
 } from "./security.mjs";
 import { createRegistrySearch, validateSearchQuery } from "./searching.mjs";
 import {
+  expandDetailsForTarget,
   renderChallengePage,
   renderEntryPage,
 } from "./entry-pages.mjs";
@@ -202,6 +203,8 @@ function entryCard(
     );
     meta.append(project);
   }
+  const details = el("details", "card-details");
+  details.append(el("summary", "", "Entry details"), meta);
   const footer = el("div", "card-footer");
   const location = topSourceLocation(entry, null);
   const historyUrl = new URL(localPageUrl("entry.html", entry));
@@ -230,7 +233,7 @@ function entryCard(
     historyLink.setAttribute("aria-label", `${versionCount} versions of ${entry.id}`);
     footer.append(historyLink);
   }
-  card.append(top, title, abstract, meta, footer);
+  card.append(top, title, abstract, details, footer);
   return card;
 }
 
@@ -337,6 +340,14 @@ async function renderIndex() {
     };
     applyCategoryParameter(arxiv, "arxiv", 32);
     applyCategoryParameter(msc, "msc", 5);
+    // A deep link that filters by subject is a request to act on it, so the
+    // hidden-until-opened controls are opened by the parameters that use them.
+    // The fallback selector keeps cached HTML from the previous deployment
+    // (which has no disclosure) working unchanged.
+    const advancedFilters = document.querySelector(".advanced-filters");
+    if (advancedFilters && (params.has("arxiv") || params.has("msc"))) {
+      advancedFilters.open = true;
+    }
     const update = () => {
       const query = search.value.trim().toLowerCase();
       const arxivValue = arxiv?.value.trim() || "";
@@ -845,11 +856,15 @@ function classificationSection(entry) {
 function provenanceSection(entry, sourceAvailability) {
   const provenance = entry.provenance;
   const section = el("section", "entry-provenance");
+  const disclosure = el("details", "section-collapse");
   const heading = el("div", "section-heading");
   const title = el("div");
   title.append(el("div", "eyebrow", "Provenance"), el("h2", "", "Mathematical origin"));
   heading.append(title);
-  section.append(heading);
+  const summary = el("summary");
+  summary.append(heading);
+  disclosure.append(summary);
+  section.append(disclosure);
 
   const details = el("dl", "details provenance-details");
   // Where the mathematics actually lives comes first. For a thin wrapper it is
@@ -892,10 +907,10 @@ function provenanceSection(entry, sourceAvailability) {
   if (entry.submission.authorization.evidence) {
     details.append(detailRow("Authorization evidence", entry.submission.authorization.evidence));
   }
-  section.append(details);
+  disclosure.append(details);
 
   if (provenance.mathematical_sources.length) {
-    section.append(el("h3", "", "Mathematical sources"));
+    disclosure.append(el("h3", "", "Mathematical sources"));
     const sources = el("ul", "plain-list provenance-sources");
     for (const source of provenance.mathematical_sources) {
       const item = el("li");
@@ -913,13 +928,13 @@ function provenanceSection(entry, sourceAvailability) {
       }
       sources.append(item);
     }
-    section.append(sources);
+    disclosure.append(sources);
   } else {
-    section.append(el("p", "no-sources", "No prior mathematical source is recorded."));
+    disclosure.append(el("p", "no-sources", "No prior mathematical source is recorded."));
   }
 
   if (provenance.related_formalizations.length) {
-    section.append(el("h3", "", "Related formalizations"));
+    disclosure.append(el("h3", "", "Related formalizations"));
     const related = el("ul", "plain-list related-formalizations");
     for (const formalization of provenance.related_formalizations) {
       const item = el("li");
@@ -932,7 +947,7 @@ function provenanceSection(entry, sourceAvailability) {
       if (formalization.note) item.append(`: ${formalization.note}`);
       related.append(item);
     }
-    section.append(related);
+    disclosure.append(related);
   }
   return section;
 }
@@ -962,7 +977,9 @@ async function renderEntry(
   const titleBlock = el("div");
   titleBlock.append(el("div", "eyebrow", "Verification"), el("h2", "", "What was checked"));
   evidenceTitle.append(titleBlock);
-  evidence.append(evidenceTitle, acceptanceCallout(entry, databaseBase));
+  const evidenceDetails = el("details", "section-collapse evidence-collapse");
+  evidenceDetails.append(el("summary", "", "Verification details"));
+  evidence.append(evidenceTitle, acceptanceCallout(entry, databaseBase), evidenceDetails);
   const details = el("dl", "details");
   details.append(
     // One date, not two. Acceptance and Lean verification have always been the
@@ -1073,7 +1090,7 @@ async function renderEntry(
       licenceRow(entry, sourceAvailability),
     );
   }
-  evidence.append(details);
+  evidenceDetails.append(details);
   {
     evidence.append(
       el(
@@ -1087,17 +1104,21 @@ async function renderEntry(
   const trust = statementDependencies(entry);
 
   const editorial = el("section", "entry-editorial");
+  const editorialDisclosure = el("details", "section-collapse");
   const editorialTitle = el("div", "section-heading");
   const editorialBlock = el("div");
   editorialBlock.append(el("div", "eyebrow", "Editorial record"), el("h2", "", "Automated review"));
   editorialTitle.append(editorialBlock, el("span", "decision", "Accepted"));
-  editorial.append(editorialTitle);
+  const editorialSummary = el("summary");
+  editorialSummary.append(editorialTitle);
+  editorialDisclosure.append(editorialSummary);
+  editorial.append(editorialDisclosure);
   // No scores. They decide whether a submission is accepted and they are kept
   // beside the database, but they never reach here: the same repository at
   // the same commit has scored 5 and then 4 on the same axis across runs, and a
   // number that moves like that reads as a judgement it cannot support. What
   // it can support is the decision, which is above.
-  editorial.append(
+  editorialDisclosure.append(
     el(
       "p",
       "review-explanation",
@@ -1107,14 +1128,14 @@ async function renderEntry(
     ),
   );
   if (entry.review.warnings.length) {
-    editorial.append(el("h3", "", "AI review comments"));
+    editorialDisclosure.append(el("h3", "", "AI review comments"));
     const comments = el("ul", "review-comments");
     for (const comment of entry.review.warnings) comments.append(el("li", "", comment));
-    editorial.append(comments);
+    editorialDisclosure.append(comments);
   } else {
-    editorial.append(el("p", "no-warnings", "The review recorded no comments on this result."));
+    editorialDisclosure.append(el("p", "no-warnings", "The review recorded no comments on this result."));
   }
-  editorial.append(
+  editorialDisclosure.append(
     dataLink(
       "Read the archived review",
       evidenceDataUrl(entry, databaseBase, "review.json"),
@@ -1183,6 +1204,22 @@ if (document.body.dataset.page === "index") {
   if (!hasInitialSearch) ensureLanding();
 }
 if (document.body.dataset.page === "entry") {
+  // A same-page anchor into a collapsed section must open that section first,
+  // or the fragment lands on a heading whose content is still hidden. The
+  // browser runs this before the default fragment navigation, so the target
+  // is already expanded by the time it scrolls.
+  document.addEventListener("click", (event) => {
+    const link = event.target.closest?.('a[href*="#"]');
+    if (!link) return;
+    const href = link.getAttribute("href");
+    if (!href) return;
+    const fragmentIndex = href.indexOf("#");
+    if (fragmentIndex === -1) return;
+    const fragment = href.slice(fragmentIndex);
+    if (fragment === "#") return;
+    const target = document.getElementById(decodeURIComponent(fragment.slice(1)));
+    if (target) expandDetailsForTarget(target);
+  });
   renderEntryPage({
     params,
     document,

--- a/assets/entry-pages.mjs
+++ b/assets/entry-pages.mjs
@@ -8,6 +8,27 @@ function parsedVersion(value) {
 }
 
 /**
+ * Open the disclosures that would otherwise hide a fragment target.
+ *
+ * A section's body is a `details.section-collapse`; its heading is the
+ * summary. Opening the target's own section disclosure, or any disclosure
+ * ancestor, guarantees the element a fragment link names is visible before the
+ * caller scrolls to it. Missing DOM hooks are tolerated so the route stays
+ * testable with a stub element.
+ */
+export function expandDetailsForTarget(target) {
+  if (!target) return;
+  if (target.tagName === "DETAILS" && !target.open) target.open = true;
+  const disclosure = typeof target.querySelector === "function"
+    ? target.querySelector("details.section-collapse")
+    : null;
+  if (disclosure && !disclosure.open) disclosure.open = true;
+  for (let node = target; node; node = node.parentElement) {
+    if (node.tagName === "DETAILS" && !node.open) node.open = true;
+  }
+}
+
+/**
  * Orchestrate the entry route around the data loader and page composer.
  *
  * The caller retains those two domain boundaries. This module owns URL input,
@@ -55,7 +76,10 @@ export async function renderEntryPage({
     const anchorTarget = requestedHash.startsWith("#")
       ? document.getElementById(decodeURIComponent(requestedHash.slice(1)))
       : null;
-    if (anchorTarget) anchorTarget.scrollIntoView();
+    if (anchorTarget) {
+      expandDetailsForTarget(anchorTarget);
+      anchorTarget.scrollIntoView();
+    }
   } catch (error) {
     status.textContent = `The registry entry could not be loaded: ${error.message}`;
     status.classList.add("error");

--- a/assets/formalization-presentation.mjs
+++ b/assets/formalization-presentation.mjs
@@ -67,16 +67,19 @@ export function createFormalizationPresentation({ document }) {
     const disclosure = el("details", "section-collapse");
     const heading = el("div", "section-heading");
     const title = el("div");
-    title.append(
-      el("div", "eyebrow", "Statement dependencies"),
-      el(
-        "h2",
-        "",
-        entry.trust.level === "high"
-          ? "Depends only on Mathlib"
-          : "Depends on additional libraries",
-      ),
+    // Named from its own heading, so the section is a landmark even where a
+    // summary's contents are flattened into its accessible name and the
+    // heading inside it is not exposed as one.
+    const sectionHeading = el(
+      "h2",
+      "",
+      entry.trust.level === "high"
+        ? "Depends only on Mathlib"
+        : "Depends on additional libraries",
     );
+    sectionHeading.id = "statement-dependencies-heading";
+    section.setAttribute("aria-labelledby", sectionHeading.id);
+    title.append(el("div", "eyebrow", "Statement dependencies"), sectionHeading);
     heading.append(title);
     const summary = el("summary");
     summary.append(heading);
@@ -116,7 +119,10 @@ export function createFormalizationPresentation({ document }) {
     const disclosure = el("details", "section-collapse");
     const heading = el("div", "section-heading");
     const title = el("div");
-    title.append(el("div", "eyebrow", "Accepted proof"), el("h2", "", "Verified proof"));
+    const sectionHeading = el("h2", "", "Verified proof");
+    sectionHeading.id = "proof-heading";
+    section.setAttribute("aria-labelledby", sectionHeading.id);
+    title.append(el("div", "eyebrow", "Accepted proof"), sectionHeading);
     heading.append(title, el("span", "decision accepted-decision", "Accepted"));
     const summary = el("summary");
     summary.append(heading);

--- a/assets/formalization-presentation.mjs
+++ b/assets/formalization-presentation.mjs
@@ -64,6 +64,7 @@ export function createFormalizationPresentation({ document }) {
   function statementDependencies(entry) {
     const section = el("section", "entry-trust");
     section.id = "statement-dependencies";
+    const disclosure = el("details", "section-collapse");
     const heading = el("div", "section-heading");
     const title = el("div");
     title.append(
@@ -76,36 +77,52 @@ export function createFormalizationPresentation({ document }) {
           : "Depends on additional libraries",
       ),
     );
-    heading.append(title, trustBadge(entry));
-    section.append(heading);
-    const imports = el("div", "token-list");
-    for (const item of entry.trust.challenge_imports) imports.append(el("code", "", item));
-    section.append(el("h3", "", "Libraries imported by the statement"), imports);
-    if (entry.trust.challenge_dependencies.length) {
-      section.append(el("h3", "", "Source repositories"));
-      const dependencies = el("ul", "plain-list");
-      for (const dependency of entry.trust.challenge_dependencies) {
-        dependencies.append(el("li", "", dependency.repository));
+    heading.append(title);
+    const summary = el("summary");
+    summary.append(heading);
+    disclosure.append(summary);
+    section.append(disclosure);
+    const imports = entry.trust.challenge_imports;
+    const dependencies = entry.trust.challenge_dependencies;
+    disclosure.append(el("h3", "", "Imported libraries"));
+    if (imports.length === 1 && dependencies.length === 1) {
+      const line = el("p", "statement-import-line");
+      line.append(el("code", "", imports[0]), el("span", "", ` · ${dependencies[0].repository}`));
+      disclosure.append(line);
+    } else {
+      const importList = el("div", "token-list");
+      for (const item of imports) importList.append(el("code", "", item));
+      disclosure.append(importList);
+      if (dependencies.length) {
+        disclosure.append(el("h3", "", "Source repositories"));
+        const dependencyList = el("ul", "plain-list");
+        for (const dependency of dependencies) {
+          dependencyList.append(el("li", "", dependency.repository));
+        }
+        disclosure.append(dependencyList);
       }
-      section.append(dependencies);
     }
     if (entry.trust.reasons.length) {
-      section.append(el("h3", "", "Why additional libraries are needed"));
+      disclosure.append(el("h3", "", "Why additional libraries are needed"));
       const reasons = el("ul", "reason-list");
       for (const reason of entry.trust.reasons) reasons.append(el("li", "", reason));
-      section.append(reasons);
+      disclosure.append(reasons);
     }
     return section;
   }
 
   function solutionMetadata(entry, renderMetadata, sourceAvailability = null) {
     const section = el("section", "entry-solution");
+    const disclosure = el("details", "section-collapse");
     const heading = el("div", "section-heading");
     const title = el("div");
     title.append(el("div", "eyebrow", "Accepted proof"), el("h2", "", "Verified proof"));
     heading.append(title, el("span", "decision accepted-decision", "Accepted"));
-    section.append(heading);
-    section.append(
+    const summary = el("summary");
+    summary.append(heading);
+    disclosure.append(summary);
+    section.append(disclosure);
+    disclosure.append(
       el(
         "p",
         "solution-summary",
@@ -141,7 +158,7 @@ export function createFormalizationPresentation({ document }) {
       row.append(value);
       details.append(row);
     }
-    section.append(details);
+    disclosure.append(details);
 
     const dependencies = entry.formalization.project_dependencies;
     const closure = el("details", "solution-dependencies");
@@ -208,7 +225,7 @@ export function createFormalizationPresentation({ document }) {
       list.append(item);
     }
     closure.append(list);
-    section.append(closure);
+    disclosure.append(closure);
     return section;
   }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -215,10 +215,6 @@ h3 {
   margin-bottom: 0;
 }
 
-.data-link {
-  font-size: .9rem;
-}
-
 /* The registry-wide search, which asks the published index a question, above
    the toolbar, which filters what is already on the page. Two controls that
    both take words need to be told apart by where they are and what they say. */
@@ -300,6 +296,42 @@ button:focus-visible {
   display: flex;
   align-items: center;
   gap: .35rem;
+}
+
+.advanced-filters {
+  position: relative;
+}
+
+.advanced-filters summary {
+  min-height: 2rem;
+  padding: .25rem .5rem;
+  border: 1px solid var(--field);
+  border-radius: 0;
+  background: var(--control);
+  color: var(--ink);
+  cursor: pointer;
+  font: .8rem var(--sans);
+}
+
+.advanced-filters summary:hover {
+  background: var(--control-hover);
+}
+
+.advanced-filters[open] summary {
+  border-color: var(--ink);
+  background: var(--paper);
+  font-weight: bold;
+}
+
+.advanced-filters .category-filters {
+  position: absolute;
+  right: 0;
+  z-index: 2;
+  margin-top: .35rem;
+  padding: .6rem .7rem;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .15);
 }
 
 .category-filters {
@@ -421,6 +453,25 @@ button:focus-visible {
 .card-abstract {
   max-width: 76ch;
   margin-bottom: .75rem;
+}
+
+.card-details {
+  margin-bottom: .65rem;
+}
+
+.card-details summary {
+  cursor: pointer;
+  color: var(--muted);
+  font: .78rem/1.3 var(--sans);
+}
+
+.card-details summary:hover,
+.card-details summary:focus-visible {
+  color: var(--link);
+}
+
+.card-details[open] .card-meta {
+  margin-top: .6rem;
 }
 
 .card-meta {
@@ -712,6 +763,33 @@ footer {
   border-top: 1px solid var(--line);
 }
 
+/* Dense sections open on demand. The section heading is the summary, so the
+   collapsed page reads as a list of section titles and the disclosure marker
+   is the affordance; the verification table's toggle is the small text below
+   the acceptance callout instead. */
+.section-collapse > summary {
+  cursor: pointer;
+}
+
+.section-collapse > summary::-webkit-details-marker {
+  color: var(--muted);
+}
+
+.section-collapse > summary:focus-visible {
+  outline: 2px solid var(--link);
+  outline-offset: 3px;
+}
+
+.entry-evidence .section-collapse > summary {
+  color: var(--muted);
+  font: .8rem/1.3 var(--sans);
+}
+
+.entry-evidence .section-collapse > summary:hover,
+.entry-evidence .section-collapse > summary:focus-visible {
+  color: var(--link);
+}
+
 .challenge-links {
   margin-bottom: .75rem;
   font: .9rem/1.4 var(--sans);
@@ -882,6 +960,10 @@ pre {
   font-family: var(--mono);
 }
 
+.statement-import-line {
+  margin-top: .35rem;
+}
+
 .token-list {
   display: flex;
   flex-wrap: wrap;
@@ -984,6 +1066,18 @@ pre {
 
   .filters {
     flex-wrap: wrap;
+  }
+
+  .advanced-filters {
+    width: 100%;
+  }
+
+  .advanced-filters .category-filters {
+    position: static;
+    margin-top: .4rem;
+    padding: 0;
+    border: 0;
+    box-shadow: none;
   }
 
   .card-top,

--- a/assets/style.css
+++ b/assets/style.css
@@ -251,6 +251,7 @@ h3 {
 
 .toolbar {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
@@ -298,11 +299,16 @@ button:focus-visible {
   gap: .35rem;
 }
 
-.advanced-filters {
-  position: relative;
+/* The opened inputs take a row of the toolbar rather than floating over the
+   rows below it: a panel that covers the first card hides part of the answer
+   a subject deep link was asking for. Its own row also keeps the toggle from
+   widening and squeezing the controls beside it. */
+.advanced-filters[open] {
+  flex-basis: 100%;
 }
 
 .advanced-filters summary {
+  width: fit-content;
   min-height: 2rem;
   padding: .25rem .5rem;
   border: 1px solid var(--field);
@@ -324,14 +330,10 @@ button:focus-visible {
 }
 
 .advanced-filters .category-filters {
-  position: absolute;
-  right: 0;
-  z-index: 2;
   margin-top: .35rem;
   padding: .6rem .7rem;
   border: 1px solid var(--line);
   background: var(--paper);
-  box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .15);
 }
 
 .category-filters {
@@ -453,25 +455,6 @@ button:focus-visible {
 .card-abstract {
   max-width: 76ch;
   margin-bottom: .75rem;
-}
-
-.card-details {
-  margin-bottom: .65rem;
-}
-
-.card-details summary {
-  cursor: pointer;
-  color: var(--muted);
-  font: .78rem/1.3 var(--sans);
-}
-
-.card-details summary:hover,
-.card-details summary:focus-visible {
-  color: var(--link);
-}
-
-.card-details[open] .card-meta {
-  margin-top: .6rem;
 }
 
 .card-meta {
@@ -768,11 +751,33 @@ footer {
    is the affordance; the verification table's toggle is the small text below
    the acceptance callout instead. */
 .section-collapse > summary {
+  display: flex;
+  align-items: baseline;
+  gap: .5rem;
   cursor: pointer;
+  /* The default marker is a list item bullet, which a heading block pushes on
+     to a line of its own above the section title. Drawing it here keeps the
+     affordance beside the words it opens. */
+  list-style: none;
 }
 
 .section-collapse > summary::-webkit-details-marker {
+  display: none;
+}
+
+.section-collapse > summary::before {
   color: var(--muted);
+  content: "\25B8";
+  font-size: .9em;
+}
+
+.section-collapse[open] > summary::before {
+  content: "\25BE";
+}
+
+.section-collapse > summary > .section-heading {
+  flex: 1;
+  min-width: 0;
 }
 
 .section-collapse > summary:focus-visible {
@@ -970,6 +975,7 @@ pre {
   gap: .35rem;
 }
 
+.statement-import-line code,
 .token-list code {
   padding: .15rem .3rem;
   border: 1px solid var(--token-line);
@@ -1073,11 +1079,9 @@ pre {
   }
 
   .advanced-filters .category-filters {
-    position: static;
     margin-top: .4rem;
     padding: 0;
     border: 0;
-    box-shadow: none;
   }
 
   .card-top,

--- a/index.html
+++ b/index.html
@@ -38,14 +38,7 @@
         </div>
       </section>
 
-      <section class="registry-section" id="registry" aria-labelledby="registry-heading">
-        <div class="section-heading">
-          <h2 id="registry-heading">Accepted results</h2>
-          <a class="data-link" href="https://data.palomar-registry.org/browse/index.json">
-            Machine-readable index
-          </a>
-        </div>
-
+      <section class="registry-section" id="registry" aria-label="Accepted results">
         <form id="registry-search" class="registry-search" role="search">
           <label for="query">Search the registry:</label>
           <input id="query" name="q" type="search" placeholder="words from a title, abstract, or author" autocomplete="off" spellcheck="false" maxlength="4096">
@@ -56,25 +49,28 @@
 
         <div class="toolbar">
           <label class="search">
-            <span>Filter:</span>
+            <span>Filter the list:</span>
             <input id="search" type="search" placeholder="title, author, theorem, or repository" autocomplete="off">
           </label>
-          <div class="category-filters" role="group" aria-label="Subject filters">
-            <label>arXiv:
-              <input id="arxiv-query" type="search" list="arxiv-options" maxlength="32" placeholder="e.g. math.CO" autocomplete="off" spellcheck="false">
-            </label>
-            <datalist id="arxiv-options"></datalist>
-            <label>MSC:
-              <input id="msc-query" type="search" list="msc-options" maxlength="5" placeholder="e.g. 05C10" autocomplete="off" spellcheck="false">
-            </label>
-            <datalist id="msc-options"></datalist>
-          </div>
           <div class="filters" role="group" aria-label="Statement dependency filters">
             <span>Show:</span>
             <button class="filter active" type="button" data-trust="all" aria-pressed="true">All</button>
             <button class="filter" type="button" data-trust="high" aria-pressed="false">Mathlib only</button>
             <button class="filter" type="button" data-trust="qualified" aria-pressed="false">Additional libraries</button>
           </div>
+          <details class="advanced-filters">
+            <summary>Subject filters</summary>
+            <div class="category-filters" role="group" aria-label="Subject filters">
+              <label>arXiv:
+                <input id="arxiv-query" type="search" list="arxiv-options" maxlength="32" placeholder="e.g. math.CO" autocomplete="off" spellcheck="false">
+              </label>
+              <datalist id="arxiv-options"></datalist>
+              <label>MSC:
+                <input id="msc-query" type="search" list="msc-options" maxlength="5" placeholder="e.g. 05C10" autocomplete="off" spellcheck="false">
+              </label>
+              <datalist id="msc-options"></datalist>
+            </div>
+          </details>
         </div>
 
         <div id="status" class="status" role="status">

--- a/tests/entry-pages.test.js
+++ b/tests/entry-pages.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  expandDetailsForTarget,
   renderChallengePage,
   renderEntryPage,
 } from "../assets/entry-pages.mjs";
@@ -22,6 +23,18 @@ function node({ hidden = false } = {}) {
     textContent: "",
     append(...children) {
       this.children.push(...children);
+    },
+  };
+}
+
+function detailsElement() {
+  return {
+    children: [],
+    open: false,
+    parentElement: null,
+    tagName: "DETAILS",
+    querySelector() {
+      return null;
     },
   };
 }
@@ -176,6 +189,36 @@ test("entry routes preserve exact tombstones and load failures", async (t) => {
     assert.equal(view.status.classList.contains("error"), true);
     assert.equal(view.content.hidden, true);
   });
+});
+
+test("expandDetailsForTarget opens the disclosure that would hide a fragment", () => {
+  const disclosure = detailsElement();
+  const ancestor = detailsElement();
+  const section = {
+    tagName: "SECTION",
+    parentElement: ancestor,
+    querySelector(selector) {
+      assert.equal(selector, "details.section-collapse");
+      return disclosure;
+    },
+  };
+  ancestor.children.push(section);
+
+  expandDetailsForTarget(section);
+
+  assert.equal(disclosure.open, true);
+  assert.equal(ancestor.open, true);
+});
+
+test("expandDetailsForTarget opens a details target itself", () => {
+  const target = detailsElement();
+  expandDetailsForTarget(target);
+  assert.equal(target.open, true);
+});
+
+test("expandDetailsForTarget tolerates stub elements without DOM hooks", () => {
+  const stub = { scrollIntoView() {} };
+  expandDetailsForTarget(stub);
 });
 
 test("named-declaration routes validate before loading and reveal only completed views", async () => {

--- a/tests/formalization-presentation.test.mjs
+++ b/tests/formalization-presentation.test.mjs
@@ -28,6 +28,7 @@ function fakeDocument() {
     activeElement: null,
     createElement(tag) {
       return {
+        attributes: {},
         children: [],
         className: "",
         href: "",
@@ -37,6 +38,12 @@ function fakeDocument() {
         textContent: "",
         append(...children) {
           this.children.push(...children);
+        },
+        setAttribute(name, value) {
+          this.attributes[name] = String(value);
+        },
+        getAttribute(name) {
+          return Object.hasOwn(this.attributes, name) ? this.attributes[name] : null;
         },
         focus() {
           document.activeElement = this;
@@ -81,6 +88,11 @@ test("the trust badge and statement dependency section present the accepted trus
   const highSection = presentation.statementDependencies(high);
   assert.equal(highSection.id, "statement-dependencies");
   assert.ok(texts(highSection, "h2").includes("Depends only on Mathlib"));
+  // The heading sits inside a summary, so the section carries its own name:
+  // a reader whose browser flattens the summary still has a landmark here.
+  const highHeading = byTag(highSection, "h2")[0];
+  assert.equal(highSection.getAttribute("aria-labelledby"), highHeading.id);
+  assert.equal(highHeading.textContent, "Depends only on Mathlib");
   assert.deepEqual(texts(highSection, "code"), ["Mathlib"]);
   assert.equal(byClass(highSection, "reason-list").length, 0);
 

--- a/tests/formalization-presentation.test.mjs
+++ b/tests/formalization-presentation.test.mjs
@@ -84,6 +84,20 @@ test("the trust badge and statement dependency section present the accepted trus
   assert.deepEqual(texts(highSection, "code"), ["Mathlib"]);
   assert.equal(byClass(highSection, "reason-list").length, 0);
 
+  const singleLibrary = entry();
+  singleLibrary.trust = {
+    ...singleLibrary.trust,
+    challenge_dependencies: [{ repository: "leanprover-community/mathlib4" }],
+  };
+  const merged = presentation.statementDependencies(singleLibrary);
+  assert.deepEqual(
+    byClass(merged, "statement-import-line")[0].children.map((node) => node.textContent),
+    ["Mathlib", " · leanprover-community/mathlib4"],
+  );
+  assert.ok(!texts(merged, "h3").includes("Source repositories"));
+  assert.equal(byClass(merged, "plain-list").length, 0);
+  assert.equal(byClass(merged, "token-list").length, 0);
+
   const qualified = entry();
   qualified.trust = {
     ...qualified.trust,

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -171,27 +171,19 @@ test("landing cards show the registration date and dated identifier", async ({ p
   expect(dynamicRequests).toHaveLength(2);
 });
 
-test("card metadata stays collapsed until the entry details toggle is opened", async ({ page }) => {
+test("card metadata is on the card, not behind a toggle", async ({ page }) => {
   await page.goto(`/?database=${database}`);
   const card = page.locator(".entry-card").first();
-  const details = card.locator(".card-details");
 
-  // The landing card leads with identity, title, abstract and source links;
-  // authors, theorems, subjects and the project directory wait behind a toggle.
-  await expect(details.locator("summary")).toHaveText("Entry details");
-  await expect(details.locator(".card-meta")).toBeHidden();
-  await expect(card.locator(".entry-id")).toBeVisible();
-  await expect(card.locator(".card-abstract")).toBeVisible();
-  await expect(card.locator(".repo-link")).toBeVisible();
-
-  await details.locator("summary").click();
-  await expect(details.locator(".card-meta")).toBeVisible();
-  await expect(details.locator(".card-subjects")).toContainText("math.CO");
-  await expect(details.locator(".card-project")).toContainText("Project directory");
-
-  // Collapse again to leave the listing compact.
-  await details.locator("summary").click();
-  await expect(details.locator(".card-meta")).toBeHidden();
+  // Titles in this registry are repository names, so the authors and the
+  // theorem are what make a row identifiable while scanning the list. They
+  // are read without opening anything, and there is nothing to open.
+  await expect(card.locator(".card-meta")).toBeVisible();
+  await expect(card.locator(".card-meta")).toContainText("Example");
+  await expect(card.locator(".card-meta")).toContainText("Example.theorem");
+  await expect(card.locator(".card-subjects")).toContainText("math.CO");
+  await expect(card.locator(".card-project")).toContainText("Project directory");
+  await expect(card.locator("details")).toHaveCount(0);
 });
 
 test("landing cards preserve the publisher's newest-first order", async ({ page }) => {
@@ -410,6 +402,57 @@ test("an entry answers its reader's first three questions first", async ({ page 
     "",
   );
   expect(page.url().split("#")[0]).toBe(before.split("#")[0]);
+});
+
+test("a hash that arrives without a click still opens its section", async ({ page }) => {
+  await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}`);
+  await expect(page.locator("#statement-dependencies")).toBeVisible();
+  await expect(page.locator("#statement-dependencies .section-collapse")).not.toHaveAttribute(
+    "open",
+    "",
+  );
+
+  // What the address bar and the history buttons do: the fragment changes on a
+  // page that is already loaded, with no link to intercept.
+  await page.evaluate(() => {
+    window.location.hash = "#statement-dependencies";
+  });
+  await expect(page.locator("#statement-dependencies .section-collapse")).toHaveAttribute(
+    "open",
+    "",
+  );
+  await expect(page.locator("#statement-dependencies")).toBeInViewport();
+});
+
+test("the licence caveat travels with the licence evidence it qualifies", async ({ page }) => {
+  await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}`);
+  const collapse = page.locator(".entry-evidence .section-collapse");
+
+  // A page that says this licence evidence covers the snapshot only, while the
+  // licence row is folded away, is a caveat about nothing on the page.
+  await expect(collapse).toBeVisible();
+  await expect(collapse.locator(".licence-boundary")).toHaveCount(1);
+  await expect(page.locator(".licence-boundary")).toBeHidden();
+
+  await collapse.locator("summary").click();
+  await expect(collapse).toHaveAttribute("open", "");
+  await expect(page.locator(".licence-boundary")).toBeVisible();
+  await expect(collapse.locator("dl.details")).toContainText("Repository licence");
+});
+
+test("the subject filters make room in the toolbar instead of covering the list", async ({ page }) => {
+  await page.goto(`/?database=${database}`);
+  const card = page.locator(".entry-card").first();
+  const top = await card.boundingBox();
+
+  await page.locator(".advanced-filters summary").click();
+  const inputs = await page.locator(".advanced-filters .category-filters").boundingBox();
+  const moved = await card.boundingBox();
+
+  // The opened panel pushes the list down; nothing it would otherwise float
+  // over, such as the first card's trust label, is hidden by it.
+  expect(inputs.y + inputs.height).toBeLessThanOrEqual(moved.y);
+  expect(moved.y).toBeGreaterThan(top.y);
 });
 
 test("a thin wrapper says where the mathematics is before anything else", async ({ page }) => {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -171,6 +171,29 @@ test("landing cards show the registration date and dated identifier", async ({ p
   expect(dynamicRequests).toHaveLength(2);
 });
 
+test("card metadata stays collapsed until the entry details toggle is opened", async ({ page }) => {
+  await page.goto(`/?database=${database}`);
+  const card = page.locator(".entry-card").first();
+  const details = card.locator(".card-details");
+
+  // The landing card leads with identity, title, abstract and source links;
+  // authors, theorems, subjects and the project directory wait behind a toggle.
+  await expect(details.locator("summary")).toHaveText("Entry details");
+  await expect(details.locator(".card-meta")).toBeHidden();
+  await expect(card.locator(".entry-id")).toBeVisible();
+  await expect(card.locator(".card-abstract")).toBeVisible();
+  await expect(card.locator(".repo-link")).toBeVisible();
+
+  await details.locator("summary").click();
+  await expect(details.locator(".card-meta")).toBeVisible();
+  await expect(details.locator(".card-subjects")).toContainText("math.CO");
+  await expect(details.locator(".card-project")).toContainText("Project directory");
+
+  // Collapse again to leave the listing compact.
+  await details.locator("summary").click();
+  await expect(details.locator(".card-meta")).toBeHidden();
+});
+
 test("landing cards preserve the publisher's newest-first order", async ({ page }) => {
   const registeredAt = new Map([
     ["PALOMAR-2026-07-29-000124", "2026-07-29T23:00:00Z"],
@@ -250,6 +273,9 @@ test("an unavailable recent summary reports failure instead of emptiness", async
 
 test("registry entries can be filtered by arXiv and MSC classifications", async ({ page }) => {
   await page.goto(`/?database=${database}`);
+  // The subject inputs sit behind the toolbar's disclosure until opened.
+  await page.locator(".advanced-filters summary").click();
+  await expect(page.locator('.advanced-filters')).toHaveAttribute("open", "");
   await expect(page.locator('#arxiv-options option[value="math.NT"]')).toHaveCount(1);
   await expect(page.locator('#msc-options option[value="05C10"]')).toHaveCount(1);
 
@@ -269,6 +295,8 @@ test("registry entries can be filtered by arXiv and MSC classifications", async 
 
 test("classification filters apply from a deep link", async ({ page }) => {
   await page.goto(`/?database=${database}&arxiv=math.NT`);
+  // A linked subject filter opens the disclosure that holds its inputs.
+  await expect(page.locator(".advanced-filters")).toHaveAttribute("open", "");
   await expect(page.locator("#arxiv-query")).toHaveValue("math.NT");
   await expect(page.locator(".entry-card:visible")).toHaveCount(1);
   await expect(page.locator(".entry-card:visible")).toContainText("000124");
@@ -365,13 +393,22 @@ test("an entry answers its reader's first three questions first", async ({ page 
 
   // The dependencies are further down this page, so following the link scrolls
   // rather than loading anything. (The href is absolute either way, so what is
-  // worth asserting is where it lands.)
+  // worth asserting is where it lands.) The dense sections start collapsed, so
+  // the fragment link has to open the section before the browser scrolls to it.
+  await expect(page.locator("#statement-dependencies .section-collapse")).not.toHaveAttribute(
+    "open",
+    "",
+  );
   const before = page.url();
   await page
     .locator(".challenge-links")
     .getByRole("link", { name: "Inspect statement dependencies" })
     .click();
   await expect(page.locator("#statement-dependencies")).toBeInViewport();
+  await expect(page.locator("#statement-dependencies .section-collapse")).toHaveAttribute(
+    "open",
+    "",
+  );
   expect(page.url().split("#")[0]).toBe(before.split("#")[0]);
 });
 
@@ -399,7 +436,7 @@ test("a thin wrapper says where the mathematics is before anything else", async 
   await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}`);
   const rows = page.locator(".entry-provenance .provenance-details .detail-row dt");
   await expect(rows.first()).toHaveText("Substantive formalization");
-  await expect(page.getByRole("link", { name: `${repository}@${commit.slice(0, 12)}` }))
+  await expect(page.getByRole("link", { name: `${repository}@${commit.slice(0, 12)}`, includeHidden: true }))
     .toHaveAttribute("href", `https://github.com/${repository}/tree/${commit}`);
 });
 
@@ -518,6 +555,7 @@ test("a missing original automatically switches source links to the Palomar copy
     "href",
     /github\.com\/PalomarArchive\/example--challenge\/blob\/1{40}\/project\/Comparator\/Task\.lean$/,
   );
+  await page.locator(".entry-solution .section-collapse > summary").click();
   await page.locator("details.solution-dependencies > summary").click();
   await expect(page.getByRole("link", { name: "example/dependency (Palomar copy)" })).toHaveAttribute(
     "href",
@@ -714,7 +752,7 @@ test("entry pages list immutable versions and flag superseded snapshots", async 
   const fullRecord = page.locator(".entry-evidence .detail-row", {
     has: page.getByText("Full registry record", { exact: true }),
   });
-  await expect(fullRecord.getByRole("link")).toHaveText(
+  await expect(fullRecord.getByRole("link", { includeHidden: true })).toHaveText(
     "PALOMAR-2026-07-29-000123-v1.json",
   );
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
@@ -744,7 +782,7 @@ test("entries display repository licence evidence and its boundary", async ({ pa
   // One row, not four: the licence, the file, and the digest. Declared and
   // detected are the same fact when they agree, which is the ordinary case.
   await expect(evidence).toContainText("Repository licence");
-  await expect(evidence.getByRole("link", { name: "LICENSE.md" })).toHaveAttribute(
+  await expect(evidence.getByRole("link", { name: "LICENSE.md", includeHidden: true })).toHaveAttribute(
     "href",
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/LICENSE.md`,
   );
@@ -903,9 +941,9 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   });
   await expect(editorialAssurance.locator("code")).toHaveText("Challenge.lean");
   await expect(page.getByRole("link", { name: "Archived mechanical report" })).toBeVisible();
-  await expect(page.getByText("Verification workflow commit")).toBeVisible();
+  await expect(page.locator(".entry-evidence")).toContainText("Verification workflow commit");
   await expect(page.getByRole("link", { name: "Archived editorial review" })).toBeVisible();
-  await expect(page.getByRole("link", { name: "project/Comparator/Answer.lean" }).first()).toHaveAttribute(
+  await expect(page.getByRole("link", { name: "project/Comparator/Answer.lean", includeHidden: true }).first()).toHaveAttribute(
     "href",
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/project/Comparator/Answer.lean`,
   );
@@ -926,6 +964,7 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   await expect(page.locator(".entry-evidence")).toContainText("Project directory");
   await expect(page.locator(".entry-evidence")).toContainText("project");
   await expect(page.locator(".entry-solution .token-list code")).toHaveText("ExampleDependency");
+  await page.locator(".entry-solution .section-collapse > summary").click();
   await page.locator(".solution-dependencies summary").click();
   await expect(page.locator(".dependency-list")).toContainText("example/dependency");
   await expect(page.getByRole("link", { name: "shared" })).toHaveAttribute(
@@ -991,9 +1030,6 @@ test("qualified statement and proof dependencies retain their distinct presentat
   const statement = page.locator("#statement-dependencies");
   await expect(statement.getByRole("heading", { name: "Depends on additional libraries" }))
     .toBeVisible();
-  await expect(statement.locator(".trust-badge")).toHaveText(
-    "Statement dependencies: additional libraries",
-  );
   await expect(statement.locator(".plain-list li")).toHaveText([
     "leanprover-community/mathlib4",
     "TauCetiProject/TauCeti",
@@ -1005,6 +1041,7 @@ test("qualified statement and proof dependencies retain their distinct presentat
   await expect(proof.locator(".solution-dependencies summary")).toHaveText(
     "1 project dependencies used by the proof",
   );
+  await proof.locator(".section-collapse > summary").click();
   await proof.locator(".solution-dependencies summary").click();
   await expect(proof.getByRole("link", { name: "example/dependency" })).toHaveAttribute(
     "href",


### PR DESCRIPTION
This PR simplifies the landing page and the entry pages.

On the landing page, the arXiv and MSC inputs sit behind a "Subject filters" disclosure, which an `?arxiv=` or `?msc=` deep link opens; the opened inputs take a row of the toolbar rather than floating over the list. "Filter:" becomes "Filter the list:", and the section heading above the search box goes, along with its machine-readable index link, which the footer already carries.

On an entry page, the statement and the acceptance callout come first, and the verification table, statement dependencies, proof, provenance, and review comments sit behind section disclosures that open when their heading is selected. A fragment link into one, such as `#statement-dependencies`, opens it before scrolling, whether the fragment arrives from a link, from the address bar, or from the history buttons. Each of those sections is named by its own heading, so it stays reachable as a landmark where a browser folds a summary's contents into the disclosure's accessible name rather than exposing the heading inside it.

The "Statement dependencies" badge is no longer repeated inside the section it labels, and a statement that imports one library from one repository renders a single line, `Mathlib · leanprover-community/mathlib4`, in place of two headings and a list.

🤖 Prepared with Claude Code
