### PR TITLE
test: stop the inline render scroll check racing the compositor

### DIFF
--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -1065,9 +1065,20 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
     "href",
     `https://github.com/example/challenge/tree/${"1".repeat(40)}/shared`,
   );
-  await iframe.hover();
-  await page.mouse.wheel(0, 2000);
-  await expect.poll(() => rendered.locator("html").evaluate((node) => node.scrollTop)).toBeGreaterThan(0);
+  // A wheel is hit-tested against the compositor's last committed frame, so
+  // one sent immediately after hover() has scrolled the frame into view can
+  // still be aimed at where the page used to be and scroll the page instead:
+  // the frame stays at 0 and never moves again, because nothing sends a
+  // second wheel. Re-aim and send until the frame's own document moves. What
+  // is being asserted is that a wheel over the frame scrolls the frame rather
+  // than the page around it, not how many events that takes. Chromium latches
+  // a wheel gesture to one scroller, so the frame absorbs the whole of the
+  // wheel that reaches it and stops at its own end.
+  await expect.poll(async () => {
+    await iframe.hover();
+    await page.mouse.wheel(0, 2000);
+    return rendered.locator("html").evaluate((node) => node.scrollTop);
+  }).toBeGreaterThan(0);
   await expect(rendered.locator("#theorem-end")).toBeInViewport();
 });
 


### PR DESCRIPTION
This PR makes the inline-render scroll check re-aim and re-send its wheel until the framed document moves, so it stops failing on a site that is behaving correctly.

A wheel is hit-tested against the compositor's last committed frame. The wheel this test sent immediately after `hover()` had scrolled the frame into view was therefore sometimes aimed at where the page used to be: it scrolled the page, the framed document stayed at its origin, and nothing sent a second one. That failed four runs in ten locally. What the test asserts is unchanged, since a wheel over the frame still has to scroll the frame rather than the page around it, and Chromium latches a wheel gesture to a single scroller, so the frame absorbs the whole of the wheel that reaches it.

🤖 Prepared with Claude Code
