### PR TITLE
test: hold the render frame and the page on one background

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,17 @@ referrer. The frame sizes itself from a height the document posts back, clamped
 between 160 and 672 pixels, so an untrusted render can ask for a sensible height
 without being able to take the page over.
 
+The frame follows the browser's light and dark preference, and nothing is sent
+across the origin boundary to make it. A media query is answered by whichever
+browser lays the document out, and that is the same browser either side of the
+frame, so the render bundle carries its own palette and reads
+`prefers-color-scheme` for itself. There is no theme message to look for. The
+palettes are held level by a browser test that asserts the page and the framed
+document land on the same background in both modes; the bundle side is generated
+by PalomarSubmission's `render_challenge.py`. Renders published before that
+palette existed are immutable and stay light, because a bundle's bytes are what
+its recorded hash is of.
+
 A record that arrives carrying review scores is refused rather than rendered.
 The scores are not published and are not in the record; a served record that had
 them would mean something upstream had gone wrong, and displaying it would be

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -641,6 +641,19 @@ class Handler(SimpleHTTPRequestHandler):
 <title>Hostile render fixture</title>
 <style>html, body {{ height: auto; overflow: auto; }} body {{ margin: 0; }}
 .theorem {{ padding: 1rem; }} .theorem-lines {{ height: 70rem; }}</style>
+<style id="palomar-declaration-style">
+/* The two colours a real bundle's palette binds for the frame's own canvas.
+   PalomarSubmission injects the whole palette; only these reach a browser
+   here, because what this fixture is for is the boundary: the frame reads
+   prefers-color-scheme for itself, and has to land on the paper the page
+   around it is drawn on. If PalomarWeb's --paper moves and this does not,
+   the frame is a rectangle of the wrong colour and the spec says so. */
+:root {{ color-scheme: light dark; --palomar-paper: #ffffff; --palomar-ink: #24292e; }}
+@media (prefers-color-scheme: dark) {{
+  :root {{ --palomar-paper: #101216; --palomar-ink: #e8eaee; }}
+}}
+html, body {{ background: var(--palomar-paper); color: var(--palomar-ink); }}
+</style>
 <body><main><p class="docstring">The theorem doc-string.</p>
 <div class="theorem"><pre>theorem Example.theorem :</pre><div class="theorem-lines"></div>
 <pre id="theorem-end">  True := by trivial</pre></div>

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -85,6 +85,25 @@ test("the registry follows the browser's light and dark preference", async ({ pa
   await expect(page.locator(".filter.active")).toHaveCSS("background-color", "rgb(255, 255, 255)");
 });
 
+test("the render frame lands on the same paper as the page around it", async ({ page }) => {
+  // The framed render is a separate document on a separate origin, so the page
+  // cannot reach in and theme it, and does not try: the frame reads
+  // prefers-color-scheme itself. That only looks right if the two palettes
+  // agree, which is what is asserted on both sides of the boundary here.
+  const paper = { dark: "rgb(16, 18, 22)", light: "rgb(255, 255, 255)" };
+  await page.emulateMedia({ colorScheme: "dark" });
+  await page.goto(`/render.html?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`);
+  const frame = page.locator(".challenge-presentation iframe");
+  for (const scheme of ["dark", "light"]) {
+    await page.emulateMedia({ colorScheme: scheme });
+    await expect(page.locator("html")).toHaveCSS("background-color", paper[scheme]);
+    await expect(frame).toHaveCSS("background-color", paper[scheme]);
+    await expect(
+      page.frameLocator(".challenge-presentation iframe").locator("body"),
+    ).toHaveCSS("background-color", paper[scheme]);
+  }
+});
+
 test("about headings expose hoverable links that copy their section URL", async ({ context, page }) => {
   await context.grantPermissions(["clipboard-read", "clipboard-write"]);
   await page.goto("/about.html");


### PR DESCRIPTION
This PR asserts across the origin boundary that the framed Challenge render and
the page around it land on the same background in both light and dark mode.

The framed render reads `prefers-color-scheme` for itself, because the browser
that lays out the page lays out the frame too and answers the same query. That
only looks right while the two palettes agree, and nothing was checking that
they did. The render fixture now carries the canvas half of the palette
PalomarSubmission injects, and the spec reads the computed background on both
sides.

The README says why no theme is posted into the frame, so the next reader does
not go looking for a message that is deliberately not sent.

🤖 Prepared with Claude Code