### PR TITLE
feat: preview a result's rendered statement on hover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,17 @@
   validation or route ownership. Entry and render content must consume that
   availability result progressively through `source-preservation.mjs`; an
   ancillary health request must never delay a verified record or render;
+  `assets/statement-preview.mjs` owns the listing grids' hover preview: pointer
+  intent and its delays, panel placement and lifetime, and resolving a card to
+  its rendering from either a whole record or the bounded companion document.
+  It consumes the confined artifact URL and the disposable sandboxed frame from
+  their owners and must not acquire its own; `challenge-presentation.mjs` still
+  owns the frame, and a surface that mounts and discards frames must dispose
+  them, because the height listener is on `window` rather than on the frame.
+  The preview is deliberately pointer-only and deliberately does not repeat the
+  entry page's render-metadata correspondence check; it is a preview of an
+  immutable artifact at a content address, and the entry page remains where a
+  rendering is tied to its accepted record.
   `assets/app.js` owns remaining page composition and controller wiring. Do not
   duplicate registry-document validation, source resolution, or route
   orchestration across those modules; the route module still rejects malformed

--- a/README.md
+++ b/README.md
@@ -182,6 +182,15 @@ by PalomarSubmission's `render_challenge.py`. Renders published before that
 palette existed are immutable and stay light, because a bundle's bytes are what
 its recorded hash is of.
 
+Resting the pointer on a result's title in the registry listing or in search
+results raises the same rendering in the same kind of frame, clamped between 120
+and 420 pixels, so the formal statement can be read without leaving the list.
+The preview is pointer-only: it is not raised by a keyboard or on a touch
+screen, where the card's own links remain the way to the statement. It frames
+the immutable artifact at its published content address and does not repeat the
+entry page's check that the render's declarations match the accepted record, so
+the entry page remains the place a rendering is tied to its entry.
+
 A record that arrives carrying review scores is refused rather than rendered.
 The scores are not published and are not in the record; a served record that had
 them would mean something upstream had gone wrong, and displaying it would be

--- a/assets/app.js
+++ b/assets/app.js
@@ -24,6 +24,7 @@ import { createChallengePresentation } from "./challenge-presentation.mjs";
 import { createEntryHistoryPresentation } from "./entry-history-presentation.mjs";
 import { createFormalizationPresentation } from "./formalization-presentation.mjs";
 import { createRegistryLoader } from "./registry-loading.mjs";
+import { createStatementPreview } from "./statement-preview.mjs";
 import { renderSubjectPage } from "./subject-pages.mjs";
 import {
   bindSourceControl,
@@ -79,6 +80,7 @@ const {
   fetchJson,
   loadAvailabilityBounded,
   loadRecent,
+  loadRecentRenders,
   loadEntry,
   loadSubjectHead,
   loadSubjectYear,
@@ -90,6 +92,14 @@ const {
 });
 
 const searchRegistry = createRegistrySearch(fetchJson);
+
+const statementPreview = createStatementPreview({
+  document,
+  window,
+  dataSource,
+  loadRecentRenders,
+  warn: (message) => console.warn(message),
+});
 
 function authorNames(entry) {
   return entry.authors.map((author) => author.name).join(", ");
@@ -300,7 +310,12 @@ function entryCard(
   );
   top.append(identity, trustBadge(entry));
   const title = el("h3");
-  title.append(internalLink(entry.title, localPageUrl("entry.html", entry)));
+  const titleLink = internalLink(entry.title, localPageUrl("entry.html", entry));
+  // The card is built from a landing row on one grid and from a whole
+  // validated record on the other. The preview is told which it has rather
+  // than left to work it out from what is missing.
+  statementPreview.register(titleLink, entry);
+  title.append(titleLink);
   const abstract = el("p", "card-abstract", entry.abstract);
   const meta = el("div", "card-meta");
   const authors = el("div");
@@ -361,6 +376,10 @@ function setLandingStatusHidden(hidden) {
 
 function setLandingSuppressed(suppressed) {
   landingSuppressed = suppressed;
+  // A panel outlives the card it was raised from unless something says so:
+  // it is over the page, not in the grid, and hiding the grid does not reach
+  // it. The same goes for the redraws below.
+  statementPreview.close();
   document.body.classList.toggle("registry-searching", suppressed);
   const toolbar = document.querySelector(".toolbar");
   const status = document.querySelector("#status");
@@ -558,6 +577,7 @@ let searchGeneration = 0;
 let activeSearchController = null;
 
 function renderSearchCards(results, entries) {
+  statementPreview.close();
   const cards = entries.map((entry) => entryCard(entry));
   results.replaceChildren(...cards);
   return cards;
@@ -1492,6 +1512,10 @@ function renderExactTombstone(tombstone, content) {
 }
 
 if (document.body.dataset.page === "index") {
+  // Bound to the containers, not to the cards, because both grids replace
+  // their children whenever a query or a filter changes.
+  statementPreview.watch(document.querySelector("#entry-grid"));
+  statementPreview.watch(document.querySelector("#search-results"));
   // A linked search is its own view. Avoid fetching and exposing a hidden
   // recent listing until the query is cleared; then load it exactly once.
   const hasInitialSearch = wireSearch();

--- a/assets/challenge-presentation.mjs
+++ b/assets/challenge-presentation.mjs
@@ -46,6 +46,65 @@ export function validateChallengeMetadata(entry, metadata) {
 }
 
 /**
+ * Mount one Verso rendering, sandboxed, and size it to what it reports.
+ *
+ * The rendering runs with scripts and without same-origin privilege, so it can
+ * neither read this document nor be read by it, and the one thing it is allowed
+ * to say arrives as a message: how tall it turned out. That message is checked
+ * to have come from this frame and to be a plausible height before it moves
+ * anything.
+ *
+ * `dispose` exists because that listener is on `window`, not on the frame. One
+ * frame kept for a page's lifetime can leave it; a surface that mounts a frame
+ * and throws it away again cannot, or every rendering a reader passed over
+ * stays subscribed for as long as the page is open.
+ */
+export function createRenderFrames({ document, window }) {
+  return function createRenderFrame({
+    src,
+    title,
+    lazy = false,
+    minHeight = 160,
+    maxHeight = 672,
+    onHeight = () => {},
+  }) {
+    const frame = document.createElement("iframe");
+    frame.className = "challenge-frame";
+    frame.src = safeDataUrl(src, window.location.href).href;
+    frame.title = title;
+    if (lazy) frame.loading = "lazy";
+    frame.referrerPolicy = "no-referrer";
+    frame.setAttribute("sandbox", "allow-scripts");
+    frame.setAttribute("scrolling", "auto");
+    const onMessage = (event) => {
+      if (
+        !frame.contentWindow ||
+        event.source !== frame.contentWindow ||
+        event.data?.type !== "palomar-render-height"
+      ) {
+        return;
+      }
+      const height = event.data.height;
+      if (!Number.isSafeInteger(height) || height <= 0) return;
+      frame.style.height = `${Math.max(minHeight, Math.min(maxHeight, height + 2))}px`;
+      frame.dataset.heightAdjusted = "true";
+      // The height arrives after the frame is in the document, so anything
+      // that positioned itself around the frame guessed. This is where it
+      // finds out. An entry page lays out in flow and ignores it.
+      onHeight();
+    };
+    window.addEventListener("message", onMessage);
+    return {
+      frame,
+      dispose() {
+        window.removeEventListener("message", onMessage);
+        frame.remove();
+      },
+    };
+  };
+}
+
+/**
  * Bind the named-declarations presentation to its browser and data adapters.
  *
  * Registry validation, source resolution, URL confinement, and inline policy
@@ -53,6 +112,8 @@ export function validateChallengeMetadata(entry, metadata) {
  * artifact's correspondence to an entry and the DOM states used to present it.
  */
 export function createChallengePresentation({ fetchJson, document, window, localPageUrl }) {
+  const createRenderFrame = createRenderFrames({ document, window });
+
   function el(tag, className, text) {
     const node = document.createElement(tag);
     if (className) node.className = className;
@@ -83,30 +144,13 @@ export function createChallengePresentation({ fetchJson, document, window, local
   }
 
   function challengeFrame(entry, renderBase) {
-    const frame = el("iframe", "challenge-frame");
-    frame.src = safeDataUrl(
-      challengeArtifactUrl(entry, renderBase).href,
-      window.location.href,
-    ).href;
-    frame.title = `Named compared declarations for ${entry.id} version ${entry.version}`;
-    frame.loading = "lazy";
-    frame.referrerPolicy = "no-referrer";
-    frame.setAttribute("sandbox", "allow-scripts");
-    frame.setAttribute("scrolling", "auto");
-    window.addEventListener("message", (event) => {
-      if (
-        !frame.contentWindow ||
-        event.source !== frame.contentWindow ||
-        event.data?.type !== "palomar-render-height"
-      ) {
-        return;
-      }
-      const height = event.data.height;
-      if (!Number.isSafeInteger(height) || height <= 0) return;
-      frame.style.height = `${Math.max(160, Math.min(672, height + 2))}px`;
-      frame.dataset.heightAdjusted = "true";
-    });
-    return frame;
+    // An entry page mounts one of these and keeps it for the page's lifetime,
+    // so it never disposes. A surface that mounts and discards them has to.
+    return createRenderFrame({
+      src: challengeArtifactUrl(entry, renderBase).href,
+      title: `Named compared declarations for ${entry.id} version ${entry.version}`,
+      lazy: true,
+    }).frame;
   }
 
   function metadataPanel(metadata) {

--- a/assets/registry-loading.mjs
+++ b/assets/registry-loading.mjs
@@ -2,6 +2,7 @@ import { loadSettledBounded } from "./loading.mjs";
 import {
   databaseBaseFor,
   entryRecordUrl,
+  recentRendersUrl,
   recentUrl,
   selectAvailabilityUrl,
   selectDatabaseUrl,
@@ -13,6 +14,7 @@ import {
   validateAvailability,
   validateEntry,
   validateRecent,
+  validateRecentRenders,
   validateSubjectHead,
   validateSubjectPage,
   validateSubjectYear,
@@ -136,6 +138,30 @@ export function createRegistryLoader({
     );
   }
 
+  // One read per page however many previews are asked for, and none at all if
+  // none is. The same bargain as the availability manifest: share a successful
+  // read, but never let one temporary failure become this page's answer for the
+  // rest of its lifetime. An absent document is a stable absence — a release
+  // that has not published one yet — and previews stay off until a reload.
+  const renderLoads = new Map();
+  function loadRecentRenders(databaseBase) {
+    const url = recentRendersUrl(databaseBase);
+    const key = url.href;
+    if (!renderLoads.has(key)) {
+      const loading = fetchJson(url)
+        .then((document) => validateRecentRenders(document))
+        .catch((error) => {
+          if (error?.status !== 404) {
+            renderLoads.delete(key);
+            warn(`Render previews are unavailable: ${error?.message || String(error)}`);
+          }
+          return null;
+        });
+      renderLoads.set(key, loading);
+    }
+    return renderLoads.get(key);
+  }
+
   async function loadEntry(id, requestedVersion) {
     const { databaseBase, renderBase, availabilityUrl } = dataSource();
     // The versions of this one result, not the whole registry. Reading a
@@ -192,6 +218,7 @@ export function createRegistryLoader({
     fetchJson,
     loadAvailabilityBounded,
     loadRecent,
+    loadRecentRenders,
     loadEntry,
     loadSubjectHead,
     loadSubjectYear,

--- a/assets/rendering.js
+++ b/assets/rendering.js
@@ -1,6 +1,10 @@
 export const INLINE_CHALLENGE_MAX_LINES = 100;
 export const INLINE_CHALLENGE_MAX_BYTES = 32 * 1024;
 
+// A constant of the render format rather than a field to read. A record still
+// declares it, and is refused below if it declares anything else.
+const CHALLENGE_ENTRYPOINT = "Challenge/index.html";
+
 const ID = /^PALOMAR-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6}$/;
 const SHA = /^[0-9a-f]{40}$/;
 const SHA256 = /^[0-9a-f]{64}$/;
@@ -55,6 +59,33 @@ export function challengeSourceUrl(entry, repositoryOverride = null) {
   return pinnedRepositoryFileUrl(selectedRepository, commit, challengePath).href;
 }
 
+/**
+ * Where one result's Verso rendering is served, from its content address.
+ *
+ * The path a record carries is derivable from exactly these three, and the
+ * record's own `artifact_path` is checked against the derivation rather than
+ * followed. So this is where the derivation lives, and both the record below
+ * and the landing page's bounded companion document resolve through it: two
+ * routes to the same rendering that agreed by inspection would eventually stop
+ * agreeing.
+ */
+export function renderArtifactUrl(id, version, treeHash, renderBase) {
+  if (!ID.test(id || "") || !Number.isInteger(version) || version < 1) {
+    throw new Error("render target has an invalid Palomar identifier or version");
+  }
+  if (!SHA256.test(treeHash || "")) {
+    throw new Error("render target has an invalid artifact tree hash");
+  }
+  const base = new URL(renderBase);
+  if (!['http:', 'https:'].includes(base.protocol)) {
+    throw new Error("Challenge render base must use HTTP or HTTPS");
+  }
+  return new URL(
+    `renders/${id}-v${version}/${treeHash}/${CHALLENGE_ENTRYPOINT}`,
+    base,
+  );
+}
+
 export function challengeArtifactUrl(entry, renderBase) {
   const id = entry?.id;
   const version = entry?.version;
@@ -66,17 +97,13 @@ export function challengeArtifactUrl(entry, renderBase) {
   const expectedPath = `renders/${id}-v${version}/${treeHash}/`;
   if (
     render?.format !== "verso-html" ||
-    render?.entrypoint !== "Challenge/index.html" ||
+    render?.entrypoint !== CHALLENGE_ENTRYPOINT ||
     !SHA256.test(treeHash || "") ||
     render?.artifact_path !== expectedPath
   ) {
     throw new Error("entry has invalid Challenge render metadata");
   }
-  const base = new URL(renderBase);
-  if (!['http:', 'https:'].includes(base.protocol)) {
-    throw new Error("Challenge render base must use HTTP or HTTPS");
-  }
-  return new URL(`${expectedPath}${render.entrypoint}`, base);
+  return renderArtifactUrl(id, version, treeHash, renderBase);
 }
 
 export function challengeMetadataUrl(entry, renderBase) {

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -71,6 +71,7 @@ export const AVAILABILITY_MAX_CLOCK_SKEW_MS = 5 * 60 * 1000;
 // raw lookalikes instead of falling back to repeated array scans.
 const availabilityIndexes = new WeakMap();
 const validatedSourceRecords = new WeakMap();
+const recentRenderIndexes = new WeakMap();
 
 function fail(message) {
   throw new Error(`invalid registry data: ${message}`);
@@ -282,6 +283,15 @@ export function recentUrl(databaseBase) {
   return expected;
 }
 
+export function recentRendersUrl(databaseBase) {
+  const base = new URL(databaseBase);
+  const expected = new URL("recent-renders.json", base);
+  if (expected.origin !== base.origin) {
+    fail("recent renders path escaped the database origin");
+  }
+  return expected;
+}
+
 /**
  * What is new, from `recent.json`.
  *
@@ -431,6 +441,68 @@ export function validateRecent(value) {
     validatedSourceRecords.set(receipt.record, receipt);
   }
   return document;
+}
+
+/**
+ * The content address of each listed result's rendering, from
+ * `recent-renders.json`.
+ *
+ * A landing row is the card and nothing else, so it cannot say where the
+ * result's rendering is served. This document says, for exactly the results on
+ * that page, and the landing page reads it only when a reader asks to see one.
+ *
+ * It carries the tree hash alone. The path is derivable from the identifier,
+ * the version and the hash, and the format and entrypoint are constants
+ * `renderArtifactUrl` applies rather than fields to be told, so a row that
+ * carried them would be a row that could disagree with them.
+ *
+ * Rows strictly increase by identifier, which is distinctness and a canonical
+ * order in one rule. One row per result, as on the page this accompanies, so a
+ * repeated identifier means this is not the projection it says it is, and
+ * reading it as if it were would offer a reader one result's statement under
+ * another result's name.
+ */
+export function validateRecentRenders(value) {
+  const document = exactObject(value, ["schema_version", "renders"], "recent renders");
+  if (document.schema_version !== RECENT_SCHEMA_VERSION) {
+    fail(`unsupported recent renders schema_version ${String(document.schema_version)}`);
+  }
+  const renders = array(document.renders, "recent renders rows");
+  if (renders.length > RECENT_ITEMS) fail("recent renders carries more rows than it may");
+  const index = new Map();
+  let previous = "";
+  for (const [position, value] of renders.entries()) {
+    const field = `recent renders rows[${position}]`;
+    const item = exactObject(value, ["artifact_tree_sha256", "id", "version"], field);
+    const id = string(item.id, `${field}.id`);
+    if (!ID_RE.test(id)) fail(`${field}.id is malformed`);
+    if (id <= previous) fail("recent renders rows are not in increasing identifier order");
+    previous = id;
+    const version = integer(item.version, `${field}.version`);
+    if (version < 1) fail(`${field}.version is not a version`);
+    const treeHash = string(item.artifact_tree_sha256, `${field}.artifact_tree_sha256`);
+    if (!SHA256_RE.test(treeHash)) fail(`${field}.artifact_tree_sha256 is malformed`);
+    index.set(id, Object.freeze({ id, version, artifact_tree_sha256: treeHash }));
+  }
+  // Captured by value while the document is accepted, so a lookup answers from
+  // what was checked rather than from a public row that has since been written
+  // over. Set only after the whole projection succeeds: a reference to an early
+  // row of a later-rejected document must not become presentation data.
+  recentRenderIndexes.set(document, index);
+  return document;
+}
+
+/**
+ * The validated render row for one result, or `null` if this page has none.
+ *
+ * Refuses a raw lookalike rather than scanning it, for the same reason the
+ * availability lookup does: an object that merely has the right keys has not
+ * been through the bounds above.
+ */
+export function recentRenderRow(document, id) {
+  const index = recentRenderIndexes.get(document);
+  if (!index) fail("recent renders document was not validated");
+  return index.get(id) || null;
 }
 
 function availabilityTimestamp(value) {

--- a/assets/statement-preview.mjs
+++ b/assets/statement-preview.mjs
@@ -1,0 +1,263 @@
+import { createRenderFrames } from "./challenge-presentation.mjs";
+import { challengeArtifactUrl, renderArtifactUrl } from "./rendering.js";
+import { recentRenderRow } from "./security.mjs";
+
+// Long enough that crossing a grid of cards on the way somewhere else opens
+// nothing, short enough that stopping on a title feels like the answer was
+// already there.
+const OPEN_DELAY_MS = 350;
+// The panel is not under the pointer when it leaves the title, and on the way
+// to it the pointer is over neither. Closing on that instant would make the
+// panel unreachable, which is the whole of this delay.
+const CLOSE_DELAY_MS = 200;
+const MIN_HEIGHT = 120;
+const MAX_HEIGHT = 420;
+const GAP = 8;
+const MARGIN = 8;
+
+/**
+ * A reader's preview of the formal statement, raised by resting on a title.
+ *
+ * The registry lists results by title and abstract, which says what was proved
+ * about what but not what was actually stated. That is in the Verso rendering,
+ * one page further in, and a reader comparing a handful of results was paying a
+ * navigation each way to see it. This puts it under the pointer.
+ *
+ * It is a preview and not the record. The entry page remains where a rendering
+ * is presented with the pinned source, the dependency surface, and the checks
+ * tying it to the accepted entry; this frames the same immutable artifact from
+ * the same content address and says nothing further about it.
+ *
+ * Hover is the only trigger, which is a decision with consequences worth
+ * naming: it reaches neither a keyboard nor a touch screen. Both already reach
+ * the statement, by the card's own links, and nothing here changes that. What
+ * this must not do is degrade those; every failure below closes quietly and
+ * leaves the card exactly as it was.
+ */
+export function createStatementPreview({
+  document,
+  window,
+  dataSource,
+  loadRecentRenders,
+  warn = () => {},
+  openDelayMs = OPEN_DELAY_MS,
+  closeDelayMs = CLOSE_DELAY_MS,
+}) {
+  const sources = new WeakMap();
+  const createRenderFrame = createRenderFrames({ document, window });
+  const hoverable = window.matchMedia?.("(hover: hover)")?.matches ?? false;
+
+  let panel = null;
+  let mounted = null;
+  let openTimer = null;
+  let closeTimer = null;
+  let pending = null;
+  let anchored = null;
+  // Rests supersede one another. A preview whose reads finish after the reader
+  // has moved on belongs to nobody, and showing it would put one result's
+  // statement under the pointer while it rests on another's title.
+  let generation = 0;
+
+  function cancelOpen() {
+    window.clearTimeout(openTimer);
+    openTimer = null;
+    pending = null;
+  }
+
+  /** Take the panel down. Not a supersession, so in-flight reads still count. */
+  function unmount() {
+    window.clearTimeout(closeTimer);
+    closeTimer = null;
+    if (mounted) {
+      mounted.dispose();
+      mounted = null;
+    }
+    if (panel) {
+      panel.remove();
+      panel = null;
+    }
+    anchored = null;
+  }
+
+  function dismiss() {
+    generation += 1;
+    unmount();
+  }
+
+  function close() {
+    cancelOpen();
+    dismiss();
+  }
+
+  function place(node, box) {
+    const room = window.innerHeight;
+    const height = node.offsetHeight || MAX_HEIGHT;
+    // The roomier side, and never over the title: a panel that covered what
+    // raised it would take the pointer off the title and close itself.
+    const below = room - box.bottom - GAP;
+    const top = below >= height || below >= box.top - GAP
+      ? box.bottom + GAP
+      : Math.max(MARGIN, box.top - GAP - height);
+    const width = node.offsetWidth || 0;
+    const left = Math.max(
+      MARGIN,
+      Math.min(box.left, window.innerWidth - width - MARGIN),
+    );
+    node.style.top = `${top}px`;
+    node.style.left = `${left}px`;
+  }
+
+  function open(link, target) {
+    const box = link.getBoundingClientRect();
+    panel = document.createElement("div");
+    const current = panel;
+    panel.className = "statement-preview";
+    panel.setAttribute("role", "presentation");
+    // The pointer is inside the frame for most of the panel's life, and a
+    // cross-origin frame reports none of that to this document. Entering the
+    // frame does not leave the panel, so these two are the whole of it.
+    panel.addEventListener("mouseenter", () => window.clearTimeout(closeTimer));
+    panel.addEventListener("mouseleave", scheduleClose);
+    mounted = createRenderFrame({
+      src: target.href,
+      title: `Formal statement of ${target.id} version ${target.version}`,
+      minHeight: MIN_HEIGHT,
+      maxHeight: MAX_HEIGHT,
+      // Placed once on the guessed height and again on the real one. A panel
+      // put above a title on a guess that was short would otherwise grow back
+      // down over the title it was raised from.
+      onHeight: () => {
+        if (panel === current) place(panel, link.getBoundingClientRect());
+      },
+    });
+    panel.append(mounted.frame);
+    document.body.append(panel);
+    place(panel, box);
+  }
+
+  async function resolve(link) {
+    const source = sources.get(link);
+    if (!source) return null;
+    const { renderBase, databaseBase } = dataSource();
+    // A search result is a whole validated record and says where its rendering
+    // is. A landing row is the card and nothing else, so its hash comes from
+    // the bounded companion document. An explicit test, not a failed attempt:
+    // the two are different documents, not one document sometimes short of a
+    // field.
+    if (source.challenge_render) {
+      return {
+        id: source.id,
+        version: source.version,
+        href: challengeArtifactUrl(source, renderBase).href,
+      };
+    }
+    const renders = await loadRecentRenders(databaseBase);
+    if (!renders) return null;
+    const row = recentRenderRow(renders, source.id);
+    // The page and this document are built from one selection, so a row that
+    // is not here, or is here for another version, is a reader looking at a
+    // page newer than the hashes beside it. Say nothing rather than frame the
+    // wrong version of a result.
+    if (!row || row.version !== source.version) return null;
+    return {
+      id: row.id,
+      version: row.version,
+      href: renderArtifactUrl(
+        row.id,
+        row.version,
+        row.artifact_tree_sha256,
+        renderBase,
+      ).href,
+    };
+  }
+
+  function scheduleClose() {
+    window.clearTimeout(closeTimer);
+    closeTimer = window.setTimeout(dismiss, closeDelayMs);
+  }
+
+  function scheduleOpen(link) {
+    // Back on the title of the panel already up: cancel its dismissal, and any
+    // open scheduled for whatever the pointer passed over on the way back.
+    if (anchored === link) {
+      cancelOpen();
+      window.clearTimeout(closeTimer);
+      closeTimer = null;
+      return;
+    }
+    if (pending === link) return;
+    cancelOpen();
+    pending = link;
+    openTimer = window.setTimeout(async () => {
+      openTimer = null;
+      pending = null;
+      const mine = (generation += 1);
+      let target = null;
+      try {
+        target = await resolve(link);
+      } catch (error) {
+        warn(`A statement preview could not be resolved: ${error.message}`);
+      }
+      // Nothing to show, the reader has moved on, or the grid has been redrawn
+      // under this card. Any of the three leaves whatever is up alone: it is
+      // the panel of a rest that is still current.
+      if (!target || mine !== generation || !link.isConnected) return;
+      unmount();
+      anchored = link;
+      try {
+        open(link, target);
+      } catch (error) {
+        warn(`A statement preview could not be shown: ${error.message}`);
+        close();
+      }
+    }, openDelayMs);
+  }
+
+  function titleLink(node) {
+    const link = node?.closest?.("h3 > a");
+    return link && sources.has(link) ? link : null;
+  }
+
+  function onOver(event) {
+    const link = titleLink(event.target);
+    if (link) scheduleOpen(link);
+  }
+
+  function onOut(event) {
+    const link = titleLink(event.target);
+    if (!link) return;
+    // `mouseout` also fires moving between the link's own children.
+    if (link.contains(event.relatedTarget)) return;
+    cancelOpen();
+    // The panel that is up gets the delay, so the pointer can cross the gap
+    // into it. A rest that never became one has nothing to cross to.
+    if (anchored) scheduleClose();
+    else dismiss();
+  }
+
+  const bound = [];
+  function watch(grid) {
+    if (!hoverable || !grid || bound.includes(grid)) return;
+    // Delegated, because the grids replace their children on every search and
+    // filter. `mouseenter` does not bubble, so this is the pair that can be.
+    grid.addEventListener("mouseover", onOver);
+    grid.addEventListener("mouseout", onOut);
+    bound.push(grid);
+  }
+
+  return {
+    /** Bind a card's title to the entry or landing row it was built from. */
+    register(link, source) {
+      if (hoverable && link && source) sources.set(link, source);
+    },
+    watch,
+    close,
+    destroy() {
+      close();
+      for (const grid of bound.splice(0)) {
+        grid.removeEventListener("mouseover", onOver);
+        grid.removeEventListener("mouseout", onOut);
+      }
+    },
+  };
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -904,6 +904,36 @@ footer {
   background: var(--paper);
 }
 
+/* Raised by resting on a card title, over the grid rather than in it, so the
+   listing does not reflow under the pointer that asked for this. */
+.statement-preview {
+  position: fixed;
+  z-index: 20;
+  /* Wide, because a Lean statement is rendered with `white-space: pre` and does
+     not wrap. The frame still scrolls sideways for the ones that need it. */
+  width: min(48rem, calc(100vw - 1rem));
+  padding: .3rem;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 25%);
+}
+
+.statement-preview .challenge-frame {
+  height: 12rem;
+  min-height: 7.5rem;
+  max-height: 26rem;
+  border: 0;
+}
+
+@media (hover: none) {
+  /* Never raised without a pointer that can rest. Belt to the media query the
+     controller itself asks, so a panel cannot be left over a touch reader by a
+     browser that answers the two differently. */
+  .statement-preview {
+    display: none;
+  }
+}
+
 .acceptance-callout {
   display: flex;
   gap: .8rem;

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -26,6 +26,7 @@ const browserModuleFiles = [
   "searching.mjs",
   "security.mjs",
   "source-preservation.mjs",
+  "statement-preview.mjs",
   "subject-pages.mjs",
 ];
 const browserModulePaths = new Set(browserModuleFiles.map((file) => `/assets/${file}`));

--- a/scripts/check-published.mjs
+++ b/scripts/check-published.mjs
@@ -22,6 +22,7 @@ import {
   validateBrowseYear,
   validateEntry,
   validateRecent,
+  validateRecentRenders,
   validateSubjectHead,
   validateVersions,
   versionsUrl,
@@ -64,7 +65,9 @@ export function publishState(html, expected) {
  * every row the producer advertises; they are not an independent proof that
  * the producer omitted nothing. `recent.json` is also checked against each
  * current history head and entry, because it is the landing page's separate
- * exact projection.
+ * exact projection, and `recent-renders.json` against both, because it and the
+ * page are one projection published as two documents and only a reader who
+ * hovers would otherwise discover they had drifted apart.
  */
 const PUBLIC_DATA_CONCURRENCY = 8;
 const PUBLIC_REQUEST_POLICY = Object.freeze({
@@ -136,6 +139,7 @@ const PUBLIC_VALIDATORS = {
   validateBrowseYear,
   validateEntry,
   validateRecent,
+  validateRecentRenders,
   validateSubjectHead,
   validateVersions,
 };
@@ -151,6 +155,9 @@ export async function publicDataState(
   try {
     const recent = validators.validateRecent(
       await fetchJson(new URL("recent.json", base), fetcher, policy),
+    );
+    const recentRenders = validators.validateRecentRenders(
+      await fetchJson(new URL("recent-renders.json", base), fetcher, policy),
     );
     const browse = validators.validateBrowseHead(
       await fetchJson(new URL("browse/index.json", base), fetcher, policy),
@@ -226,6 +233,7 @@ export async function publicDataState(
     );
     const entriesByPath = new Map(fetchedEntries);
     const historiesById = new Map(histories.map((history) => [history.id, history.entries]));
+    const rendersById = new Map(recentRenders.renders.map((row) => [row.id, row]));
     for (const summary of recent.entries) {
       const history = historiesById.get(summary.id);
       const current = history?.at(-1);
@@ -238,6 +246,21 @@ export async function publicDataState(
       if (!entry || summary.published_at !== entry.registered_at) {
         throw new Error(`recent row for ${summary.id} does not match its entry registered_at`);
       }
+      // The two are one projection published as two documents, so a page row
+      // without its hash, or with the hash of another version or of a render
+      // the record does not claim, is drift between them. A reader who hovers
+      // is the one who finds out, which is exactly what this check exists to
+      // do first.
+      const render = rendersById.get(summary.id);
+      if (!render || render.version !== summary.version) {
+        throw new Error(`recent row for ${summary.id} has no render hash of its version`);
+      }
+      if (render.artifact_tree_sha256 !== entry.challenge_render.artifact_tree_sha256) {
+        throw new Error(`recent render hash for ${summary.id} is not its entry's`);
+      }
+    }
+    if (recentRenders.renders.length !== recent.entries.length) {
+      throw new Error("recent renders names results the landing page does not");
     }
     // The subject pages the website now links every classification code to.
     // Bounded by the classification vocabulary of the newest rows rather than

--- a/tests/check-published.test.js
+++ b/tests/check-published.test.js
@@ -13,6 +13,7 @@ const page = (version) =>
 
 const registryValidators = {
   validateRecent: (value) => value,
+  validateRecentRenders: (value) => value,
   validateBrowseHead: (value) => value,
   validateBrowseYear: (value) => value,
   validateBrowsePage: (value) => value,
@@ -63,17 +64,26 @@ function oneEntryRegistry() {
   };
   const browsePage = { entries: [row] };
   const history = { id, entries: [row] };
-  const entry = { id, registered_at: registeredAt, classification: CLASSIFICATION };
+  const digest = "a".repeat(64);
+  const entry = {
+    id,
+    registered_at: registeredAt,
+    classification: CLASSIFICATION,
+    challenge_render: { artifact_tree_sha256: digest },
+  };
+  const renders = { renders: [{ id, version: 1, artifact_tree_sha256: digest }] };
   return {
     entry,
     head,
     history,
     page: browsePage,
     recent,
+    renders,
     row,
     year,
     responses: new Map([
       ["https://data.example/recent.json", { entries: [recent] }],
+      ["https://data.example/recent-renders.json", renders],
       ["https://data.example/browse/index.json", head],
       ["https://data.example/browse/2026.json", year],
       ["https://data.example/browse/2026-08-08/1.json", browsePage],
@@ -176,11 +186,16 @@ test("live-data health traverses browse and history to validate every public per
       id: "one-v1",
       registered_at: "2026-08-08T11:00:00Z",
       classification: CLASSIFICATION,
+      challenge_render: { artifact_tree_sha256: "b".repeat(64) },
     }],
     ["https://data.example/entries/PALOMAR-2026-08-08-000001-v2.json", {
       id: "one-v2",
       registered_at: registeredAt,
       classification: CLASSIFICATION,
+      challenge_render: { artifact_tree_sha256: "a".repeat(64) },
+    }],
+    ["https://data.example/recent-renders.json", {
+      renders: [{ id: first.id, version: 2, artifact_tree_sha256: "a".repeat(64) }],
     }],
     ["https://data.example/subjects/arxiv/math.CO.json", subjectHead("arxiv", "math.CO", [second])],
     ["https://data.example/subjects/msc/05C10.json", subjectHead("msc", "05C10", [second])],
@@ -196,6 +211,10 @@ test("live-data health traverses browse and history to validate every public per
   const state = await publicDataState("https://data.example", fetcher, {
     validateRecent(page) {
       validated.push("recent");
+      return page;
+    },
+    validateRecentRenders(page) {
+      validated.push("recent-renders");
       return page;
     },
     validateBrowseHead(page) {
@@ -226,6 +245,7 @@ test("live-data health traverses browse and history to validate every public per
   assert.equal(state.healthy, true);
   assert.deepEqual(calls, [
     "https://data.example/recent.json",
+    "https://data.example/recent-renders.json",
     "https://data.example/browse/index.json",
     "https://data.example/browse/2026.json",
     "https://data.example/browse/2026-08-08/1.json",
@@ -237,6 +257,7 @@ test("live-data health traverses browse and history to validate every public per
   ]);
   assert.deepEqual(validated, [
     "recent",
+    "recent-renders",
     "browse-head",
     "year:2026",
     "page:2026-08-08:1",
@@ -308,6 +329,7 @@ test("live-data health fails closed when a version index omits or rewrites brows
   };
   const responses = new Map([
     ["https://data.example/recent.json", { entries: [] }],
+    ["https://data.example/recent-renders.json", { renders: [] }],
     ["https://data.example/browse/index.json", {
       results: 1,
       versions: 1,
@@ -331,6 +353,7 @@ test("live-data health fails closed when a version index omits or rewrites brows
   ]);
   const identityValidators = {
     validateRecent: (value) => value,
+    validateRecentRenders: (value) => value,
     validateBrowseHead: (value) => value,
     validateBrowseYear: (value) => value,
     validateBrowsePage: (value) => value,
@@ -468,6 +491,50 @@ test("live-data health rejects a recent row absent from advertised history", asy
 
   assert.equal(state.healthy, false);
   assert.match(state.reason, /recent row .* does not equal its current version history/);
+});
+
+test("live-data health rejects a render companion that has drifted from the page", async (t) => {
+  for (const [name, mutate, reason] of [
+    [
+      "naming no hash for a listed result",
+      (fixture) => { fixture.renders.renders = []; },
+      /has no render hash of its version/,
+    ],
+    [
+      "naming another version",
+      (fixture) => { fixture.renders.renders[0].version = 2; },
+      /has no render hash of its version/,
+    ],
+    [
+      "naming a render the record does not claim",
+      (fixture) => { fixture.renders.renders[0].artifact_tree_sha256 = "c".repeat(64); },
+      /is not its entry's/,
+    ],
+    [
+      "naming a result the page does not",
+      (fixture) => {
+        fixture.renders.renders.push({
+          id: "PALOMAR-2026-08-08-000002",
+          version: 1,
+          artifact_tree_sha256: "d".repeat(64),
+        });
+      },
+      /names results the landing page does not/,
+    ],
+  ]) {
+    await t.test(name, async () => {
+      const fixture = oneEntryRegistry();
+      mutate(fixture);
+      const state = await publicDataState(
+        "https://data.example",
+        responseFrom(fixture.responses),
+        registryValidators,
+      );
+
+      assert.equal(state.healthy, false);
+      assert.match(state.reason, reason);
+    });
+  }
 });
 
 test("live-data health checks recent publication time against the already fetched entry", async () => {

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -528,6 +528,31 @@ class Handler(SimpleHTTPRequestHandler):
                 return
             self.send_bytes(json.dumps(document).encode(), "application/json")
             return
+        # The render hashes of exactly the results on that page, which the
+        # landing page reads only when a reader asks to see one. Built from the
+        # same current selection, so the two cannot disagree here either.
+        if path == "/database/recent-renders.json":
+            current = {}
+            for item in ENTRIES.values():
+                previous = current.get(item["id"])
+                if previous is None or item["version"] > previous["version"]:
+                    current[item["id"]] = item
+            rows = [
+                {
+                    "id": item["id"],
+                    "version": item["version"],
+                    "artifact_tree_sha256": item["challenge_render"][
+                        "artifact_tree_sha256"
+                    ],
+                }
+                for item in current.values()
+            ]
+            rows.sort(key=lambda row: row["id"])
+            self.send_bytes(
+                json.dumps({"schema_version": 1, "renders": rows}).encode(),
+                "application/json",
+            )
+            return
         # The versions of one result, which is what an entry page reads instead
         # of the whole index.
         versions = re.fullmatch(

--- a/tests/registry-fixture.mjs
+++ b/tests/registry-fixture.mjs
@@ -63,6 +63,20 @@ export function recent(entries = [recentRow()], overrides = {}) {
   return { schema_version: 1, entries, ...overrides };
 }
 
+export function renderRow(overrides = {}) {
+  const record = entry();
+  return {
+    id: record.id,
+    version: record.version,
+    artifact_tree_sha256: record.challenge_render.artifact_tree_sha256,
+    ...overrides,
+  };
+}
+
+export function recentRenders(renders = [renderRow()], overrides = {}) {
+  return { schema_version: 1, renders, ...overrides };
+}
+
 export function availabilityEndpoint(overrides = {}) {
   return {
     status: "available",

--- a/tests/registry-loading.test.mjs
+++ b/tests/registry-loading.test.mjs
@@ -6,6 +6,7 @@ import {
   availabilityManifest,
   entry,
   recent,
+  recentRenders,
   secondVersion,
   summary,
 } from "./registry-fixture.mjs";
@@ -177,6 +178,54 @@ test("the recent projection is fetched from the selected database and validated"
   );
   assert.deepEqual(loaded, document);
   assert.deepEqual(calls.map(({ url }) => url.pathname), ["/recent.json"]);
+});
+
+test("the render companion is read once a page and caches only a stable absence", async () => {
+  const database = new URL("https://data.palomar-registry.org/");
+  const document = recentRenders();
+  const calls = [];
+  const shared = createRegistryLoader({
+    fetch: routedFetch(new Map([["/recent-renders.json", jsonResponse(document)]]), calls),
+    location: productionLocation("index.html"),
+  });
+
+  const [first, second] = await Promise.all([
+    shared.loadRecentRenders(database),
+    shared.loadRecentRenders(database),
+  ]);
+  assert.deepEqual(first, document);
+  assert.equal(second, first, "one read however many previews ask");
+  assert.deepEqual(await shared.loadRecentRenders(database), document);
+  assert.equal(calls.length, 1);
+
+  // A release that has not published one yet is this page's answer. A
+  // transport failure is not: previews resume when the next rest retries.
+  const absentCalls = [];
+  const absent = createRegistryLoader({
+    fetch: routedFetch(
+      new Map([["/recent-renders.json", jsonResponse(null, 404)]]),
+      absentCalls,
+    ),
+    location: productionLocation("index.html"),
+  });
+  assert.equal(await absent.loadRecentRenders(database), null);
+  assert.equal(await absent.loadRecentRenders(database), null);
+  assert.equal(absentCalls.length, 1);
+
+  const warnings = [];
+  const transientCalls = [];
+  const transient = createRegistryLoader({
+    fetch: routedFetch(
+      new Map([["/recent-renders.json", jsonResponse(null, 503, "Service Unavailable")]]),
+      transientCalls,
+    ),
+    location: productionLocation("index.html"),
+    warn: (message) => warnings.push(message),
+  });
+  assert.equal(await transient.loadRecentRenders(database), null);
+  assert.equal(await transient.loadRecentRenders(database), null);
+  assert.equal(transientCalls.length, 2);
+  assert.match(warnings.join("\n"), /Render previews are unavailable/);
 });
 
 test("an unversioned entry read resolves and validates the current immutable record", async () => {

--- a/tests/rendering.test.js
+++ b/tests/rendering.test.js
@@ -6,6 +6,7 @@ import {
   challengeMetadataUrl,
   challengeSourceUrl,
   isInlineChallenge,
+  renderArtifactUrl,
 } from "../assets/rendering.js";
 
 function entry(overrides = {}) {
@@ -62,6 +63,38 @@ test("artifact URL is derived only from the content-addressed registry fields", 
   const traversal = entry();
   traversal.challenge_render.artifact_path = "renders/../../attacker/";
   assert.throws(() => challengeArtifactUrl(traversal, "https://example.test/"), /invalid/);
+});
+
+test("a content address alone resolves to the same rendering a record does", () => {
+  const record = entry();
+  assert.equal(
+    renderArtifactUrl(
+      record.id,
+      record.version,
+      record.challenge_render.artifact_tree_sha256,
+      "https://data.palomar-registry.org/",
+    ).href,
+    challengeArtifactUrl(record, "https://data.palomar-registry.org/").href,
+  );
+});
+
+test("a content address is refused rather than encoded when it is not one", () => {
+  const base = "https://data.palomar-registry.org/";
+  const hash = "a".repeat(64);
+  for (const [id, version, treeHash, reason] of [
+    ["../../attacker", 1, hash, /identifier or version/],
+    ["PALOMAR-2026-07-29-000123", 0, hash, /identifier or version/],
+    ["PALOMAR-2026-07-29-000123", 1.5, hash, /identifier or version/],
+    ["PALOMAR-2026-07-29-000123", 1, "../attacker", /artifact tree hash/],
+    ["PALOMAR-2026-07-29-000123", 1, `${hash}/..`, /artifact tree hash/],
+    ["PALOMAR-2026-07-29-000123", 1, "A".repeat(64), /artifact tree hash/],
+  ]) {
+    assert.throws(() => renderArtifactUrl(id, version, treeHash, base), reason);
+  }
+  assert.throws(
+    () => renderArtifactUrl("PALOMAR-2026-07-29-000123", 1, hash, "javascript:alert(1)"),
+    /HTTP or HTTPS/,
+  );
 });
 
 test("artifact metadata URL stays inside the content-addressed bundle", () => {

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -13,7 +13,9 @@ import {
   availabilityRow,
   entry,
   recent,
+  recentRenders,
   recentRow,
+  renderRow,
   secondVersion,
   summary,
 } from "./registry-fixture.mjs";
@@ -40,6 +42,8 @@ import {
   selectDatabaseUrl,
   selectAvailabilityUrl,
   selectRenderBase,
+  recentRenderRow,
+  recentRendersUrl,
   recentUrl,
   tombstoneUrl,
   validateEntry,
@@ -55,6 +59,7 @@ import {
   validateSubjectPage,
   validateSubjectYear,
   validateRecent,
+  validateRecentRenders,
   validateTombstone,
   validateVersions,
   versionsUrl,
@@ -178,6 +183,10 @@ test("what is new is read from the database prefix and nowhere else", () => {
     recentUrl(databaseBaseFor("https://example.test/database/")).href,
     "https://example.test/database/recent.json",
   );
+  assert.equal(
+    recentRendersUrl(databaseBaseFor("https://example.test/database/")).href,
+    "https://example.test/database/recent-renders.json",
+  );
 });
 
 test("recent validation rejects unsupported, rejected, and malformed rows", () => {
@@ -215,6 +224,48 @@ test("recent validation accepts the Database-owned landing-card fixture", async 
 
 test("an empty recent registry is valid", () => {
   assert.deepEqual(validateRecent(recent([])).entries, []);
+});
+
+test("the render companion is one exact closed shape", () => {
+  assert.deepEqual(validateRecentRenders(recentRenders([])).renders, []);
+
+  for (const mutate of [
+    (document) => { document.entries = []; },
+    (document) => { document.schema_version = 2; },
+    (document) => { delete document.renders[0].version; },
+    (document) => { document.renders[0].artifact_path = "renders/"; },
+    (document) => { document.renders[0].id = "PALOMAR-2026-07-29-00012"; },
+    (document) => { document.renders[0].version = 0; },
+    (document) => { document.renders[0].version = 1.5; },
+    (document) => { document.renders[0].artifact_tree_sha256 = "a".repeat(63); },
+    (document) => { document.renders[0].artifact_tree_sha256 = "A".repeat(64); },
+    (document) => { document.renders = Array(201).fill(renderRow()); },
+  ]) {
+    const document = recentRenders();
+    mutate(document);
+    assert.throws(() => validateRecentRenders(document), /invalid registry data/);
+  }
+});
+
+test("the render companion names each result once, in one order", () => {
+  const first = renderRow();
+  const second = renderRow({ id: "PALOMAR-2026-07-29-000124" });
+
+  assert.ok(validateRecentRenders(recentRenders([first, second])));
+  assert.throws(
+    () => validateRecentRenders(recentRenders([second, first])),
+    /increasing identifier order/,
+  );
+  assert.throws(
+    () => validateRecentRenders(recentRenders([first, renderRow({ version: 2 })])),
+    /increasing identifier order/,
+  );
+});
+
+test("a rejected render companion leaves no row usable", () => {
+  const document = recentRenders([renderRow(), renderRow({ id: "nope" })]);
+  assert.throws(() => validateRecentRenders(document), /invalid registry data/);
+  assert.throws(() => recentRenderRow(document, renderRow().id), /was not validated/);
 });
 
 test("recent is one exact complete projection, not a legacy summary shape", () => {
@@ -917,10 +968,23 @@ test("user documentation names current examples and iframe height units", async 
     new URL("../assets/challenge-presentation.mjs", import.meta.url),
     "utf8",
   );
-  const bounds = /Math\.max\((\d+), Math\.min\((\d+),/.exec(presentation);
+  const bounds = /minHeight = (\d+),\s*\n\s*maxHeight = (\d+),/.exec(presentation);
   assert.notEqual(bounds, null, "iframe height policy must remain explicit");
   assert.match(readme, new RegExp(`clamped\\s+between ${bounds[1]} and ${bounds[2]} pixels`));
   assert.doesNotMatch(readme, /between 10rem and 42rem/);
+
+  // The preview overrides those defaults, so its own bounds are a second
+  // policy and are documented as one rather than left to be inferred.
+  const preview = await readFile(
+    new URL("../assets/statement-preview.mjs", import.meta.url),
+    "utf8",
+  );
+  const previewBounds = /MIN_HEIGHT = (\d+);\nconst MAX_HEIGHT = (\d+);/.exec(preview);
+  assert.notEqual(previewBounds, null, "preview height policy must remain explicit");
+  assert.match(
+    readme,
+    new RegExp(`clamped between ${previewBounds[1]}\\s+and ${previewBounds[2]} pixels`),
+  );
   assert.doesNotMatch(readme, /PALOMAR-2026-07-29-000001/);
 });
 

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -2169,3 +2169,103 @@ for (const scheme of ["light", "dark"]) {
     await readableTextOnly(page, `${scheme} entry`, 25);
   });
 }
+test("resting on a landing title raises the result's rendering over the listing", async ({ page }) => {
+  const asked = [];
+  page.on("request", (request) => asked.push(new URL(request.url()).pathname));
+  await page.goto(`/?database=${database}`);
+  const title = page.locator(".entry-card h3 > a").first();
+  const identifier = await page.locator(".entry-card .entry-id").first().textContent();
+  const versioned = /(PALOMAR-[0-9-]+) v([0-9]+)/.exec(identifier);
+
+  // Nothing is read for a listing nobody has rested on.
+  expect(asked).not.toContain("/database/recent-renders.json");
+
+  await title.hover();
+  const panel = page.locator(".statement-preview");
+  await expect(panel).toBeVisible();
+  const frame = panel.locator("iframe");
+  await expect(frame).toHaveAttribute("sandbox", "allow-scripts");
+  await expect(frame).toHaveAttribute("referrerpolicy", "no-referrer");
+  await expect(frame).toHaveAttribute(
+    "src",
+    `http://127.0.0.1:4173/database/renders/${versioned[1]}-v${versioned[2]}/${"a".repeat(64)}/Challenge/index.html`,
+  );
+  expect(asked).toContain("/database/recent-renders.json");
+  // The card is a landing row, so this must not have become a record read.
+  expect(asked.filter((path) => path.startsWith("/database/entries/"))).toEqual([]);
+
+  // The rendering runs, and is as unprivileged inside the panel as it is on an
+  // entry page.
+  const body = page.frameLocator(".statement-preview iframe").locator("body");
+  await expect(body).toHaveAttribute("data-script-ran", "true");
+  await expect(body).toHaveAttribute("data-top-access", "blocked");
+  await expect(page.locator("body")).not.toHaveAttribute("data-compromised", "true");
+
+  await page.mouse.move(5, 5);
+  await expect(panel).toHaveCount(0);
+});
+
+test("a search result previews from the record it already holds", async ({ page }) => {
+  await page.goto(`/?database=${database}`);
+  // Runs on the typing pause now, and the provisional cards it stands in are
+  // drawn like the verified ones, so wait for the spinner rather than counting.
+  await runSearch(page, "quasicoherent");
+  await expect(page.locator("#search-results .entry-card").first()).toBeVisible();
+
+  const asked = [];
+  page.on("request", (request) => asked.push(new URL(request.url()).pathname));
+  await page.locator("#search-results .entry-card h3 > a").first().hover();
+
+  await expect(page.locator(".statement-preview iframe")).toHaveAttribute(
+    "src",
+    /\/Challenge\/index\.html$/,
+  );
+  expect(asked).not.toContain("/database/recent-renders.json");
+});
+
+test("a preview survives the pointer crossing into it", async ({ page }) => {
+  await page.goto(`/?database=${database}`);
+  await page.locator(".entry-card h3 > a").first().hover();
+  const panel = page.locator(".statement-preview");
+  await expect(panel).toBeVisible();
+
+  const box = await panel.boundingBox();
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.waitForTimeout(500);
+
+  await expect(panel).toBeVisible();
+});
+
+test("an absent or unusable render companion leaves the listing usable", async ({ page }) => {
+  for (const body of ["", '{"schema_version":1,"renders":[{"id":"nope"}]}']) {
+    await page.route("**/database/recent-renders.json", (route) =>
+      body
+        ? route.fulfill({ status: 200, contentType: "application/json", body })
+        : route.fulfill({ status: 404, contentType: "application/json", body: "{}" }));
+    await page.goto(`/?database=${database}`);
+    const title = page.locator(".entry-card h3 > a").first();
+    await title.hover();
+    await page.waitForTimeout(600);
+
+    await expect(page.locator(".statement-preview")).toHaveCount(0);
+    // The listing is what matters, and it is untouched.
+    await expect(page.locator(".entry-card")).not.toHaveCount(0);
+    await expect(title).toBeVisible();
+  }
+});
+
+test("previews are not raised where a pointer cannot rest", async ({ browser }) => {
+  const context = await browser.newContext({ hasTouch: true, isMobile: false });
+  const page = await context.newPage();
+  await page.emulateMedia({ media: "screen", forcedColors: "none" });
+  await page.goto(`/?database=${database}`);
+  // The controller asks `(hover: hover)`; a coarse pointer answers no, and the
+  // stylesheet refuses to show a panel even if one were somehow raised.
+  const hides = await page.evaluate(() =>
+    [...document.styleSheets]
+      .flatMap((sheet) => [...sheet.cssRules])
+      .some((rule) => rule.conditionText === "(hover: none)"
+        && [...rule.cssRules].some((inner) => inner.selectorText === ".statement-preview")));
+  expect(hides).toBe(true);
+  await context.close();
+});

--- a/tests/statement-preview.test.mjs
+++ b/tests/statement-preview.test.mjs
@@ -1,0 +1,399 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createStatementPreview } from "../assets/statement-preview.mjs";
+import {
+  recentRenderRow,
+  validateEntry,
+  validateRecentRenders,
+} from "../assets/security.mjs";
+import {
+  DIGEST,
+  entry,
+  recentRenders,
+  recentRow,
+  renderRow,
+  summary,
+} from "./registry-fixture.mjs";
+
+const DATABASE = "http://127.0.0.1:4173/database/";
+const OPEN_MS = 350;
+const CLOSE_MS = 200;
+
+/**
+ * A pointer, a clock, and enough of a document to hang a panel off.
+ *
+ * Small on purpose. What is under test is when a panel appears, which one it
+ * frames, and what is torn down afterwards, and none of that needs layout.
+ */
+function fakeBrowser({ hover = true } = {}) {
+  let now = 0;
+  let sequence = 0;
+  const timers = new Map();
+  const windowListeners = new Map();
+
+  function createElement(tag) {
+    const node = {
+      attributes: new Map(),
+      children: [],
+      className: "",
+      dataset: {},
+      href: "",
+      isConnected: false,
+      listeners: new Map(),
+      parent: null,
+      style: {},
+      tagName: tag.toUpperCase(),
+      textContent: "",
+      contentWindow: tag === "iframe" ? {} : undefined,
+      offsetHeight: 200,
+      offsetWidth: 400,
+      append(...children) {
+        for (const child of children) {
+          child.parent = node;
+          child.isConnected = true;
+          node.children.push(child);
+        }
+      },
+      remove() {
+        if (node.parent) {
+          node.parent.children = node.parent.children.filter((item) => item !== node);
+        }
+        node.parent = null;
+        node.isConnected = false;
+      },
+      setAttribute(name, value) {
+        node.attributes.set(name, String(value));
+      },
+      getAttribute(name) {
+        return node.attributes.get(name) ?? null;
+      },
+      addEventListener(name, listener) {
+        node.listeners.set(name, [...(node.listeners.get(name) || []), listener]);
+      },
+      removeEventListener(name, listener) {
+        node.listeners.set(
+          name,
+          (node.listeners.get(name) || []).filter((item) => item !== listener),
+        );
+      },
+      emit(name, event = {}) {
+        for (const listener of node.listeners.get(name) || []) listener(event);
+      },
+      closest(selector) {
+        return node.matches === selector ? node : null;
+      },
+      contains(other) {
+        return other === node;
+      },
+      getBoundingClientRect() {
+        return { top: 100, bottom: 120, left: 40, right: 300 };
+      },
+    };
+    return node;
+  }
+
+  const body = createElement("div");
+  body.isConnected = true;
+
+  return {
+    body,
+    createElement,
+    now: () => now,
+    document: { createElement, body },
+    window: {
+      innerHeight: 800,
+      innerWidth: 1200,
+      location: { href: "http://127.0.0.1:4173/" },
+      matchMedia: (query) => ({ matches: hover && query === "(hover: hover)" }),
+      setTimeout(callback, delay) {
+        const id = (sequence += 1);
+        timers.set(id, { at: now + delay, callback });
+        return id;
+      },
+      clearTimeout(id) {
+        timers.delete(id);
+      },
+      addEventListener(name, listener) {
+        windowListeners.set(name, [...(windowListeners.get(name) || []), listener]);
+      },
+      removeEventListener(name, listener) {
+        windowListeners.set(
+          name,
+          (windowListeners.get(name) || []).filter((item) => item !== listener),
+        );
+      },
+    },
+    windowListeners,
+    /** Advance the clock, then let anything the timers started settle. */
+    async tick(ms) {
+      now += ms;
+      for (const [id, timer] of [...timers]) {
+        if (timer.at <= now) {
+          timers.delete(id);
+          timer.callback();
+        }
+      }
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    },
+  };
+}
+
+function titleLink(browser) {
+  const link = browser.createElement("a");
+  link.matches = "h3 > a";
+  link.isConnected = true;
+  return link;
+}
+
+function build(browser, { renders = recentRenders(), warn = () => {} } = {}) {
+  let reads = 0;
+  const preview = createStatementPreview({
+    document: browser.document,
+    window: browser.window,
+    dataSource: () => ({ databaseBase: DATABASE, renderBase: DATABASE }),
+    loadRecentRenders: async () => {
+      reads += 1;
+      return renders === null ? null : validateRecentRenders(renders);
+    },
+    warn,
+  });
+  const grid = browser.createElement("div");
+  preview.watch(grid);
+  return { preview, grid, reads: () => reads };
+}
+
+function panels(browser) {
+  return browser.body.children.filter((node) =>
+    String(node.className).split(" ").includes("statement-preview"));
+}
+
+function frameOf(browser) {
+  return panels(browser)[0]?.children.find((node) => node.tagName === "IFRAME");
+}
+
+test("a rest on a landing title frames that result's published rendering", async () => {
+  const browser = fakeBrowser();
+  const { preview, grid } = build(browser);
+  const link = titleLink(browser);
+  preview.register(link, recentRow());
+
+  grid.emit("mouseover", { target: link });
+  assert.equal(panels(browser).length, 0, "nothing opens before the rest is one");
+
+  await browser.tick(OPEN_MS);
+
+  const frame = frameOf(browser);
+  assert.equal(
+    frame.src,
+    `${DATABASE}renders/PALOMAR-2026-07-29-000123-v1/${DIGEST}/Challenge/index.html`,
+  );
+  // Scripts, because the rendering is one; nothing else, because it is not this
+  // page's.
+  assert.equal(frame.getAttribute("sandbox"), "allow-scripts");
+  assert.equal(frame.referrerPolicy, "no-referrer");
+});
+
+test("a search result carries its own render metadata and needs no companion read", async () => {
+  const browser = fakeBrowser();
+  const { preview, grid, reads } = build(browser);
+  const link = titleLink(browser);
+  preview.register(link, validateEntry(entry(), summary()));
+
+  grid.emit("mouseover", { target: link });
+  await browser.tick(OPEN_MS);
+
+  assert.equal(reads(), 0, "a whole record already says where its rendering is");
+  assert.match(frameOf(browser).src, /Challenge\/index\.html$/);
+});
+
+test("moving to another title replaces the panel rather than adding one", async () => {
+  const browser = fakeBrowser();
+  const second = { ...renderRow(), id: "PALOMAR-2026-07-29-000124" };
+  const { preview, grid } = build(browser, {
+    renders: recentRenders([renderRow(), second]),
+  });
+  const first = titleLink(browser);
+  const other = titleLink(browser);
+  preview.register(first, recentRow());
+  preview.register(other, recentRow({ id: second.id }));
+
+  grid.emit("mouseover", { target: first });
+  await browser.tick(OPEN_MS);
+  grid.emit("mouseout", { target: first, relatedTarget: null });
+  grid.emit("mouseover", { target: other });
+  await browser.tick(OPEN_MS);
+
+  assert.equal(panels(browser).length, 1, "one panel, and one frame, at a time");
+  assert.match(frameOf(browser).src, new RegExp(`${second.id}-v1`));
+  assert.equal(browser.windowListeners.get("message").length, 1);
+});
+
+test("leaving the title closes the panel, and crossing into it does not", async () => {
+  const browser = fakeBrowser();
+  const { preview, grid } = build(browser);
+  const link = titleLink(browser);
+  preview.register(link, recentRow());
+
+  grid.emit("mouseover", { target: link });
+  await browser.tick(OPEN_MS);
+  const panel = panels(browser)[0];
+
+  grid.emit("mouseout", { target: link, relatedTarget: null });
+  panel.emit("mouseenter");
+  await browser.tick(CLOSE_MS);
+  assert.equal(panels(browser).length, 1, "the pointer reached the panel in time");
+
+  panel.emit("mouseleave");
+  await browser.tick(CLOSE_MS);
+  assert.equal(panels(browser).length, 0);
+});
+
+test("passing over a title opens nothing and starts no read", async () => {
+  const browser = fakeBrowser();
+  const { preview, grid, reads } = build(browser);
+  const link = titleLink(browser);
+  preview.register(link, recentRow());
+
+  grid.emit("mouseover", { target: link });
+  await browser.tick(OPEN_MS - 1);
+  grid.emit("mouseout", { target: link, relatedTarget: null });
+  await browser.tick(OPEN_MS);
+
+  assert.equal(panels(browser).length, 0);
+  assert.equal(reads(), 0);
+});
+
+test("a panel above its title is placed again on the height the render reports", async () => {
+  const browser = fakeBrowser();
+  const { preview, grid } = build(browser);
+  const link = titleLink(browser);
+  preview.register(link, recentRow());
+  // A title low enough that the roomier side is above it, so a panel that grew
+  // after placement would grow back down over the title.
+  link.getBoundingClientRect = () => ({ top: 700, bottom: 720, left: 40, right: 300 });
+
+  grid.emit("mouseover", { target: link });
+  await browser.tick(OPEN_MS);
+  const panel = panels(browser)[0];
+  assert.equal(panel.style.top, `${700 - 8 - 200}px`);
+
+  panel.offsetHeight = 400;
+  for (const listener of browser.windowListeners.get("message")) {
+    listener({ source: frameOf(browser).contentWindow, data: { type: "palomar-render-height", height: 500 } });
+  }
+
+  assert.equal(panel.style.top, `${700 - 8 - 400}px`, "replaced against the reported height");
+  assert.equal(frameOf(browser).style.height, "420px", "and clamped to the preview's bound");
+});
+
+test("a closed panel leaves nothing subscribed to the height channel", async () => {
+  const browser = fakeBrowser();
+  const { preview, grid } = build(browser);
+  const link = titleLink(browser);
+  preview.register(link, recentRow());
+
+  grid.emit("mouseover", { target: link });
+  await browser.tick(OPEN_MS);
+  assert.equal(browser.windowListeners.get("message").length, 1);
+
+  preview.close();
+
+  assert.equal(
+    browser.windowListeners.get("message").length,
+    0,
+    "the listener is on the window, so the frame going away does not remove it",
+  );
+  assert.equal(panels(browser).length, 0);
+});
+
+test("a rest superseded while its reads are in flight does not open behind the reader", async () => {
+  const browser = fakeBrowser();
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const preview = createStatementPreview({
+    document: browser.document,
+    window: browser.window,
+    dataSource: () => ({ databaseBase: DATABASE, renderBase: DATABASE }),
+    loadRecentRenders: async () => {
+      await gate;
+      return validateRecentRenders(recentRenders());
+    },
+  });
+  const grid = browser.createElement("div");
+  preview.watch(grid);
+  const link = titleLink(browser);
+  preview.register(link, recentRow());
+
+  grid.emit("mouseover", { target: link });
+  await browser.tick(OPEN_MS);
+  grid.emit("mouseout", { target: link, relatedTarget: null });
+  await browser.tick(CLOSE_MS);
+  release();
+  await browser.tick(0);
+
+  assert.equal(panels(browser).length, 0);
+});
+
+test("a card the grid has redrawn under raises nothing", async () => {
+  const browser = fakeBrowser();
+  const { preview, grid } = build(browser);
+  const link = titleLink(browser);
+  preview.register(link, recentRow());
+
+  grid.emit("mouseover", { target: link });
+  link.isConnected = false;
+  await browser.tick(OPEN_MS);
+
+  assert.equal(panels(browser).length, 0);
+});
+
+test("an absent or unusable companion document leaves the listing alone", async (t) => {
+  for (const [name, renders, reason] of [
+    ["absent", null, null],
+    ["naming no such result", recentRenders([renderRow({ id: "PALOMAR-2026-07-29-000999" })]), null],
+    ["naming another version", recentRenders([renderRow({ version: 7 })]), null],
+    ["malformed", { schema_version: 1, renders: [{ id: "nope" }] }, /invalid registry data/],
+  ]) {
+    await t.test(name, async () => {
+      const browser = fakeBrowser();
+      const warnings = [];
+      const { preview, grid } = build(browser, {
+        renders,
+        warn: (message) => warnings.push(message),
+      });
+      const link = titleLink(browser);
+      preview.register(link, recentRow());
+
+      grid.emit("mouseover", { target: link });
+      await browser.tick(OPEN_MS);
+
+      assert.equal(panels(browser).length, 0);
+      if (reason) assert.match(warnings.join("\n"), reason);
+      else assert.deepEqual(warnings, []);
+    });
+  }
+});
+
+test("without a pointer that can rest, nothing is registered or bound", async () => {
+  const browser = fakeBrowser({ hover: false });
+  const { preview, grid } = build(browser);
+  const link = titleLink(browser);
+  preview.register(link, recentRow());
+
+  grid.emit("mouseover", { target: link });
+  await browser.tick(OPEN_MS);
+
+  assert.equal(panels(browser).length, 0);
+  assert.deepEqual(grid.listeners.get("mouseover"), undefined);
+});
+
+test("a lookup refuses a companion document that was never validated", () => {
+  const raw = recentRenders();
+  assert.throws(() => recentRenderRow(raw, raw.renders[0].id), /was not validated/);
+  const accepted = validateRecentRenders(recentRenders());
+  assert.equal(recentRenderRow(accepted, "PALOMAR-2026-07-29-000123").version, 1);
+  assert.equal(recentRenderRow(accepted, "PALOMAR-2026-07-29-000999"), null);
+});


### PR DESCRIPTION
This PR raises the Verso rendering of a result's formal statement when the pointer rests on its title, in the registry listing and in search results, so a reader scanning the registry can see what was actually stated without a navigation each way.

The panel frames the same immutable artifact, at the same content address and under the same `sandbox="allow-scripts"` confinement, that an entry page does. It is a preview and not the record: it does not repeat the entry page's check that a render's declarations match the accepted entry, and the entry page remains where a rendering is tied to its record.

A search result is a whole validated record and already says where its rendering is served. A landing row is the card and nothing else, so its content address comes from `recent-renders.json`, read once a page and only once a reader has asked for a preview. Both resolve through one derivation of the artifact path, so the two routes to a rendering cannot come to disagree.

The preview is deliberately pointer-only, and reaches neither a keyboard nor a touch screen; the card's own links remain the way to a statement from both. It is also deliberately unable to disturb the listing: every failure closes quietly and leaves the cards as they were.

The sandboxed frame's height listener is on `window` rather than on the frame, so mounting one now returns a disposal alongside it. An entry page keeps its frame for the page's lifetime and does not dispose; a surface that mounts and discards frames as a pointer moves has to. The height also arrives after the frame is in the document, so the panel is placed again when it does, rather than staying where a guess put it.

This depends on https://github.com/PalomarRegistry/PalomarDatabase/pull/137 and cannot go green until a release from it has published: the presentation tests read the new document as a Database-owned contract, and the published-data traversal now reconciles it against the landing page.

🤖 Prepared with Claude Code