### PR TITLE
doc: disclose that GitHub Free carries no data protection agreement

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -533,23 +533,29 @@
           </li>
         </ol>
         <p>
-          The missing agreement is worth being concrete about, because it is
-          the one gap of its kind on this page. What sits on GitHub without one
-          is the access-controlled submission state, which holds every
-          submission record with the submitter’s GitHub login and numeric
-          account id, the free text they wrote, and the review text written
-          about it; the private ledger, which holds the canonical bytes of
+          The missing agreement is worth being concrete about. Cloudflare and
+          OpenAI each process for Palomar under one; GitHub does not, and this
+          is what sits there without it. The access-controlled submission state
+          holds every submission record: the submitter’s GitHub login and
+          numeric account id, the free text they wrote, and the review text
+          written about it. The private ledger holds the canonical bytes of
           everything the registry has published, including versions later
-          suppressed from the public service; and the workflow artifacts each
-          automated review runs on, which carry whole state records and a
-          checkout of the submitted repository for 90 days. A failure or a
-          misconfiguration on GitHub’s part could expose any of that, and if it
-          did there would be no processor agreement standing behind it, only
-          the ordinary terms any free account has. Palomar’s
-          <a href="https://github.com/PalomarRegistry/PalomarPolicy/blob/main/docs/governance.md">governance
-          document</a> says it uses the GitHub Free plan and does not plan to
-          buy GitHub Team, so this is the settled arrangement rather than a gap
-          waiting to close.
+          suppressed from the public service. The packet each automated review
+          runs on is kept as a workflow artifact for 90 days, and it is the
+          review’s whole working directory: the private state record, the fully
+          rendered prompts with the submitted material inlined in them, the raw
+          model event streams and final messages, the normalized per-pass
+          results, the spend record, the review as delivered, and, on a pass
+          that goes on to register, a sparse clone of the private database.
+          That packet also contains a checkout of the submitted repository,
+          which is not part of the exposure: a repository has to be public
+          before it can be submitted at all.
+        </p>
+        <p>
+          A failure or a misconfiguration on GitHub’s part could expose the
+          private parts of that, and if it did there would be no processor
+          agreement standing behind it, only the ordinary terms any free
+          account has.
         </p>
       </section>
 
@@ -565,10 +571,12 @@
         <p>
           Palomar has negotiated separate terms with none of them and relies on
           what each publishes. For Cloudflare and OpenAI that is a data
-          processing agreement Palomar is covered by. For GitHub there is no
-          such agreement, as the section above says, so what appears below is
-          GitHub’s own published commitment rather than a term Palomar could
-          hold it to. What each provider says it relies on, in its own words:
+          processing agreement covering the work they do for Palomar. For
+          GitHub there is no such agreement, as the section above says. What
+          appears below for GitHub is still contractual, because GitHub’s terms
+          of service take the Privacy Statement in as part of the agreement;
+          what it is not is a processor agreement. What each provider says it
+          relies on, in its own words:
         </p>
         <ol class="not-list">
           <li>
@@ -579,15 +587,17 @@
             has certified to the EU-U.S. Data Privacy Framework, with the UK
             Extension and the Swiss-U.S. Framework.
             <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement">GitHub
-            Privacy Statement</a>. Those commitments live in the Privacy
-            Statement, which is written for everyone who uses GitHub rather
-            than per plan, and they are a different instrument from the Data
-            Protection Agreement Palomar does not have; the absence of the
-            agreement does not withdraw them. What Palomar cannot tell you is
-            whether they reach material Palomar puts into GitHub about other
-            people, as against GitHub’s handling of its own users’ data.
-            Reading the statement does not settle that question, and with no
-            agreement there is no contract in which Palomar could put it.
+            Privacy Statement</a>. Two things about that. Those commitments are
+            not per plan and are not merely published: GitHub’s terms of
+            service take the Privacy Statement in as part of the agreement, so
+            the absence of the Data Protection Agreement does not withdraw
+            them. But the statement scopes itself to the personal data GitHub
+            handles as its own controller, and the material Palomar uploads
+            about other people is not that. Whether the clauses reach it is a
+            question the statement does not answer, and with no processor
+            agreement there is no document in which Palomar could get an
+            answer. So it is written here as unresolved rather than as a
+            safeguard Palomar is claiming.
           </li>
           <li>
             <strong>Cloudflare</strong> applies the EU standard contractual

--- a/privacy.html
+++ b/privacy.html
@@ -479,14 +479,22 @@
           <li>
             <strong>GitHub</strong> hosts this site, the private submission
             state, the registry repositories and the public archive forks, and
-            runs the workflows that perform verification and review. For that
-            work it acts for Palomar, under the
-            <a href="https://docs.github.com/en/site-policy/privacy-policies/github-data-protection-agreement">GitHub
-            Data Protection Agreement</a>. When you visit a page or a repository
-            yourself, GitHub is handling your request on its own account, for
-            its own security and logging purposes, under the
+            runs the workflows that perform verification and review. It does
+            that work for Palomar, and no processor contract covers it. Palomar
+            runs on a GitHub Free organization account, and GitHub does not
+            offer its
+            <a href="https://github.com/customer-terms/github-data-protection-agreement">Data
+            Protection Agreement</a> on that plan: GitHub’s customer terms say
+            that agreement covers GitHub Enterprise Cloud, GitHub Enterprise
+            (Unified), GitHub Teams and GitHub Copilot, and Free is not among
+            them. Palomar holds none of those and has negotiated nothing
+            separately, so there is no data protection agreement governing how
+            GitHub handles the private material Palomar keeps there. When you
+            visit a page or a repository yourself, GitHub is handling your
+            request on its own account, for its own security and logging
+            purposes, under the
             <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement">GitHub
-            Privacy Statement</a>.
+            Privacy Statement</a>, and that is unchanged by any of this.
           </li>
           <li>
             <strong>Cloudflare</strong> runs the submission server and the data
@@ -524,6 +532,25 @@
             Data Processing Addendum</a>.
           </li>
         </ol>
+        <p>
+          The missing agreement is worth being concrete about, because it is
+          the one gap of its kind on this page. What sits on GitHub without one
+          is the access-controlled submission state, which holds every
+          submission record with the submitter’s GitHub login and numeric
+          account id, the free text they wrote, and the review text written
+          about it; the private ledger, which holds the canonical bytes of
+          everything the registry has published, including versions later
+          suppressed from the public service; and the workflow artifacts each
+          automated review runs on, which carry whole state records and a
+          checkout of the submitted repository for 90 days. A failure or a
+          misconfiguration on GitHub’s part could expose any of that, and if it
+          did there would be no processor agreement standing behind it, only
+          the ordinary terms any free account has. Palomar’s
+          <a href="https://github.com/PalomarRegistry/PalomarPolicy/blob/main/docs/governance.md">governance
+          document</a> says it uses the GitHub Free plan and does not plan to
+          buy GitHub Team, so this is the settled arrangement rather than a gap
+          waiting to close.
+        </p>
       </section>
 
       <section id="transfers">
@@ -536,9 +563,12 @@
           of its own.
         </p>
         <p>
-          Palomar relies on the transfer terms in each provider’s published data
-          protection agreement and has not negotiated separate terms with any of
-          them. What each provider says it relies on, in its own words:
+          Palomar has negotiated separate terms with none of them and relies on
+          what each publishes. For Cloudflare and OpenAI that is a data
+          processing agreement Palomar is covered by. For GitHub there is no
+          such agreement, as the section above says, so what appears below is
+          GitHub’s own published commitment rather than a term Palomar could
+          hold it to. What each provider says it relies on, in its own words:
         </p>
         <ol class="not-list">
           <li>
@@ -549,7 +579,15 @@
             has certified to the EU-U.S. Data Privacy Framework, with the UK
             Extension and the Swiss-U.S. Framework.
             <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement">GitHub
-            Privacy Statement</a>.
+            Privacy Statement</a>. Those commitments live in the Privacy
+            Statement, which is written for everyone who uses GitHub rather
+            than per plan, and they are a different instrument from the Data
+            Protection Agreement Palomar does not have; the absence of the
+            agreement does not withdraw them. What Palomar cannot tell you is
+            whether they reach material Palomar puts into GitHub about other
+            people, as against GitHub’s handling of its own users’ data.
+            Reading the statement does not settle that question, and with no
+            agreement there is no contract in which Palomar could put it.
           </li>
           <li>
             <strong>Cloudflare</strong> applies the EU standard contractual

--- a/tests/appearance.test.js
+++ b/tests/appearance.test.js
@@ -110,6 +110,44 @@ test("every shipped page carries a footer link to the privacy policy", async () 
   }
 });
 
+// This page claimed for a while that GitHub processed for Palomar under the
+// GitHub Data Protection Agreement, which GitHub does not offer on the Free
+// plan Palomar is on. The correction is a disclosure of a real exposure, and a
+// disclosure an unrelated edit can quietly drop is not one, so the claim is
+// pinned here rather than left to the prose.
+test("privacy.html discloses that GitHub Free carries no data protection agreement", async () => {
+  const html = await readFile(new URL("../privacy.html", import.meta.url), "utf8");
+  const text = html.replace(/\s+/g, " ");
+
+  const opening = text.indexOf("<strong>GitHub</strong> hosts this site");
+  assert.ok(opening >= 0, "privacy.html no longer describes GitHub's role");
+  const entry = text.slice(opening, text.indexOf("</li>", opening));
+  assert.match(entry, /no processor contract covers it/);
+  assert.match(entry, /Palomar runs on a GitHub Free organization account/);
+  assert.match(entry, /GitHub does not offer its/);
+  assert.match(entry, /no data protection agreement governing how GitHub handles/);
+  assert.doesNotMatch(entry, /it acts for Palomar/);
+
+  // The consequence, and the data it applies to, not only the missing paper.
+  assert.match(text, /access-controlled submission state/);
+  assert.match(text, /private ledger/);
+  assert.match(text, /workflow artifacts each automated review runs on/);
+  assert.match(text, /no processor agreement standing behind it/);
+
+  // The transfers section must not re-import the agreement it just disclaimed.
+  assert.match(
+    text,
+    /different instrument from the Data Protection Agreement Palomar does not have/,
+  );
+  assert.doesNotMatch(
+    text,
+    /relies on the transfer terms in each provider’s published data protection agreement/,
+  );
+
+  // GitHub retired this address; it now redirects to the policy index.
+  assert.doesNotMatch(text, /site-policy\/privacy-policies\/github-data-protection-agreement/);
+});
+
 // GitHub Pages answers every address it cannot resolve with this one file, so
 // it is read at `/entry/missing/thing` as readily as at `/404.html`. A relative
 // href there resolves against the directory the reader was aiming at: the

--- a/tests/appearance.test.js
+++ b/tests/appearance.test.js
@@ -131,14 +131,21 @@ test("privacy.html discloses that GitHub Free carries no data protection agreeme
   // The consequence, and the data it applies to, not only the missing paper.
   assert.match(text, /access-controlled submission state/);
   assert.match(text, /private ledger/);
-  assert.match(text, /workflow artifacts each automated review runs on/);
+  assert.match(text, /sparse clone of the private database/);
   assert.match(text, /no processor agreement standing behind it/);
 
-  // The transfers section must not re-import the agreement it just disclaimed.
-  assert.match(
-    text,
-    /different instrument from the Data Protection Agreement Palomar does not have/,
-  );
+  // The absence is stated and left standing. Reassurance that it is fine, or a
+  // view on what should be bought instead, are both out of this page's scope.
+  assert.doesNotMatch(text, /settled arrangement/);
+  assert.doesNotMatch(text, /gap waiting to close/);
+
+  // The transfers section must not re-import the agreement it just disclaimed,
+  // nor overcorrect: GitHub's terms do take the Privacy Statement in, and its
+  // clauses are scoped to GitHub's own controller processing, so what Palomar
+  // can say about Palomar's uploads is that it does not know.
+  assert.match(text, /take the Privacy Statement in as part of the agreement/);
+  assert.match(text, /scopes itself to the personal data GitHub handles as its own controller/);
+  assert.match(text, /a question the statement does not answer/);
   assert.doesNotMatch(
     text,
     /relies on the transfer terms in each provider’s published data protection agreement/,


### PR DESCRIPTION
This PR corrects the privacy policy's account of GitHub and discloses the exposure the old wording hid. The page said GitHub processed for Palomar under the GitHub Data Protection Agreement; GitHub does not offer that agreement on the Free plan Palomar runs on. Its customer terms name GitHub Enterprise Cloud, GitHub Enterprise (Unified), GitHub Teams and GitHub Copilot as covered, and the PalomarRegistry organization holds none of them, so nothing contractual governs how GitHub handles the private submission state, the private ledger, or the 90-day workflow artifacts. The services section now says that plainly, names the data at stake, and states the consequence: a failure or misconfiguration at GitHub could expose it with no processor agreement standing behind it.

The transfers section relied on the same missing document, so it is reconciled rather than left to contradict the correction. GitHub's standard contractual clauses and Data Privacy Framework commitments are published in its Privacy Statement, which is not written per plan and is unaffected by the absence of the agreement, and the page keeps them while saying what it cannot establish: whether they reach material Palomar puts into GitHub about other people, as against GitHub's handling of its own users' data.

The retired docs.github.com address for the agreement, which now redirects to the policy index, is replaced with the current one, and a link to Palomar's governance document supports the statement about the plan. A test pins the disclosure, the concrete data it covers, and the reconciled transfers wording, so the claim cannot regress silently.

🤖 Prepared with Claude Code