### PR TITLE
feat: search the registry as you type

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -8,7 +8,12 @@ import {
   safeInternalUrl,
   workflowRunId,
 } from "./security.mjs";
-import { createRegistrySearch, validateSearchQuery } from "./searching.mjs";
+import {
+  SEARCH_RESULT_LIMIT,
+  SEARCH_TERM_LIMIT,
+  createRegistrySearch,
+  validateSearchQuery,
+} from "./searching.mjs";
 import {
   renderChallengePage,
   renderEntryPage,
@@ -31,6 +36,10 @@ const params = new URLSearchParams(window.location.search);
 const ARXIV_FILTER_RE = /^[a-z]+(?:-[a-z]+)*(?:\.[A-Za-z-]+)?$/;
 const MSC2020_FILTER_RE = /^[0-9]{2}(?:[A-Z][0-9]{2}|-[0-9]{2})$/;
 const FILTER_UPDATE_DELAY_MS = 200;
+// Longer than the classification filter above, because each registry search
+// costs a stopword read, a head read per word, posting pages, and up to sixty
+// record reads. A pause is the signal; a keystroke is not.
+const SEARCH_UPDATE_DELAY_MS = 300;
 
 function el(tag, className, text) {
   const node = document.createElement(tag);
@@ -155,16 +164,16 @@ const {
   trustBadge,
 } = createFormalizationPresentation({ document });
 
-function entryCard(
-  entry,
-  { versionCount = null, current = false, registeredAt = entry.registered_at } = {},
-) {
+/**
+ * Everything on a card that a reader might type at it, as one lowercase run.
+ *
+ * The instant matches shown while the registry answers are chosen from this,
+ * and so is the card's own index. Deriving both from here is what keeps the
+ * provisional set from disagreeing with the cards it is drawn from.
+ */
+function searchBlob(entry) {
   const categories = classification(entry);
-  const card = el("article", "entry-card");
-  card.dataset.trust = entry.trust.level;
-  card.dataset.arxiv = categories.arxiv.join(" ");
-  card.dataset.msc = categories.msc2020.join(" ");
-  card.dataset.search = [
+  return [
     entry.title,
     entry.abstract,
     authorNames(entry),
@@ -175,6 +184,18 @@ function entryCard(
     ...categories.arxiv,
     ...categories.msc2020,
   ].join(" ").toLowerCase();
+}
+
+function entryCard(
+  entry,
+  { versionCount = null, current = false, registeredAt = entry.registered_at } = {},
+) {
+  const categories = classification(entry);
+  const card = el("article", "entry-card");
+  card.dataset.trust = entry.trust.level;
+  card.dataset.arxiv = categories.arxiv.join(" ");
+  card.dataset.msc = categories.msc2020.join(" ");
+  card.dataset.search = searchBlob(entry);
 
   const top = el("div", "card-top");
   const identity = el("div", "card-identity");
@@ -269,6 +290,7 @@ async function renderIndex() {
     // therefore costs one summary read, not one record read per card.
     const recent = await loadRecent(databaseBase);
     const entries = recent.entries;
+    landingMatches = entries.map((entry) => ({ entry, blob: searchBlob(entry) }));
     // GitHub Pages may briefly pair HTML and JavaScript from adjacent deployments.
     // Metrics are presentation-only, so a removed metric must not abort the registry.
     setOptionalText("#metric-results", String(entries.length));
@@ -299,7 +321,6 @@ async function renderIndex() {
       console.warn(`Landing card source availability could not be applied: ${error.message}`);
     });
     let trust = "all";
-    const search = document.querySelector("#search");
     // The fallback selectors keep new JavaScript compatible with cached HTML
     // from the previous GitHub Pages deployment.
     const arxiv = document.querySelector("#arxiv-query, #arxiv-filter");
@@ -337,8 +358,10 @@ async function renderIndex() {
     };
     applyCategoryParameter(arxiv, "arxiv", 32);
     applyCategoryParameter(msc, "msc", 5);
+    // Words are the registry search's business now. What is left here narrows
+    // the landing selection by facts the cards already carry, which is why it
+    // can stay instant and local.
     const update = () => {
-      const query = search.value.trim().toLowerCase();
       const arxivValue = arxiv?.value.trim() || "";
       const mscValue = msc?.value.trim() || "";
       const arxivInvalid = Boolean(arxivValue && !ARXIV_FILTER_RE.test(arxivValue));
@@ -348,8 +371,7 @@ async function renderIndex() {
         const visible =
           (trust === "all" || card.dataset.trust === trust) &&
           (!arxivValue || (!arxivInvalid && card.dataset.arxiv.split(" ").includes(arxivValue))) &&
-          (!mscValue || (!mscInvalid && card.dataset.msc.split(" ").includes(mscValue))) &&
-          (!query || card.dataset.search.includes(query));
+          (!mscValue || (!mscInvalid && card.dataset.msc.split(" ").includes(mscValue)));
         card.hidden = !visible;
         if (visible) shown += 1;
       }
@@ -375,7 +397,6 @@ async function renderIndex() {
       window.clearTimeout(updateTimer);
       updateTimer = window.setTimeout(update, FILTER_UPDATE_DELAY_MS);
     };
-    search.addEventListener("input", scheduleUpdate);
     for (const control of [arxiv, msc]) {
       for (const eventName of ["input", "change", "search"]) {
         control?.addEventListener(eventName, scheduleUpdate);
@@ -401,6 +422,12 @@ async function renderIndex() {
     return false;
   }
 }
+
+// The landing selection with its text already flattened, kept so that a reader
+// who starts typing sees the entries the page holds without waiting for
+// anything. Matching happens on a keystroke pause, so the flattening is done
+// once here rather than two hundred times per pause.
+let landingMatches = [];
 
 let landingLoad = null;
 function ensureLanding() {
@@ -433,6 +460,49 @@ function renderSearchCards(results, entries) {
   return cards;
 }
 
+/**
+ * The loaded entries that carry what was typed, for the wait.
+ *
+ * This is not the question the registry index answers. It looks for the text
+ * anywhere inside the newest entries the page happens to hold; the index looks
+ * for whole words, requires all of them, and covers every published version.
+ * So this will show entries the search then removes, and miss ones it finds.
+ * That gap is why the result of this is drawn as provisional and thrown away
+ * the moment the registry answers.
+ */
+function previewEntries(query) {
+  // Every word must appear, as the index requires, but a word matches anywhere
+  // inside a longer one, because half a word is what a reader has typed so far.
+  // Bounded like the index bounds itself: the query is up to four thousand
+  // characters, and this runs between two keystrokes.
+  const wanted = [...new Set(query.trim().toLowerCase().split(/\s+/).filter(Boolean))]
+    .slice(0, SEARCH_TERM_LIMIT);
+  if (!wanted.length) return [];
+  const matches = [];
+  for (const { entry, blob } of landingMatches) {
+    if (!wanted.every((word) => blob.includes(word))) continue;
+    matches.push(entry);
+    if (matches.length === SEARCH_RESULT_LIMIT) break;
+  }
+  return matches;
+}
+
+function renderPreviewCards(results, entries) {
+  // Drawn like the search cards that will replace them, down to leaving out
+  // which version is current: the landing rows do carry that, but showing it
+  // here would mean every card quietly lost a claim when the results arrived.
+  const cards = entries.map((entry) =>
+    entryCard(entry, { registeredAt: entry.published_at }));
+  results.replaceChildren(...cards);
+  results.classList.add("preview");
+  return cards;
+}
+
+function setSearchBusy(busy) {
+  const spinner = document.querySelector("#search-spinner");
+  if (spinner) spinner.hidden = !busy;
+}
+
 function clearSearchQueryWarning(input) {
   input?.removeAttribute("aria-invalid");
   input?.removeAttribute("aria-describedby");
@@ -456,6 +526,8 @@ async function renderSearch(query) {
   const input = document.querySelector("#query");
   if (!status || !results) return;
   results.replaceChildren();
+  results.classList.remove("preview");
+  setSearchBusy(false);
   status.className = "status";
   let asked;
   try {
@@ -481,7 +553,19 @@ async function renderSearch(query) {
   const controller = new AbortController();
   activeSearchController = controller;
   status.hidden = false;
-  status.textContent = "Searching the registry…";
+  // Something to read while the registry is asked. It is drawn from a smaller
+  // pool by a looser rule, so the status says so rather than letting it pass
+  // for an answer.
+  const preview = previewEntries(query);
+  if (preview.length) {
+    renderPreviewCards(results, preview);
+    status.textContent =
+      `Showing ${preview.length} match${preview.length === 1 ? "" : "es"} from the ` +
+      `newest ${landingMatches.length} entries while the registry search runs…`;
+  } else {
+    status.textContent = "Searching the registry…";
+  }
+  setSearchBusy(true);
   try {
     const { databaseBase, availabilityUrl } = dataSource();
     const found = await searchRegistry(query, databaseBase, { signal: controller.signal });
@@ -542,13 +626,22 @@ async function renderSearch(query) {
     status.classList.toggle("warning", Boolean(degraded));
   } catch (error) {
     if (generation !== searchGeneration) return;
+    // A failed search shows nothing rather than leaving the provisional set
+    // standing under an error that does not describe it.
+    results.replaceChildren();
     if (error instanceof RangeError) showSearchQueryWarning(input, status, error);
     else {
       status.textContent = `The search could not be run: ${error.message}`;
       status.classList.add("error");
     }
   } finally {
-    if (generation === searchGeneration) activeSearchController = null;
+    // A superseded search owns none of this any more: the query that replaced
+    // it has already put up its own provisional set and its own spinner.
+    if (generation === searchGeneration) {
+      activeSearchController = null;
+      results.classList.remove("preview");
+      setSearchBusy(false);
+    }
   }
 }
 
@@ -558,10 +651,9 @@ function wireSearch() {
   if (!form || !input) return false;
   const initial = params.get("q") || "";
   input.value = initial;
-  form.addEventListener("submit", (event) => {
-    // The page's own content security policy forbids form submission, which is
-    // right: nothing here posts anywhere. The query is a link to this page.
-    event.preventDefault();
+  let queryTimer;
+  const runQuery = () => {
+    window.clearTimeout(queryTimer);
     const rawQuery = input.value;
     try {
       // Validate before trimming or constructing the shareable URL. This also
@@ -572,8 +664,22 @@ function wireSearch() {
       return;
     }
     const query = rawQuery.trim();
+    // replaceState, not pushState: typing a query is not a series of pages to
+    // walk back through, but the address stays worth copying at every pause.
     window.history.replaceState(null, "", searchPageUrlFor(query));
     renderSearch(query);
+  };
+  const scheduleQuery = () => {
+    window.clearTimeout(queryTimer);
+    queryTimer = window.setTimeout(runQuery, SEARCH_UPDATE_DELAY_MS);
+  };
+  input.addEventListener("input", scheduleQuery);
+  form.addEventListener("submit", (event) => {
+    // The page's own content security policy forbids form submission, which is
+    // right: nothing here posts anywhere. The query is a link to this page.
+    event.preventDefault();
+    // Enter means stop waiting for the pause, not run a second search.
+    runQuery();
   });
   if (initial) renderSearch(initial);
   return Boolean(initial);

--- a/assets/app.js
+++ b/assets/app.js
@@ -192,6 +192,7 @@ function entryCard(
 ) {
   const categories = classification(entry);
   const card = el("article", "entry-card");
+  card.dataset.id = entry.id;
   card.dataset.trust = entry.trust.level;
   card.dataset.arxiv = categories.arxiv.join(" ");
   card.dataset.msc = categories.msc2020.join(" ");
@@ -321,6 +322,11 @@ async function renderIndex() {
       console.warn(`Landing card source availability could not be applied: ${error.message}`);
     });
     let trust = "all";
+    // Cached HTML from the previous deployment still carries the filter box
+    // this JavaScript no longer wires. Leaving it on the page would offer a
+    // reader a control that silently does nothing.
+    const legacyFilter = document.querySelector(".toolbar .search");
+    if (legacyFilter) legacyFilter.hidden = true;
     // The fallback selectors keep new JavaScript compatible with cached HTML
     // from the previous GitHub Pages deployment.
     const arxiv = document.querySelector("#arxiv-query, #arxiv-filter");
@@ -498,9 +504,37 @@ function renderPreviewCards(results, entries) {
   return cards;
 }
 
-function setSearchBusy(busy) {
+function setSearchBusy(results, busy) {
   const spinner = document.querySelector("#search-spinner");
   if (spinner) spinner.hidden = !busy;
+  // The results grid is a polite live region. Without this it reads out the
+  // provisional cards and then reads the whole verified set again, which is
+  // two announcements for one search and the first of them not yet true.
+  if (busy) results.setAttribute("aria-busy", "true");
+  else results.removeAttribute("aria-busy");
+}
+
+/** The result a reader is standing on, so that replacing the set can put them back. */
+function focusedEntryId(results) {
+  const active = document.activeElement;
+  if (!active || !results.contains(active)) return null;
+  return active.closest(".entry-card")?.dataset.id || null;
+}
+
+/**
+ * Put the reader back where they were once the provisional cards are replaced.
+ *
+ * Without this, confirming a result silently drops focus to the document body,
+ * because the node the reader was on is one of the ones thrown away.
+ */
+function restoreFocusAfterSwap(results, entryId) {
+  if (!entryId) return;
+  // Matched by walking the cards rather than by building a selector out of a
+  // value that came from data, which is the rule everywhere else here.
+  const card = [...results.children].find((node) => node.dataset.id === entryId);
+  const link = card?.querySelector("a");
+  if (link) link.focus();
+  else document.querySelector("#query")?.focus();
 }
 
 function clearSearchQueryWarning(input) {
@@ -516,7 +550,16 @@ function showSearchQueryWarning(input, status, error) {
   input?.setAttribute("aria-describedby", status.id);
 }
 
-async function renderSearch(query) {
+/**
+ * Show what this query looks like from here, and unless told otherwise, ask.
+ *
+ * `ask: false` is the keystroke half. A reader who has typed on has already
+ * left the answer on the page behind, so the request in flight for it is
+ * abandoned and the provisional set is repainted at once, without waiting out
+ * the pause first. Waiting would leave one query in the box and a different
+ * query's results, verified and undimmed, underneath it.
+ */
+async function renderSearch(query, { ask = true } = {}) {
   const generation = searchGeneration + 1;
   searchGeneration = generation;
   activeSearchController?.abort(new Error("superseded registry search"));
@@ -527,7 +570,7 @@ async function renderSearch(query) {
   if (!status || !results) return;
   results.replaceChildren();
   results.classList.remove("preview");
-  setSearchBusy(false);
+  setSearchBusy(results, false);
   status.className = "status";
   let asked;
   try {
@@ -550,8 +593,6 @@ async function renderSearch(query) {
     ensureLanding();
     return;
   }
-  const controller = new AbortController();
-  activeSearchController = controller;
   status.hidden = false;
   // Something to read while the registry is asked. It is drawn from a smaller
   // pool by a looser rule, so the status says so rather than letting it pass
@@ -565,7 +606,10 @@ async function renderSearch(query) {
   } else {
     status.textContent = "Searching the registry…";
   }
-  setSearchBusy(true);
+  setSearchBusy(results, true);
+  if (!ask) return;
+  const controller = new AbortController();
+  activeSearchController = controller;
   try {
     const { databaseBase, availabilityUrl } = dataSource();
     const found = await searchRegistry(query, databaseBase, { signal: controller.signal });
@@ -578,7 +622,11 @@ async function renderSearch(query) {
     }
     // Availability changes only where a source link points. It must never hold
     // verified registry results behind its own long timeout.
+    // Read immediately before the swap, not when the search began: the reader
+    // had the whole wait in which to go and stand on one of these cards.
+    const wasOn = focusedEntryId(results);
     const cards = renderSearchCards(results, found.entries);
+    restoreFocusAfterSwap(results, wasOn);
     if (found.entries.length) {
       void loadAvailabilityBounded(availabilityUrl).then((availability) => {
         if (availability !== null && generation === searchGeneration) {
@@ -640,7 +688,7 @@ async function renderSearch(query) {
     if (generation === searchGeneration) {
       activeSearchController = null;
       results.classList.remove("preview");
-      setSearchBusy(false);
+      setSearchBusy(results, false);
     }
   }
 }
@@ -671,6 +719,11 @@ function wireSearch() {
   };
   const scheduleQuery = () => {
     window.clearTimeout(queryTimer);
+    // Repaint from what is already loaded now, and ask the registry once the
+    // typing stops. Only the request is worth waiting for: filtering entries
+    // the page is already holding costs nothing, and doing it on the same
+    // delay would leave the last query's answer sitting under the new one.
+    renderSearch(input.value, { ask: false });
     queryTimer = window.setTimeout(runQuery, SEARCH_UPDATE_DELAY_MS);
   };
   input.addEventListener("input", scheduleQuery);

--- a/assets/style.css
+++ b/assets/style.css
@@ -287,9 +287,14 @@ h3 {
  * Provisional matches, drawn from the entries the page already holds. They are
  * a different question than the one the registry index answers, so they are
  * shown as unfinished business rather than as results.
+ *
+ * Set apart by their ground rather than by opacity. These are cards a reader is
+ * meant to read and may click, so fading the text would put it under the
+ * contrast a reader is owed, and shifting the box would make the whole set jump
+ * when the verified cards land in their place.
  */
 #search-results.preview .entry-card {
-  opacity: .55;
+  background: var(--shade);
 }
 
 .toolbar {

--- a/assets/style.css
+++ b/assets/style.css
@@ -249,8 +249,47 @@ h3 {
   outline-offset: 2px;
 }
 
+/*
+ * The search runs on a typing pause rather than on a button press, so the only
+ * thing distinguishing "you have stopped typing" from "the registry has
+ * answered" is this mark. The status text beside it carries the same fact for
+ * anyone not watching the pixels.
+ */
+.spinner {
+  flex: none;
+  width: 1.05rem;
+  height: 1.05rem;
+  border: 2px solid var(--line);
+  border-top-color: var(--link);
+  border-radius: 50%;
+  animation: spin .7s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/*
+ * A reader who asks for less motion still has to be told a request is running,
+ * so the ring stays and only the rotation goes.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: none;
+  }
+}
+
 #search-results:empty {
   display: none;
+}
+
+/*
+ * Provisional matches, drawn from the entries the page already holds. They are
+ * a different question than the one the registry index answers, so they are
+ * shown as unfinished business rather than as results.
+ */
+#search-results.preview .entry-card {
+  opacity: .55;
 }
 
 .toolbar {
@@ -270,26 +309,6 @@ body.registry-searching #entry-grid {
   display: none;
 }
 
-.search {
-  display: flex;
-  align-items: center;
-  gap: .45rem;
-  flex: 1;
-  max-width: 37rem;
-}
-
-.search input {
-  width: 100%;
-  min-height: 2rem;
-  padding: .25rem .4rem;
-  border: 1px solid var(--field);
-  border-radius: 0;
-  background: var(--paper);
-  color: var(--ink);
-  font: .9rem var(--sans);
-}
-
-.search input:focus-visible,
 .category-filters input:focus-visible,
 button:focus-visible {
   outline: 2px solid var(--link);
@@ -977,8 +996,7 @@ pre {
     flex-wrap: wrap;
   }
 
-  .toolbar,
-  .search {
+  .toolbar {
     width: 100%;
   }
 

--- a/index.html
+++ b/index.html
@@ -48,17 +48,21 @@
 
         <form id="registry-search" class="registry-search" role="search">
           <label for="query">Search the registry:</label>
-          <input id="query" name="q" type="search" placeholder="words from a title, abstract, or author" autocomplete="off" spellcheck="false" maxlength="4096">
-          <button type="submit">Search</button>
+          <input id="query" name="q" type="search" placeholder="title, author, abstract, theorem, or repository" autocomplete="off" spellcheck="false" maxlength="4096">
+          <span id="search-spinner" class="spinner" hidden aria-hidden="true"></span>
         </form>
         <div id="search-status" class="status" role="status" hidden></div>
         <div id="search-results" class="entry-grid" aria-live="polite"></div>
 
         <div class="toolbar">
-          <label class="search">
-            <span>Filter:</span>
-            <input id="search" type="search" placeholder="title, author, theorem, or repository" autocomplete="off">
-          </label>
+          <!--
+            GitHub Pages can pair this HTML with JavaScript from the previous
+            deployment, which wires a listener to this box and would otherwise
+            take the whole listing down when it is not here. It is empty, so
+            that JavaScript filters on nothing. It goes once no deployment that
+            looks for it can still be served.
+          -->
+          <input id="search" type="search" hidden aria-hidden="true" tabindex="-1">
           <div class="category-filters" role="group" aria-label="Subject filters">
             <label>arXiv:
               <input id="arxiv-query" type="search" list="arxiv-options" maxlength="32" placeholder="e.g. math.CO" autocomplete="off" spellcheck="false">

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -20,6 +20,32 @@ function fileAtPreviousDeployment(path) {
 }
 
 /**
+ * Ask the registry a deliberate question and do not wait out the typing pause.
+ *
+ * The value is set rather than typed on purpose. Typing schedules the debounced
+ * search, which would race the Enter below and make the request counts these
+ * tests assert on depend on how fast the machine is. Enter is still a real key
+ * press, because the form no longer has a button and that is the only way in.
+ * The tests that cover typing itself type.
+ */
+async function startSearch(page, query) {
+  await page.locator("#query").evaluate((input, value) => { input.value = value; }, query);
+  await page.locator("#query").press("Enter");
+}
+
+/**
+ * Ask, and wait until the registry rather than the page has answered.
+ *
+ * While a search runs the page stands in the entries it already holds, drawn
+ * exactly like the cards that will replace them. Counting cards therefore
+ * cannot tell the two apart, and the spinner is what can.
+ */
+async function runSearch(page, query) {
+  await startSearch(page, query);
+  await expect(page.locator("#search-spinner")).toBeHidden();
+}
+
+/**
  * Which entry schema the previous deployment's validator would accept.
  *
  * Cached JavaScript can only be compatible with records it can read. When the
@@ -631,9 +657,9 @@ test("a card says the original is unavailable exactly when the manifest says so"
   const card = page.locator(".entry-card").first();
   await expect(card).toHaveCount(1);
   await availabilityRequested;
-  await page.locator("#search").fill("000123");
+  await page.locator("#arxiv-query").fill("math.CO");
   await expect(page.locator(".entry-card:visible")).toHaveCount(1);
-  await page.locator("#search").evaluate((input) => input.focus());
+  await page.locator("#arxiv-query").evaluate((input) => input.focus());
   await card.evaluate((node) => { node.dataset.progressiveFixture = "same-card"; });
   // Cards and filters are usable while availability is still pending.
   await expect(card.locator(".repo-link")).toHaveText("example/challenge");
@@ -641,8 +667,8 @@ test("a card says the original is unavailable exactly when the manifest says so"
   await expect(card.locator(".source-status.missing")).toHaveText("Original unavailable");
   await expect(card.locator(".repo-link")).toHaveText("Palomar preserved copy");
   await expect(card).toHaveAttribute("data-progressive-fixture", "same-card");
-  await expect(page.locator("#search")).toBeFocused();
-  await expect(page.locator("#search")).toHaveValue("000123");
+  await expect(page.locator("#arxiv-query")).toBeFocused();
+  await expect(page.locator("#arxiv-query")).toHaveValue("math.CO");
   await expect(page.locator(".entry-card:visible")).toHaveCount(1);
 
   await page.goto(`/?database=${database}`);
@@ -1177,8 +1203,7 @@ test("a search reads one postings sequence per word and confirms every hit", asy
   await expect(page.locator(".entry-card")).toHaveCount(2);
 
   asked.length = 0;
-  await page.locator("#query").fill("quasicoherent 000124");
-  await page.getByRole("button", { name: "Search" }).click();
+  await runSearch(page, "quasicoherent 000124");
 
   await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
   await expect(page.locator("#search-results .entry-card")).toContainText("000124");
@@ -1217,15 +1242,14 @@ test("runtime data reads reuse a fresh HTTP response", async ({ page }) => {
 
   await page.goto(`/?database=${database}`);
   await page.evaluate(() => performance.clearResourceTimings());
-  await page.locator("#query").fill("cacheprobe");
-  await page.getByRole("button", { name: "Search" }).click();
+  await runSearch(page, "cacheprobe");
   await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
   await expect.poll(async () => (await timings()).length).toBe(1);
 
   // The fixture gives this otherwise ordinary postings document max-age=60.
   // Submitting the same search still calls fetch, but the browser should
   // satisfy it from its HTTP cache rather than transferring it again.
-  await page.getByRole("button", { name: "Search" }).click();
+  await page.locator("#query").press("Enter");
   await expect.poll(async () => (await timings()).length).toBe(2);
   const [network, cached] = await timings();
   expect(network.transferSize).toBeGreaterThan(0);
@@ -1263,8 +1287,7 @@ test("an over-limit term count is an accessible warning and can be corrected", a
   await page.goto(`/?database=${database}`);
   await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
   asked.length = 0;
-  await page.locator("#query").fill(query);
-  await page.getByRole("button", { name: "Search" }).click();
+  await runSearch(page, query);
   await expect(page.locator("#query")).toHaveValue(query);
   await expect(page.locator("#search-status")).toHaveText(
     `Use at most ${SEARCH_TERM_LIMIT} distinct normalized words; ` +
@@ -1273,14 +1296,12 @@ test("an over-limit term count is an accessible warning and can be corrected", a
   await page.waitForTimeout(100);
   expect(asked.filter((path) => path.includes("/database/search/"))).toEqual([]);
 
-  await page.locator("#query").fill("synthetically");
-  await page.getByRole("button", { name: "Search" }).click();
+  await runSearch(page, "synthetically");
   await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
   await expect(page.locator("#query")).not.toHaveAttribute("aria-invalid");
   await expect(page.locator("#query")).not.toHaveAttribute("aria-describedby");
 
-  await page.locator("#query").fill("");
-  await page.getByRole("button", { name: "Search" }).click();
+  await runSearch(page, "");
   await expect(page.locator("#entry-grid")).toBeVisible();
   await expect(page.locator("#search-status")).toBeHidden();
 });
@@ -1448,12 +1469,12 @@ test("transient and invalid availability responses are both retried", async ({ p
   const invalidLogged = page.waitForEvent("console", {
     predicate: (message) => message.text().includes("Source availability is unavailable"),
   });
-  await page.getByRole("button", { name: "Search" }).click();
+  await page.locator("#query").press("Enter");
   await expect.poll(() => availabilityRequests).toBe(2);
   await invalidLogged;
   await expect(card.locator(".repo-link")).toHaveText("example/challenge");
 
-  await page.getByRole("button", { name: "Search" }).click();
+  await page.locator("#query").press("Enter");
   await expect.poll(() => availabilityRequests).toBe(3);
   await expect(card.locator(".repo-link")).toHaveText("Palomar preserved copy");
   await expect(card.locator(".source-status.missing")).toHaveText("Original unavailable");
@@ -1475,7 +1496,7 @@ test("a missing availability manifest is cached for the page", async ({ page }) 
   );
   await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
   await expect.poll(() => availabilityRequests).toBe(1);
-  await page.getByRole("button", { name: "Search" }).click();
+  await page.locator("#query").press("Enter");
   await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
   await page.waitForTimeout(50);
   expect(availabilityRequests).toBe(1);
@@ -1490,11 +1511,9 @@ test("a superseded slow search cannot repaint a newer query", async ({ page }) =
   });
   await page.goto(`/?database=${database}`);
 
-  await page.locator("#query").fill("quasicoherent");
-  await page.getByRole("button", { name: "Search" }).click();
+  await startSearch(page, "quasicoherent");
   await expect.poll(() => slowHeadRequests).toBe(1);
-  await page.locator("#query").fill("synthetically");
-  await page.getByRole("button", { name: "Search" }).click();
+  await runSearch(page, "synthetically");
 
   await expect(page.locator("#search-results .entry-id")).toHaveText(
     "PALOMAR-2026-07-29-000124 v1",
@@ -1532,8 +1551,7 @@ test("a linked search hides landing DOM and retries one failed landing load", as
   }))).toEqual({ grid: true, status: true, toolbar: true });
   await expect(page.locator("#entry-grid .entry-card")).toHaveCount(0);
 
-  await page.locator("#query").fill("");
-  await page.getByRole("button", { name: "Search" }).click();
+  await runSearch(page, "");
   await firstRecent;
   expect(await page.evaluate(() => ({
     grid: document.querySelector("#entry-grid").hidden,
@@ -1542,14 +1560,14 @@ test("a linked search hides landing DOM and retries one failed landing load", as
   }))).toEqual({ grid: false, status: false, toolbar: false });
 
   // Clearing again while the first landing request is pending shares it.
-  await page.getByRole("button", { name: "Search" }).click();
+  await page.locator("#query").press("Enter");
   await page.waitForTimeout(50);
   expect(recentRequests).toBe(1);
   releaseFirstRecent();
   await expect(page.locator("#status")).toContainText("could not be loaded");
 
   // Once that attempt has settled as failed, clearing retries it.
-  await page.getByRole("button", { name: "Search" }).click();
+  await page.locator("#query").press("Enter");
   await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
   expect(recentRequests).toBe(2);
 });
@@ -1558,8 +1576,7 @@ test("a search runs from a link, and says so when nothing carries the words", as
   await page.goto(`/?database=${database}&q=quasicoherent`);
   await expect(page.locator("#search-results .entry-card")).toHaveCount(2);
 
-  await page.locator("#query").fill("quasicoherent unobtainium");
-  await page.getByRole("button", { name: "Search" }).click();
+  await runSearch(page, "quasicoherent unobtainium");
   await expect(page.locator("#search-results .entry-card")).toHaveCount(0);
   // The words with no postings are named rather than guessed about. They are
   // words nothing carries and not words the indexer drops, because the dropped
@@ -1574,8 +1591,7 @@ test("a hostile query cannot construct a path outside the postings grammar", asy
   await page.goto(`/?database=${database}`);
 
   asked.length = 0;
-  await page.locator("#query").fill("../../etc/passwd?x=1 <script>");
-  await page.getByRole("button", { name: "Search" }).click();
+  await runSearch(page, "../../etc/passwd?x=1 <script>");
   await expect(page.locator("#search-status")).toContainText("No result carries all of");
 
   // The stopword list is at a fixed path and is the only request under
@@ -1593,8 +1609,7 @@ test("a hostile query cannot construct a path outside the postings grammar", asy
 
 test("a query with no word in it leaves the listing alone", async ({ page }) => {
   await page.goto(`/?database=${database}`);
-  await page.locator("#query").fill("a !");
-  await page.getByRole("button", { name: "Search" }).click();
+  await runSearch(page, "a !");
   await expect(page.locator("#entry-grid")).toBeVisible();
   await expect(page.locator("#search-status")).toBeHidden();
 });
@@ -1610,8 +1625,7 @@ test("a word the indexer drops leaves the query instead of failing it", async ({
   await page.goto(`/?database=${database}`);
 
   asked.length = 0;
-  await page.locator("#query").fill("the quasicoherent sheaves");
-  await page.getByRole("button", { name: "Search" }).click();
+  await runSearch(page, "the quasicoherent sheaves");
 
   await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
   await expect(page.locator("#search-results .entry-card")).toContainText("000124");
@@ -1622,10 +1636,110 @@ test("a word the indexer drops leaves the query instead of failing it", async ({
 test("a search made only of words the indexer drops says which they were", async ({ page }) => {
   // Otherwise this is a registry that appears to hold nothing.
   await page.goto(`/?database=${database}`);
-  await page.locator("#query").fill("the of and");
-  await page.getByRole("button", { name: "Search" }).click();
+  await runSearch(page, "the of and");
 
   await expect(page.locator("#search-status")).toContainText("too common to be indexed");
   await expect(page.locator("#search-status")).toContainText("the");
   await expect(page.locator("#search-results .entry-card")).toHaveCount(0);
+  await expect(page.locator("#search-spinner")).toBeHidden();
+});
+
+/** Hold one head request open, and hand back the way to let it go. */
+async function holdSearchHead(page, term) {
+  let release;
+  let noteRequest;
+  const requested = new Promise((resolve) => { noteRequest = resolve; });
+  await page.route(`**/database/search/t/${term}/head.json`, async (route) => {
+    noteRequest();
+    await new Promise((resolve) => { release = resolve; });
+    await route.continue().catch(() => {});
+  });
+  return { requested, release: () => release() };
+}
+
+test("typing runs one search at the pause, not one per keystroke", async ({ page }) => {
+  const heads = [];
+  page.on("request", (request) => {
+    const path = new URL(request.url()).pathname;
+    if (path.endsWith("/head.json")) heads.push(path);
+  });
+  await page.goto(`/?database=${database}`);
+  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
+
+  // There is no button to press, so the pause is the whole of the instruction.
+  await page.locator("#query").pressSequentially("quasicoherent", { delay: 10 });
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(2);
+
+  expect(heads).toEqual(["/database/search/t/quasicoherent/head.json"]);
+  await expect(page).toHaveURL(/q=quasicoherent/);
+});
+
+test("a pause shows the entries already loaded, marked as not yet the answer", async ({ page }) => {
+  const held = await holdSearchHead(page, "quasicoherent");
+  await page.goto(`/?database=${database}`);
+  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
+
+  await startSearch(page, "quasicoherent");
+  await held.requested;
+  await expect(page.locator("#search-results")).toHaveClass(/preview/);
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(2);
+  await expect(page.locator("#search-results .entry-card").first()).toHaveCSS("opacity", "0.55");
+  await expect(page.locator("#search-status")).toContainText("while the registry search runs");
+  await expect(page.locator("#search-status")).toContainText("newest 2 entries");
+  await expect(page.locator("#search-spinner")).toBeVisible();
+  // A provisional card claims no more than the search card replacing it will.
+  await expect(page.locator("#search-results .entry-id").first()).not.toContainText("current");
+
+  held.release();
+  await expect(page.locator("#search-spinner")).toBeHidden();
+  await expect(page.locator("#search-results")).not.toHaveClass(/preview/);
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(2);
+  await expect(page.locator("#search-results .entry-card").first()).toHaveCSS("opacity", "1");
+});
+
+test("nothing loaded to show leaves the wait to the spinner alone", async ({ page }) => {
+  const held = await holdSearchHead(page, "synthetically");
+  // A linked search never reads the landing selection, so there is nothing in
+  // hand to show, and the status must not claim otherwise.
+  await page.goto(`/?database=${database}&q=synthetically`);
+  await held.requested;
+  await expect(page.locator("#search-spinner")).toBeVisible();
+  await expect(page.locator("#search-status")).toHaveText("Searching the registry…");
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(0);
+
+  held.release();
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
+  await expect(page.locator("#search-spinner")).toBeHidden();
+});
+
+test("a provisional match the index does not confirm is taken away", async ({ page }) => {
+  // What the dimming is for. "quasi" sits inside a word the newest entries
+  // carry, so it is in hand at once, but the index knows whole words and holds
+  // nothing under it. The cards go and the reader is told why.
+  await page.goto(`/?database=${database}`);
+  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
+
+  await runSearch(page, "quasi");
+  await expect(page.locator("#search-status")).toContainText("No result carries all of: quasi");
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(0);
+  await expect(page.locator("#search-results")).not.toHaveClass(/preview/);
+  await expect(page.locator("#search-spinner")).toBeHidden();
+});
+
+test("emptying the box gives the listing and its filters back", async ({ page }) => {
+  await page.goto(`/?database=${database}`);
+  // Set before searching, because a search takes the toolbar off the page.
+  await page.locator("#arxiv-query").fill("math.CO");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(1);
+
+  await runSearch(page, "quasicoherent");
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(2);
+  await expect(page.locator("body")).toHaveClass(/registry-searching/);
+
+  await runSearch(page, "");
+  await expect(page.locator("body")).not.toHaveClass(/registry-searching/);
+  await expect(page.locator(".toolbar")).toBeVisible();
+  await expect(page.locator("#search-spinner")).toBeHidden();
+  await expect(page.locator("#arxiv-query")).toHaveValue("math.CO");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(1);
 });

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -1668,10 +1668,69 @@ test("typing runs one search at the pause, not one per keystroke", async ({ page
 
   // There is no button to press, so the pause is the whole of the instruction.
   await page.locator("#query").pressSequentially("quasicoherent", { delay: 10 });
+  await expect(page.locator("#search-spinner")).toBeVisible();
+  await expect(page.locator("#search-spinner")).toBeHidden();
+  await expect(page.locator("#search-results")).not.toHaveClass(/preview/);
   await expect(page.locator("#search-results .entry-card")).toHaveCount(2);
 
   expect(heads).toEqual(["/database/search/t/quasicoherent/head.json"]);
   await expect(page).toHaveURL(/q=quasicoherent/);
+});
+
+test("a keystroke abandons the answer to the query it just replaced", async ({ page }) => {
+  // The gap the generation counter alone does not close: it turns over when a
+  // search starts, and the next one does not start until the pause. Between
+  // the two, an answer to what the reader has already typed past would arrive
+  // verified and undimmed under a box that says something else.
+  const held = await holdSearchHead(page, "quasicoherent");
+  await page.goto(`/?database=${database}`);
+  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
+
+  await startSearch(page, "quasicoherent");
+  await held.requested;
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(2);
+
+  // One real keystroke, and then the old answer is let go immediately -- well
+  // inside the pause that would otherwise still be running.
+  await page.locator("#query").press("End");
+  await page.locator("#query").press("x");
+  await expect(page.locator("#query")).toHaveValue("quasicoherentx");
+  held.release();
+  await page.waitForTimeout(150);
+
+  // Nothing the abandoned query found may be standing here, verified or not.
+  // Nothing in hand carries "quasicoherentx" either, so the page is honestly
+  // empty rather than showing the two cards the old query had just confirmed.
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(0);
+  await expect(page.locator("#search-results")).toHaveAttribute("aria-busy", "true");
+  await expect(page.locator("#search-spinner")).toBeVisible();
+  await expect(page.locator("#search-status")).toContainText("Searching the registry");
+
+  await expect(page.locator("#search-spinner")).toBeHidden();
+  await expect(page.locator("#search-status")).toContainText("No result carries all of");
+});
+
+test("confirming a result keeps the reader on the card they were standing on", async ({ page }) => {
+  // The provisional cards are replaced wholesale, so without this the reader's
+  // focus goes with the node that carried it and lands on the document.
+  const held = await holdSearchHead(page, "quasicoherent");
+  await page.goto(`/?database=${database}`);
+  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
+
+  await startSearch(page, "quasicoherent");
+  await held.requested;
+  const card = (id) => page.locator(`#search-results .entry-card[data-id="${id}"]`);
+  await expect(page.locator("#search-results .entry-card").first())
+    .toHaveAttribute("data-id", "PALOMAR-2026-07-29-000123");
+  await card("PALOMAR-2026-07-29-000123").locator("h3 a").focus();
+
+  held.release();
+  await expect(page.locator("#search-spinner")).toBeHidden();
+  // Verified results come back in posting order, so this result is no longer
+  // the first card. Focus follows the result, not the position.
+  await expect(page.locator("#search-results .entry-card").first())
+    .toHaveAttribute("data-id", "PALOMAR-2026-07-29-000124");
+  await expect(card("PALOMAR-2026-07-29-000123").locator("h3 a")).toBeFocused();
 });
 
 test("a pause shows the entries already loaded, marked as not yet the answer", async ({ page }) => {
@@ -1682,8 +1741,13 @@ test("a pause shows the entries already loaded, marked as not yet the answer", a
   await startSearch(page, "quasicoherent");
   await held.requested;
   await expect(page.locator("#search-results")).toHaveClass(/preview/);
+  await expect(page.locator("#search-results")).toHaveAttribute("aria-busy", "true");
   await expect(page.locator("#search-results .entry-card")).toHaveCount(2);
-  await expect(page.locator("#search-results .entry-card").first()).toHaveCSS("opacity", "0.55");
+  // Set apart by ground, not by fading: these are cards a reader reads and may
+  // click, so the text stays at full contrast.
+  await expect(page.locator("#search-results .entry-card").first())
+    .toHaveCSS("background-color", "rgb(242, 242, 242)");
+  await expect(page.locator("#search-results .entry-card").first()).toHaveCSS("opacity", "1");
   await expect(page.locator("#search-status")).toContainText("while the registry search runs");
   await expect(page.locator("#search-status")).toContainText("newest 2 entries");
   await expect(page.locator("#search-spinner")).toBeVisible();
@@ -1693,8 +1757,10 @@ test("a pause shows the entries already loaded, marked as not yet the answer", a
   held.release();
   await expect(page.locator("#search-spinner")).toBeHidden();
   await expect(page.locator("#search-results")).not.toHaveClass(/preview/);
+  await expect(page.locator("#search-results")).not.toHaveAttribute("aria-busy", "true");
   await expect(page.locator("#search-results .entry-card")).toHaveCount(2);
-  await expect(page.locator("#search-results .entry-card").first()).toHaveCSS("opacity", "1");
+  await expect(page.locator("#search-results .entry-card").first())
+    .toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
 });
 
 test("nothing loaded to show leaves the wait to the spinner alone", async ({ page }) => {


### PR DESCRIPTION
This PR runs the registry search on a typing pause instead of a button press. On each pause the page shows the entries it already holds that carry the words, dimmed and named as provisional, keeps a spinner up while the index is asked, and replaces them with the verified results when they arrive. Enter still means now, and cancels the pending pause.

The toolbar's separate "Filter:" box is gone. Two live text inputs stacked in one section was the confusion that prompted this, so words are the registry search's business and the toolbar keeps classification and statement-dependency filtering over the listing.

The provisional set is not the search, and is drawn so a reader can tell. It comes from the newest two hundred current versions and matches a word anywhere inside a longer one, where the index covers every published version and matches whole words, all of them. So "quasi" fills the page from what is in hand and then empties it, because nothing is indexed under it. Dimming the cards and saying in the status where they came from is what keeps substring hits over a partial corpus from passing for verified results.

The toolbar keeps an empty hidden `#search` input. GitHub Pages can pair this HTML with JavaScript from the previous deployment, which wires a listener to that box; without it the whole listing comes down with a null dereference. It goes once no such deployment can still be served.

🤖 Prepared with Claude Code