### PR TITLE
fix: point the site's data links at a document with results in it

### DIFF
--- a/404.html
+++ b/404.html
@@ -27,7 +27,7 @@
     </main>
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="/privacy.html">Privacy</a><a href="https://data.palomar-registry.org/browse/index.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="/privacy.html">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
   </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -735,7 +735,7 @@
 
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="privacy.html">Privacy</a><a href="https://data.palomar-registry.org/browse/index.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="privacy.html">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/about.js"></script>
   </body>

--- a/entry.html
+++ b/entry.html
@@ -24,14 +24,14 @@
           <br>
           Entry pages require JavaScript because they read immutable records from
           the machine-readable registry at runtime. You can instead
-          <a href="https://data.palomar-registry.org/browse/index.json">browse the registry as JSON</a>.
+          <a href="https://data.palomar-registry.org/recent.json">read the newest results as JSON</a>.
         </noscript>
       </div>
       <article id="entry-content" hidden></article>
     </main>
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="privacy.html">Privacy</a><a href="https://data.palomar-registry.org/browse/index.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="privacy.html">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/app.js"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
         <a href="https://data.palomar-registry.org/feed.xml">RSS</a>
         <a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a>
         <a href="privacy.html">Privacy</a>
-        <a href="https://data.palomar-registry.org/browse/index.json">Data</a>
+        <a href="https://data.palomar-registry.org/recent.json">Data</a>
         <a href="https://github.com/leanprover/comparator">Comparator</a>
         <a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a>
       </div>

--- a/privacy.html
+++ b/privacy.html
@@ -645,7 +645,7 @@
 
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="privacy.html">Privacy</a><a href="https://data.palomar-registry.org/browse/index.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="privacy.html">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/about.js"></script>
   </body>

--- a/render.html
+++ b/render.html
@@ -22,7 +22,7 @@
     </main>
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="privacy.html">Privacy</a><a href="https://data.palomar-registry.org/browse/index.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="privacy.html">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/app.js"></script>
   </body>

--- a/subject.html
+++ b/subject.html
@@ -24,7 +24,7 @@
           <br>
           Subject pages require JavaScript because they read the machine-readable
           registry at runtime. You can instead
-          <a href="https://data.palomar-registry.org/browse/index.json">browse the registry as JSON</a>.
+          <a href="https://data.palomar-registry.org/recent.json">read the newest results as JSON</a>.
         </noscript>
       </div>
       <section id="subject-content" hidden></section>
@@ -35,7 +35,7 @@
     </main>
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="privacy.html">Privacy</a><a href="https://data.palomar-registry.org/browse/index.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="privacy.html">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/app.js"></script>
   </body>

--- a/tests/check-published.test.js
+++ b/tests/check-published.test.js
@@ -496,7 +496,11 @@ test("every monitored linked document is requested exactly once from its owner",
   } = await import("../scripts/check-published.mjs");
   const sources = await shippedSources();
   const documents = monitoredLinkedDocuments(sources);
-  for (const path of ["browse/index.json", "feed.xml", "recent.json", "source-availability.json"]) {
+  // The browse head is not here because no page links it: it names years and
+  // counts and no path, so a reader who followed it learned nothing and could
+  // not go on. `--data` fetches it as the root of the complete traversal, which
+  // is the only thing that ever read it.
+  for (const path of ["feed.xml", "recent.json", "source-availability.json"]) {
     assert.ok(
       documents.has(`https://data.palomar-registry.org/${path}`),
       `${path} is absent from the shipped document reconciliation`,


### PR DESCRIPTION
This PR points the four footers and the entry page's noscript fallback at `recent.json` instead of `browse/index.json`.

`browse/index.json` is the head of the browse traversal. It carries the year rows and the counts and no path, deliberately: a head naming every page would be O(pages) rewritten per publication, which is the quadratic the fixed shards had. Followed by hand it answers with two integers and a year and gives the reader nowhere to go next, because the URL grammar that would take them to a year document and then a page lives in the publisher's docstring and in no served document. `recent.json` carries whole records, and the landing page's own noscript fallback already named it.

The browse head keeps its shape and stays covered. `check-published.mjs --data` fetches it as the root of the complete traversal, so dropping it from the linked-document health list costs no monitoring; that list is what the shipped HTML names, and the shipped HTML no longer names it.

🤖 Prepared with Claude Code