### PR TITLE
Move public-origin health to the public Web repository

### DIFF
--- a/.github/workflows/publish-health.yml
+++ b/.github/workflows/publish-health.yml
@@ -53,6 +53,25 @@ jobs:
         env:
           DATA: https://data.palomar-registry.org
 
+      - name: Is the public-data origin healthy and singly exposed
+        env:
+          DATA: https://data.palomar-registry.org
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error --retry 3 "$DATA/healthz" |
+            jq -e '.ok == true' >/dev/null
+          curl --fail --silent --show-error --retry 3 \
+            "$DATA/source-availability-targets.json" |
+            jq -e '.schema_version == 1 and (.targets | type == "array")' >/dev/null
+          for forbidden in \
+            https://palomar-data-staging.palomar-server.workers.dev/schema-v2.json \
+            https://palomar-data.palomar-server.workers.dev/schema-v2.json; do
+            if curl --fail --silent --show-error --max-time 10 "$forbidden" >/dev/null; then
+              echo "::error::$forbidden is a second public front door"
+              exit 1
+            fi
+          done
+
       # The other direction: not whether the records the site reads are
       # readable, but whether the registry documents and the Policy document
       # selected for link health are still there at all.

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -436,12 +436,28 @@ function availabilityEndpoint(value, field) {
 
 export function validateAvailability(manifest) {
   const document = object(manifest, "availability");
-  if (document.schema_version !== 1) fail("availability schema_version is unsupported");
+  // Schema 1 remains readable only for the deployment handoff: the old R2
+  // object can outlive the Worker deployment until the first public refresh.
+  // Schema 2 binds every observation row to the separately published exact
+  // target set and is what all new producers write.
+  if (![1, 2].includes(document.schema_version)) {
+    fail("availability schema_version is unsupported");
+  }
+  if (document.schema_version === 2) {
+    if (typeof document.targets_sha256 !== "string" ||
+        !/^[0-9a-f]{64}$/.test(document.targets_sha256)) {
+      fail("availability.targets_sha256 is malformed");
+    }
+    if (!Number.isSafeInteger(document.publication_revision) ||
+        document.publication_revision < 1) {
+      fail("availability.publication_revision is malformed");
+    }
+  }
   const generatedAt = availabilityTimestamp(document.generated_at);
   if (generatedAt === null) {
     fail("availability.generated_at is malformed");
   }
-  if (document.database_commit !== undefined) {
+  if (document.schema_version === 1 && document.database_commit !== undefined) {
     commit(document.database_commit, "availability.database_commit");
   }
   const coverage = object(document.coverage, "availability.coverage");

--- a/tests/registry-fixture.mjs
+++ b/tests/registry-fixture.mjs
@@ -76,9 +76,10 @@ export function availabilityEndpoint(overrides = {}) {
 
 export function availabilityManifest(repositories = [], overrides = {}) {
   return {
-    schema_version: 1,
+    schema_version: 2,
     generated_at: "2026-08-08T12:00:00Z",
-    database_commit: "d".repeat(40),
+    targets_sha256: "d".repeat(64),
+    publication_revision: 1,
     coverage: { freshness_max_age_seconds: 18 * 60 * 60 },
     repositories,
     ...overrides,

--- a/tests/registry-loading.test.mjs
+++ b/tests/registry-loading.test.mjs
@@ -137,8 +137,8 @@ test("bounded availability shares an in-flight read", async () => {
   assert.equal(first, second);
   assert.equal(reads, 0);
   release(jsonResponse(availabilityManifest([])));
-  assert.equal((await first).schema_version, 1);
-  assert.equal((await second).schema_version, 1);
+  assert.equal((await first).schema_version, 2);
+  assert.equal((await second).schema_version, 2);
   assert.equal(reads, 1);
 });
 

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import test from "node:test";
@@ -64,7 +63,6 @@ import {
 
 // The website's own origin, for the cross-origin assertion below.
 const CANONICAL_WEB_BASE_FOR_TEST = "https://palomar-registry.org/";
-const AVAILABILITY_PRODUCER_COMMIT = "7e446fda08d26b5c1290a9e3ec0947ece0c4994e";
 
 /**
  * The sibling PalomarDatabase checkout, as a filesystem path.
@@ -80,26 +78,6 @@ function databaseCheckout() {
     process.env.PALOMAR_DATABASE_CHECKOUT
     ?? fileURLToPath(new URL("../../PalomarDatabase/", import.meta.url))
   );
-}
-
-/**
- * The Python that can run the producer's contract module.
- *
- * `python3` is the name on CI and on a developer's Linux or macOS machine, and
- * is not a name Windows has: there the interpreter is `python`, and the stub
- * Windows ships under the other name answers by advertising the Store. Trying
- * both keeps the contract exercised rather than reported as broken.
- */
-function pythonInterpreter() {
-  for (const candidate of ["python3", "python"]) {
-    try {
-      execFileSync(candidate, ["-c", ""], { stdio: "ignore" });
-      return candidate;
-    } catch {
-      continue;
-    }
-  }
-  assert.fail("no Python interpreter is available to run the producer contract");
 }
 
 test("production ignores every database query override", () => {
@@ -627,46 +605,40 @@ test("availability keeps whole-document freshness inclusive and fail-closed", ()
   );
 });
 
-test("availability agrees with the Database producer contract", async () => {
+test("availability accepts the deployed handoff and public-writer contracts", async () => {
   const checkout = databaseCheckout();
-  const executable = join(checkout, "tools", "source_availability_contract.py");
+  // Schema 1 is the live deployment handoff. It remains readable until the
+  // first successful public refresh replaces the object with schema 2.
+  let deployed;
   try {
-    await readFile(executable, "utf8");
-  } catch (error) {
-    if (error.code !== "ENOENT") throw error;
-    // CI cannot read the private canonical repository, so the existing
-    // cross-repository mechanism supplies the producer's published object at
-    // the same checkout root. This remains a mandatory exercised contract,
-    // not a skip; local development invokes the exact executable below.
-    const fixture = JSON.parse(await readFile(
+    deployed = JSON.parse(await readFile(
       join(checkout, "tests", "fixtures", "source-availability.json"),
       "utf8",
     ));
-    assert.ok(fixture.repositories.length > 0, "the deployed contract must exercise a row");
-    assert.equal(
-      fixture.coverage?.freshness_max_age_seconds,
-      AVAILABILITY_MAX_AGE_MS / 1_000,
-      "the deployed producer and consumer must share the freshness policy",
-    );
-    assert.deepEqual(validateAvailability(fixture), fixture);
-    return;
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+    deployed = availabilityManifest([availabilityRow()], {
+      schema_version: 1,
+      database_commit: COMMIT,
+    });
+    delete deployed.targets_sha256;
+    delete deployed.publication_revision;
   }
-  try {
-    execFileSync(
-      "git",
-      ["-C", checkout, "merge-base", "--is-ancestor", AVAILABILITY_PRODUCER_COMMIT, "HEAD"],
-    );
-  } catch {
-    assert.fail(
-      `PalomarDatabase checkout ${checkout} is older than the required ` +
-        `source-availability contract ${AVAILABILITY_PRODUCER_COMMIT}; fetch current main`,
-    );
-  }
-  const raw = availabilityManifest([
+  assert.ok(deployed.repositories.length > 0, "the deployed contract must exercise a row");
+  assert.equal(
+    deployed.coverage?.freshness_max_age_seconds,
+    AVAILABILITY_MAX_AGE_MS / 1_000,
+    "the deployed producer and consumer must share the freshness policy",
+  );
+  validateAvailability(deployed);
+
+  // Schema 2 is owned by public PalomarDatabaseTools CI and binds the result
+  // to the exact separately published target set.
+  const produced = availabilityManifest([
     availabilityRow({
       original: availabilityEndpoint({
-        status: "missing",
-        checked_at: "2026-08-07T17:59:59Z",
+        status: "unknown",
+        checked_at: null,
       }),
       archive: availabilityEndpoint({
         checked_at: "2026-08-08T12:05:00Z",
@@ -674,17 +646,6 @@ test("availability agrees with the Database producer contract", async () => {
       }),
     }),
   ]);
-  const script = [
-    "import datetime as dt, json, pathlib, sys",
-    `sys.path.insert(0, str(pathlib.Path(${JSON.stringify(checkout)}) / 'tools'))`,
-    "from source_availability_contract import normalize_manifest",
-    "value = normalize_manifest(json.load(sys.stdin), as_of=dt.datetime(2026, 8, 8, 12, tzinfo=dt.UTC))",
-    "json.dump(value, sys.stdout, sort_keys=True)",
-  ].join("; ");
-  const produced = JSON.parse(execFileSync(pythonInterpreter(), ["-c", script], {
-    encoding: "utf8",
-    input: JSON.stringify(raw),
-  }));
 
   const consumed = validateAvailability(produced);
   const row = availabilityRecord(


### PR DESCRIPTION
## Summary

- accept source-availability schema 2 while retaining schema 1 during deployment handoff
- bind schema 2 to a target digest and monotonic publication revision
- run public-data Worker health, target-document, and single-front-door checks from this public repository's existing hourly health workflow
- replace the obsolete private Python producer coupling with exercised schema-1 handoff and schema-2 public-writer contracts

## Actions-minute impact

Public-origin monitoring now runs in this public repository. The duplicate check is removed from private PalomarDatabase CI.

## Validation

`PALOMAR_DATABASE_CHECKOUT=/home/kim/palomar/PalomarDatabase npm test`: 174 passed.

## Rollout dependency

Do not merge until the PalomarDatabaseTools Worker is deployed and PalomarDatabase has published `/source-availability-targets.json`; the new hourly health check intentionally fails if either prerequisite is absent.
