### PR TITLE
feat: accept the path templates a paged collection publishes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,13 @@
 - The three browse surfaces—`browse/index.json`, `browse/<year>.json`, and
   `browse/<day>/<page>.json`—are also exact closed producer/consumer contracts.
   PalomarDatabase owns their head, year, page, count, and summary-row shapes;
-  change those producer-first. CI downloads one live head/year/page chain into
+  change those producer-first. A head and a year each publish the path of the
+  level below as a template, `year_path` and `page_path`, for readers who have
+  the document and not the grammar; a subject's are its own code's, because
+  both collections derive them from the directory being written. This consumer
+  has the grammar and requires the templates to equal it exactly. It never
+  expands one to build a request: a template read as instructions is a path the
+  data origin chooses. CI downloads one live head/year/page chain into
   the named producer-contract fixture test, then the predeploy check traverses
   every row the producer advertises. The traversal reconciles those surfaces;
   it cannot independently prove that their common producer omitted nothing.

--- a/assets/registry-loading.mjs
+++ b/assets/registry-loading.mjs
@@ -120,6 +120,8 @@ export function createRegistryLoader({
     return validateSubjectYear(
       await fetchJson(subjectYearUrl(kind, code, expected.year, databaseBase), { signal }),
       expected,
+      kind,
+      code,
     );
   }
 

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -10,6 +10,22 @@ const MAX_VERSIONS_PER_ID = 500;
 const RECENT_ITEMS = 200;
 const BROWSE_PAGE_SERIALS = 200;
 const BROWSE_MAX_PAGE = Math.ceil(999_999 / BROWSE_PAGE_SERIALS);
+// The path a day-paged collection publishes for the level below it. A head
+// named years and counts and no path, and a year named days and no path, so
+// the URL grammar that gets a reader from one to the next was stated in the
+// publisher's source and in nothing it served; a reader holding one of those
+// documents and nothing else could go no further.
+//
+// This reader has that grammar and never needed the templates, so it requires
+// them to equal what it already knows, exactly as an entry summary's `path`
+// has always had to equal the path derived here. That is the only useful
+// question a consumer can ask of a template -- whether the producer is telling
+// everybody else the truth -- and requiring the equality is also what keeps a
+// template from becoming a path the data origin chooses and this consumer
+// follows. Nothing here expands one to build a request.
+const yearTemplate = (directory) => `${directory}/{year}.json`;
+const pageTemplate = (directory) => `${directory}/{day}/{page}.json`;
+const BROWSE_DIRECTORY = "browse";
 export const ENTRY_SCHEMA_VERSION = 2;
 // The endpoint, not a document. There is no whole-registry document to name
 // any more: every surface is derived from this prefix by the function that
@@ -646,7 +662,10 @@ export function validateVersions(value, id) {
  * traversal from drifting away from the registry's, which is a disagreement
  * neither side could report.
  */
-function validateCollectionYears(document, label) {
+function validateCollectionYears(document, label, directory) {
+  if (document.year_path !== yearTemplate(directory)) {
+    fail(`${label} year_path must be ${yearTemplate(directory)}`);
+  }
   const results = nonnegativeInteger(document.results, `${label} results`);
   const versions = nonnegativeInteger(document.versions, `${label} versions`);
   if (results > versions) fail(`${label} has more results than versions`);
@@ -677,10 +696,13 @@ function validateCollectionYears(document, label) {
 }
 
 /** Every day and page range belonging to one collection head's year row. */
-function validateCollectionYear(value, expected, label) {
-  const document = exactObject(value, ["schema_version", "year", "days"], label);
+function validateCollectionYear(value, expected, label, directory) {
+  const document = exactObject(value, ["schema_version", "year", "page_path", "days"], label);
   if (document.schema_version !== BROWSE_SCHEMA_VERSION) {
     fail(`unsupported ${label} schema_version ${String(document.schema_version)}`);
+  }
+  if (document.page_path !== pageTemplate(directory)) {
+    fail(`${label} page_path must be ${pageTemplate(directory)}`);
   }
   if (document.year !== expected.year) fail(`${label} is for a different year`);
   const days = array(document.days, `${label} days`);
@@ -737,18 +759,18 @@ function pagedHere(id, day, page, field) {
 export function validateBrowseHead(value) {
   const document = exactObject(
     value,
-    ["schema_version", "results", "versions", "years"],
+    ["schema_version", "results", "versions", "year_path", "years"],
     "browse index",
   );
   if (document.schema_version !== BROWSE_SCHEMA_VERSION) {
     fail(`unsupported browse index schema_version ${String(document.schema_version)}`);
   }
-  return validateCollectionYears(document, "browse index");
+  return validateCollectionYears(document, "browse index", BROWSE_DIRECTORY);
 }
 
 /** Every day and page range belonging to one browse-index year row. */
 export function validateBrowseYear(value, expected) {
-  return validateCollectionYear(value, expected, "browse year");
+  return validateCollectionYear(value, expected, "browse year", BROWSE_DIRECTORY);
 }
 
 /** Every active version whose identifier places it on one public browse page. */
@@ -814,6 +836,11 @@ function subjectCoordinate(kind, code) {
   }
   return { kind, code };
 }
+
+// Where a code's archive is written, which is what its templates are built
+// from. A subject's archive is the registry's layout under a different
+// directory, so its head and year name their own pages and not browsing's.
+const subjectDirectory = ({ kind, code }) => `subjects/${kind}/${code}`;
 
 function subjectUrl(path, databaseBase) {
   const base = new URL(databaseBase);
@@ -896,7 +923,7 @@ export function validateSubjectHead(value, kind, code) {
   const at = subjectCoordinate(kind, code);
   const document = exactObject(
     value,
-    ["schema_version", "kind", "code", "entries", "results", "versions", "years"],
+    ["schema_version", "kind", "code", "entries", "results", "versions", "year_path", "years"],
     "subject index",
   );
   if (document.schema_version !== SUBJECT_SCHEMA_VERSION) {
@@ -934,13 +961,14 @@ export function validateSubjectHead(value, kind, code) {
     }
     rows.push(row);
   }
-  validateCollectionYears(document, "subject index");
+  validateCollectionYears(document, "subject index", subjectDirectory(at));
   return { ...document, entries: rows };
 }
 
 /** Every day and page range belonging to one subject head's year row. */
-export function validateSubjectYear(value, expected) {
-  return validateCollectionYear(value, expected, "subject year");
+export function validateSubjectYear(value, expected, kind, code) {
+  const at = subjectCoordinate(kind, code);
+  return validateCollectionYear(value, expected, "subject year", subjectDirectory(at));
 }
 
 /** Every current version under one code whose identifier places it on one page. */

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -362,6 +362,7 @@ def subject_documents() -> dict[str, dict]:
             documents[f"{directory}/{year}.json"] = {
                 "schema_version": 1,
                 "year": year,
+                "page_path": f"{directory}/{{day}}/{{page}}.json",
                 "days": day_rows,
             }
             years.append({
@@ -377,6 +378,7 @@ def subject_documents() -> dict[str, dict]:
             "entries": rows[:SUBJECT_PAGE_ITEMS],
             "results": sum(row["results"] for row in years),
             "versions": sum(row["versions"] for row in years),
+            "year_path": f"{directory}/{{year}}.json",
             "years": years,
         }
     return documents

--- a/tests/fixtures/public-browse/index.json
+++ b/tests/fixtures/public-browse/index.json
@@ -1,12 +1,13 @@
 {
   "results": 1,
   "schema_version": 1,
-  "versions": 1,
+  "versions": 2,
+  "year_path": "browse/{year}.json",
   "years": [
     {
       "days": 1,
       "results": 1,
-      "versions": 1,
+      "versions": 2,
       "year": "2026"
     }
   ]

--- a/tests/fixtures/public-browse/page.json
+++ b/tests/fixtures/public-browse/page.json
@@ -7,6 +7,13 @@
       "status": "accepted",
       "title": "kim-em/erdos-unit-distance-comparator",
       "version": 1
+    },
+    {
+      "id": "PALOMAR-2026-08-08-000001",
+      "path": "entries/PALOMAR-2026-08-08-000001-v2.json",
+      "status": "accepted",
+      "title": "kim-em/erdos-unit-distance-comparator",
+      "version": 2
     }
   ],
   "page": 1,

--- a/tests/fixtures/public-browse/year.json
+++ b/tests/fixtures/public-browse/year.json
@@ -5,9 +5,10 @@
       "first_page": 1,
       "last_page": 1,
       "results": 1,
-      "versions": 1
+      "versions": 2
     }
   ],
+  "page_path": "browse/{day}/{page}.json",
   "schema_version": 1,
   "year": "2026"
 }

--- a/tests/registry-loading.test.mjs
+++ b/tests/registry-loading.test.mjs
@@ -374,6 +374,7 @@ function subjectHead(overrides = {}) {
     }],
     results: 1,
     versions: 1,
+    year_path: "subjects/arxiv/math.CO/{year}.json",
     years: [{ year: "2026", days: 1, results: 1, versions: 1 }],
     ...overrides,
   };
@@ -389,6 +390,7 @@ test("the subject reads resolve and validate all three levels of one code", asyn
       ["/subjects/arxiv/math.CO/2026.json", jsonResponse({
         schema_version: 1,
         year: "2026",
+        page_path: "subjects/arxiv/math.CO/{day}/{page}.json",
         days: [dayRow],
       })],
       ["/subjects/arxiv/math.CO/2026-07-29/1.json", jsonResponse({

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -1127,7 +1127,13 @@ test("browse enumerates every schema-v1 history row without becoming an entry sc
     path: "entries/PALOMAR-2026-07-29-000123-v1.json",
   };
   const yearRow = { year: "2026", days: 1, results: 1, versions: 1 };
-  const head = { schema_version: 1, results: 1, versions: 1, years: [yearRow] };
+  const head = {
+    schema_version: 1,
+    results: 1,
+    versions: 1,
+    year_path: "browse/{year}.json",
+    years: [yearRow],
+  };
   const dayRow = {
     day: "2026-07-29",
     first_page: 1,
@@ -1135,7 +1141,12 @@ test("browse enumerates every schema-v1 history row without becoming an entry sc
     results: 1,
     versions: 1,
   };
-  const year = { schema_version: 1, year: "2026", days: [dayRow] };
+  const year = {
+    schema_version: 1,
+    year: "2026",
+    page_path: "browse/{day}/{page}.json",
+    days: [dayRow],
+  };
   const page = { schema_version: 1, day: dayRow.day, page: 1, entries: [row] };
   assert.equal(validateBrowseHead(head), head);
   assert.equal(validateBrowseYear(year, yearRow), year);
@@ -1176,6 +1187,68 @@ test("the producer-supplied browse head, year, and page keep Web's exact contrac
   assert.equal(validateBrowseHead(head), head);
   assert.equal(validateBrowseYear(year, expectedYear), year);
   assert.equal(validateBrowsePage(page, expectedDay.day, expectedDay.first_page), page);
+  // The producer's own templates, expanded against the producer's own rows,
+  // are the paths CI fetched these three snapshots from. Checking that here is
+  // what makes them a statement about where the documents are rather than two
+  // strings nothing compares to anything.
+  assert.equal(head.year_path.replace("{year}", expectedYear.year), "browse/2026.json");
+  assert.equal(
+    year.page_path.replace("{day}", expectedDay.day).replace("{page}", expectedDay.first_page),
+    `browse/${page.day}/${page.page}.json`,
+  );
+});
+
+test("the path a collection publishes for the level below is the one this reader knows", () => {
+  // These templates exist for a reader that has the document and not the
+  // grammar. This reader has the grammar, so the only question it can usefully
+  // ask is whether the producer is telling everybody else the same thing --
+  // and asking it by equality is also what stops a template being a path the
+  // data origin chooses and this consumer follows.
+  const yearRow = { year: "2026", days: 1, results: 1, versions: 1 };
+  const head = {
+    schema_version: 1,
+    results: 1,
+    versions: 1,
+    year_path: "browse/{year}.json",
+    years: [yearRow],
+  };
+  const year = {
+    schema_version: 1,
+    year: "2026",
+    page_path: "browse/{day}/{page}.json",
+    days: [{ day: "2026-07-29", first_page: 1, last_page: 1, results: 1, versions: 1 }],
+  };
+
+  assert.equal(validateBrowseHead(head), head);
+  assert.equal(validateBrowseYear(year, yearRow), year);
+
+  for (const wrong of [
+    "browse/{year}.JSON",
+    "browse/{yyyy}.json",
+    "https://elsewhere.example/browse/{year}.json",
+    "../{year}.json",
+    "subjects/arxiv/math.CO/{year}.json",
+    "",
+  ]) {
+    assert.throws(() => validateBrowseHead({ ...head, year_path: wrong }), /year_path must be/);
+  }
+  for (const wrong of [
+    "browse/{day}/{page}",
+    "browse/{page}/{day}.json",
+    "https://elsewhere.example/browse/{day}/{page}.json",
+    "subjects/arxiv/math.CO/{day}/{page}.json",
+    "",
+  ]) {
+    assert.throws(
+      () => validateBrowseYear({ ...year, page_path: wrong }, yearRow),
+      /page_path must be/,
+    );
+  }
+
+  const { year_path: _absent, ...headless } = head;
+  const { page_path: _missing, ...yearless } = year;
+  assert.throws(() => validateBrowseHead(headless), /invalid shape/);
+  assert.throws(() => validateBrowseYear(yearless, yearRow), /invalid shape/);
 });
 
 function subjectRow(overrides = {}) {
@@ -1213,11 +1286,13 @@ function subjectFixture() {
       entries: [front, older],
       results: 2,
       versions: 2,
+      year_path: "subjects/arxiv/math.CO/{year}.json",
       years: [yearRow],
     },
     year: {
       schema_version: 1,
       year: "2026",
+      page_path: "subjects/arxiv/math.CO/{day}/{page}.json",
       days: [
         { day: "2026-07-28", first_page: 1, last_page: 1, results: 1, versions: 1 },
         { day: "2026-07-29", first_page: 1, last_page: 1, results: 1, versions: 1 },
@@ -1226,6 +1301,41 @@ function subjectFixture() {
     page: { schema_version: 1, day: "2026-07-29", page: 1, entries: [archived] },
   };
 }
+
+test("a code's archive names its own pages and never the registry's", () => {
+  // The same layout under a different directory, so the templates have to be
+  // that code's own. A subject document carrying browsing's templates would
+  // send a reader who followed them to the whole registry under the code's
+  // heading, which is the one thing a well-formed subject document can still
+  // get wrong here.
+  const { head, year, yearRow } = subjectFixture();
+
+  assert.equal(head.year_path, "subjects/arxiv/math.CO/{year}.json");
+  assert.equal(year.page_path, "subjects/arxiv/math.CO/{day}/{page}.json");
+  assert.equal(validateSubjectYear(year, yearRow, "arxiv", "math.CO"), year);
+
+  assert.throws(
+    () => validateSubjectHead({ ...head, year_path: "browse/{year}.json" }, "arxiv", "math.CO"),
+    /year_path must be subjects\/arxiv\/math\.CO/,
+  );
+  assert.throws(
+    () => validateSubjectYear(
+      { ...year, page_path: "browse/{day}/{page}.json" }, yearRow, "arxiv", "math.CO",
+    ),
+    /page_path must be subjects\/arxiv\/math\.CO/,
+  );
+  // The templates a different code publishes are also the wrong ones, so the
+  // check is against the code that was asked for and not merely against the
+  // shape of a subject path.
+  assert.throws(
+    () => validateSubjectYear(year, yearRow, "msc", "05C10"),
+    /page_path must be subjects\/msc\/05C10/,
+  );
+  assert.throws(
+    () => validateSubjectYear(year, yearRow, "arxiv", "../../etc/passwd"),
+    /malformed/,
+  );
+});
 
 test("a subject URL cannot leave its own directory or name a code that is not one", () => {
   const base = "https://data.example.org/";
@@ -1259,7 +1369,7 @@ test("a subject document is refused unless it is about the code that was asked f
     front.id,
     "PALOMAR-2026-07-28-000001",
   ]);
-  assert.equal(validateSubjectYear(year, yearRow), year);
+  assert.equal(validateSubjectYear(year, yearRow, "arxiv", "math.CO"), year);
   assert.deepEqual(
     validateSubjectPage(page, "arxiv", "math.CO", "2026-07-29", 1).entries.map((row) => row.id),
     [archived.id],

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -1332,6 +1332,7 @@ test("a code with nothing current under it answers, and one never used does not"
       entries: [],
       results: 0,
       versions: 0,
+      year_path: "subjects/msc/05C10/{year}.json",
       years: [],
     }),
   }));


### PR DESCRIPTION
This PR teaches the collection validators about `year_path` and `page_path`, the templates the producer publishes for the level below each document. https://data.palomar-registry.org/browse/index.json serves them now, via https://github.com/PalomarRegistry/PalomarDatabaseTools/releases/tag/v0.1.4 and the lock bump in PalomarDatabase.

A head named years and counts and no path, and a year named days and no path, so getting from `browse/index.json` to a record meant knowing a URL grammar stated in the publisher's source and in nothing the registry served.

This reader has that grammar and never needed the templates, so it requires them to equal what it already knows, exactly as an entry summary's `path` has always had to equal the path this reader derives. That is the only useful question a consumer can ask of a template — whether the producer is telling everybody else the truth — and requiring the equality is also what keeps a template from becoming a path the data origin chooses and this consumer follows. Nothing here expands one to build a request.

Browsing and one classification code are the same document family, so both templates are built from the directory a collection is written into, and a code's archive is required to name its own pages rather than the registry's. Naming them means `validateSubjectYear` now takes the code it is for, which is what its one caller was already holding.

`check-published.mjs --data https://data.palomar-registry.org` passes against the live origin with this branch: all 2 active entry versions across 1 result and 4 classification codes.

🤖 Prepared with Claude Code