### PR TITLE
doc: base publication on legitimate interests rather than consent

### DIFF
--- a/about.html
+++ b/about.html
@@ -633,6 +633,13 @@
         <p>
           Nothing is registered until you ask for it. If the review is an
           acceptance, your status page offers two choices: register, or withdraw.
+          Asking to register is how you authorise the record to be served, and
+          it is the last point at which the choice is yours alone. The
+          <a href="privacy.html#lawful-bases">privacy policy</a> explains that
+          serving the record afterwards rests on Palomar's legitimate interests
+          rather than on your consent, so withdrawing is not available once you
+          have registered, and what you have instead is a further version or a
+          request under the lawful-request process that policy describes.
           Registration is meant to be permanent: the record, the review, and
           your repository and commit enter Palomar's canonical history, which is
           append-only in ordinary operation. A named Moderator may exceptionally

--- a/privacy.html
+++ b/privacy.html
@@ -208,9 +208,9 @@
           submission, and a commit in the preserved history may have been pushed
           by somebody other than the person named in it. If you are named in a
           record and think that
-          balance came out wrong for you, that is exactly what the objection
-          right below is for, and you do not need to have submitted anything to
-          use it.
+          balance came out wrong for you, that is exactly what
+          <a href="#lawful-bases">the objection right</a> is for, and you do not
+          need to have submitted anything to use it.
         </p>
       </section>
 
@@ -219,7 +219,9 @@
         <p>
           Different parts of Palomar rest on different things, and lumping them
           together would hide the part that matters: which of them you can stop,
-          and when.
+          and when. The line falls at registration, which is where the rest of
+          the system draws it too. Everything before registration rests on your
+          consent. Publishing the registered record, and keeping it, do not.
         </p>
         <ol class="not-list">
           <li>
@@ -235,10 +237,11 @@
             afterwards does not unpublish a run that has already happened.
           </li>
           <li>
-            <strong>Publishing a registry record</strong> rests on your consent,
-            acted on at the moment you register. The schema is explicit about
-            this: the registration timestamp is defined as the moment the
-            submitter’s consent was acted on.
+            <strong>Serving a registered record, and keeping it for as long as
+            the registry exists,</strong> rest on legitimate interests. Not on
+            your consent, and registration does not make them consent-based
+            either. The interest is named, and the balance behind it set out,
+            immediately below.
           </li>
           <li>
             <strong>Personal data about third parties in the record</strong>
@@ -264,17 +267,110 @@
           </li>
         </ol>
         <p>
-          The honest part about consent. Before registration, withdrawing your
-          consent stops the thing: no registry record and no editorial review
-          are published, and the private record is scrubbed as described below.
-          After registration it does not work that way, and no wording here can
-          make it. Withdrawing consent stops future processing but does not
-          reverse what was lawfully published while it stood, and a published
-          record is already in other people’s hands. What is available instead
-          is the lawful-request process: suppression of the public projection,
-          or correction by a new version, with the canonical bytes ordinarily
-          retained privately. An upheld statutory right can reach further; that
-          is described under
+          <strong>What your consent covers.</strong> Intake, the public
+          verification run your submission dispatches, the editorial review, and
+          the private submission record while the submission is still in
+          progress. Withdrawing it there genuinely stops the processing rather
+          than merely marking it stopped. You can withdraw from any state before
+          registration; no registry record and no editorial review are then
+          published, and the private record is scrubbed:
+          <a href="#withdrawing">withdrawing before registration</a> says
+          exactly which fields are removed, which are kept, and what withdrawal
+          cannot reach, which is the already-public verification run and the git
+          history of the state. That is what makes this consent rather than a
+          word for consent.
+        </p>
+        <p>
+          <strong>Why registration is not the basis for publishing.</strong>
+          Registering is how you authorise publication. Nothing is registered
+          until you have read your review and asked for it, and the registry
+          schema records the registration instant as the moment that request was
+          acted on. That is a governance act, and Palomar will not dress it up
+          as the legal basis for everything that follows. Consent has to be as
+          easy to withdraw as it was to give, and withdrawing it has to stop the
+          processing. After registration it cannot: there is no
+          submitter-facing takedown route, registration is not reversible on
+          request, and a version leaves public view only by a named Moderator’s
+          decision. A permission you cannot take back is not consent whatever it
+          is called, and a controller may not run processing as consent-based
+          and then reach for a different basis at the moment the consent fails.
+          So serving the record rests on legitimate interests from the first
+          moment it is served, and this page names that basis rather than
+          leaving it to be worked out when somebody asks.
+        </p>
+        <p>
+          <strong>The interest, named.</strong> It is the permanence of a
+          certification record, and through that the integrity of every other
+          entry in the registry. What Palomar asserts about a registered entry
+          is that an accepted result was accepted under a stated contract, by a
+          review recorded at an exact policy commit, on an exact source commit.
+          A registry that can quietly lose an entry cannot support that claim
+          about the entries it still has, because nothing distinguishes a record
+          that was never made from one that was removed. That is also why the
+          retention is indefinite and why a suppressed version leaves a
+          date-only tombstone. The interest is not only Palomar’s: it is shared
+          by everyone who cites an identifier and expects it to keep resolving,
+          and by every other submitter whose record borrows its credibility from
+          the fact that records do not silently vanish.
+        </p>
+        <p>
+          <strong>The balance, and where it is written down.</strong> There is
+          no separate balancing document, and this page will not send you
+          looking for one. The reasoning is here, and this is the record of it.
+          What is published about a submitter is deliberately small: the record
+          names no submitter, no schema has a field for one, and registration
+          does not add one. What a record does carry about people is the kind of
+          thing a paper, a preprint server or a bibliography carries about the
+          same people, taken from a public repository, and Palomar does not
+          enrich it, profile anyone from it, or contact anyone from it. A
+          submitter arrives at registration having been told that it is meant to
+          be permanent, with withdrawal available up to the moment they ask.
+          The people whose position is weakest are the ones who never submitted
+          anything: co-authors, the authors of cited sources, responsible
+          maintainers, and everyone whose name and address sits in a preserved
+          commit history. They chose none of this, so for them the counterweight
+          is not a choice they made but the objection right below, and
+          suppression of the public projection where an objection or another
+          right requires it. Palomar does not claim this balance comes out its
+          way for every person and every record; it claims the reasoning is
+          stated, so you can tell it that it came out wrong for you.
+        </p>
+        <p>
+          <strong>Objecting.</strong> Because publication, retention, and the
+          third-party data in a record rest on legitimate interests, Article 21
+          gives you the right to object to them on grounds relating to your
+          particular situation. You do not need to have submitted anything.
+          An objection is decided, not automatic: Palomar weighs the grounds you
+          give against the interest above and stops the processing unless it can
+          demonstrate compelling legitimate grounds that override your
+          interests, rights and freedoms, or that the processing is needed for
+          legal claims. Being decided is not the same as being resisted. A
+          refusal, in whole or in part, names its legal ground, gives you the
+          assessment rather than a citation, and tells you that you may complain
+          to a supervisory authority and go to court. Object by writing to
+          <a href="mailto:privacy@palomar-registry.org">privacy@palomar-registry.org</a>.
+          It is handled under
+          <a href="https://github.com/PalomarRegistry/PalomarPolicy/blob/main/docs/lawful-requests.md">the
+          lawful-request process</a>, which says who decides and what is
+          recorded. There is no form, and no wording you have to get right.
+        </p>
+        <p>
+          <strong>After registration you cannot take it back yourself.</strong>
+          Once a version is registered there is no button that unpublishes it,
+          no cooling-off period, and no ordinary takedown route for the person
+          who submitted it. Changing your mind is not, by itself, something
+          Palomar acts on. What you can do instead is register a further
+          version, which is the ordinary way a registered record is corrected
+          and leaves the earlier version resolvable; and make a data-protection
+          request, an Article 21 objection among them, which a named Moderator
+          decides and which can result in suppression of the public projection
+          with its date-only tombstone, in correction by a new version, or,
+          where an upheld right requires more than those defaults, in more. Those
+          routes are real and they are not a formality. They are also not the
+          same thing as revoking consent, and this page will not describe them
+          as though they were. Suppression also stops Palomar serving something
+          rather than recalling it; that limit, and what an upheld statutory
+          right can reach, are under
           <a href="#after-registration">correction, takedown, and erasure</a>.
         </p>
       </section>
@@ -366,7 +462,10 @@
         <p>
           Published records, and the preserved forks of the repositories behind
           them, are kept for as long as the registry exists. That is what
-          publication means here.
+          publication means here. That retention rests on legitimate interests
+          rather than on the submitter’s consent, for the reasons given under
+          <a href="#lawful-bases">the basis for each purpose</a>, and it is open
+          to objection on the same terms.
         </p>
         <p>
           Correspondence with the privacy address is kept while the matter it
@@ -447,6 +546,9 @@
           <a href="https://github.com/PalomarRegistry/PalomarPolicy/blob/main/docs/lawful-requests.md">docs/lawful-requests.md</a>
           in Palomar Policy. Send the request itself to
           <a href="mailto:privacy@palomar-registry.org">privacy@palomar-registry.org</a>.
+          An Article 21 objection to a record being served is one of the things
+          that route handles, and it is the route a submitter has once
+          registration has happened.
         </p>
         <p>
           The two default outcomes are suppression of the public projection, so
@@ -586,10 +688,15 @@
           personal data Palomar holds about you, for it to be corrected, for it
           to be erased, for its processing to be restricted, and for a copy in a
           portable form. You can object to processing that rests on legitimate
-          interests, which includes everything in the record that is about
-          somebody other than the submitter, and you can withdraw consent at any
-          time, which stops future processing without making what happened
-          before it unlawful.
+          interests, which includes serving a registered record, keeping it, and
+          everything in that record that is about somebody other than the
+          submitter;
+          <a href="#lawful-bases">the basis for each purpose</a> says what that
+          interest is and how an objection is decided. You can withdraw your
+          consent at any time while a submission is still in progress, which
+          ends the submission and scrubs the private record. Withdrawing after
+          registration reaches nothing, because publishing the record was never
+          based on that consent; the objection right is what covers it instead.
         </p>
         <p>
           Ask by writing to

--- a/privacy.html
+++ b/privacy.html
@@ -219,22 +219,41 @@
         <p>
           Different parts of Palomar rest on different things, and lumping them
           together would hide the part that matters: which of them you can stop,
-          and when. The line falls at registration, which is where the rest of
-          the system draws it too. Everything before registration rests on your
-          consent. Publishing the registered record, and keeping it, do not.
+          and when. One line falls at registration, which is where the rest of
+          the system draws it too: what a submitter can stop by changing their
+          mind stops there. But consent never covered the whole of what happens
+          before that line, and this page will not tidy it into saying so.
+          Consent covers Palomar’s processing of a submitter’s own data for a
+          submission that is still running. Personal data about other people is
+          on legitimate interests from the moment it is collected, because a
+          submitter cannot consent for them. So are the things that outlive a
+          submission: the public verification run, the retained audit history,
+          and, after registration, the record itself.
         </p>
         <ol class="not-list">
           <li>
-            <strong>Intake and editorial review</strong> rest on your consent.
-            You choose to submit, and you can withdraw at any point before
-            registration.
+            <strong>Running your submission,</strong> which is intake, the
+            push-access check, dispatching mechanical verification, the
+            editorial review, and holding the private submission record while
+            any of that is still going on, rests on your consent, and covers
+            your own data rather than anybody else’s. You choose to submit, and
+            you can stop it while the submission is still open.
           </li>
           <li>
-            <strong>Mechanical verification, which is public,</strong> also
-            rests on your consent, given when you submit: dispatching the public
-            run is how a submission gets verified, and there is no unpublic way
-            to do it. What that dispatch carries is listed below. Withdrawing
-            afterwards does not unpublish a run that has already happened.
+            <strong>Keeping the public verification run public afterwards</strong>
+            rests on legitimate interests, and did from the moment it was
+            dispatched. Dispatching it is something you ask for, and there is no
+            unpublic way to run it; what that dispatch carries is listed below.
+            But Palomar does not delete runs in the ordinary course, and nothing
+            in withdrawal reaches one, so the basis for its staying there cannot
+            be a consent you can take back. The interest is that a mechanical
+            result anybody can open and re-check is what makes verification more
+            than Palomar’s word for it, including for a submission that failed.
+            GitHub’s own retention expires the logs after 90 days, while the run
+            and the inputs it was dispatched with stay. An upheld
+            data-protection request can still reach a run: the lawful-request
+            process treats it as one of the public surfaces assessed in the same
+            decision, and removes or disables it where the request requires.
           </li>
           <li>
             <strong>Serving a registered record, and keeping it for as long as
@@ -244,14 +263,20 @@
             immediately below.
           </li>
           <li>
-            <strong>Personal data about third parties in the record</strong>
-            rests on legitimate interests, as set out in the previous section.
+            <strong>Personal data about anyone other than the submitter</strong>
+            rests on legitimate interests from the moment it is collected, as
+            set out in the previous section. It is never on consent, at any
+            stage, because the person it is about never gave any and the
+            submitter cannot give it for them. Withdrawal does not change its
+            basis, and neither does registration.
           </li>
           <li>
-            <strong>Keeping the private submission state for audit</strong>
-            rests on legitimate interests: a decision nobody can reconstruct is
-            a decision nobody can challenge, including the submitter who wants
-            to challenge it.
+            <strong>Keeping the private submission state for audit,</strong>
+            which is what remains once a submission has stopped moving, rests on
+            legitimate interests: a decision nobody can reconstruct is a
+            decision nobody can challenge, including the submitter who wants to
+            challenge it. This is the basis the record’s retained history has
+            had from the start, not one Palomar reaches for when a consent ends.
           </li>
           <li>
             <strong>Rate limiting and abuse prevention</strong> rest on
@@ -267,18 +292,35 @@
           </li>
         </ol>
         <p>
-          <strong>What your consent covers.</strong> Intake, the public
-          verification run your submission dispatches, the editorial review, and
-          the private submission record while the submission is still in
-          progress. Withdrawing it there genuinely stops the processing rather
-          than merely marking it stopped. You can withdraw from any state before
-          registration; no registry record and no editorial review are then
-          published, and the private record is scrubbed:
-          <a href="#withdrawing">withdrawing before registration</a> says
-          exactly which fields are removed, which are kept, and what withdrawal
-          cannot reach, which is the already-public verification run and the git
-          history of the state. That is what makes this consent rather than a
-          word for consent.
+          <strong>What your consent covers, and what withdrawing it does.</strong>
+          It covers Palomar processing your own data to run the submission you
+          started: intake, the push-access check, the dispatch, the editorial
+          review, and the private submission record while any of that is live.
+          Withdrawing stops that ongoing consent-based workflow rather than
+          stopping everything. It really does stop it: no registry record and no
+          editorial review are published, and the private record is scrubbed in
+          the same write that closes it.
+          <a href="#withdrawing">Withdrawing before registration</a> says which
+          fields go and which stay. What it does not reach is what was never on
+          your consent to begin with: the already-public verification run, the
+          personal data in the submission that is about other people, and the
+          git history of the state, which is the retained audit record.
+        </p>
+        <p>
+          <strong>When withdrawal is available.</strong> While the submission is
+          still open, which is most of its life and includes the states where
+          Palomar itself has gone wrong: a dispatch it lost, a review it could
+          not run, a registration that stalled. Withdrawal is deliberately kept
+          available there, because a submission that broke at Palomar’s end is
+          still yours to close. It is not available in the four states where the
+          submission has already closed: registered, already withdrawn, failed
+          mechanical verification, or a review that asked for changes. So a
+          submission can end without your ever having been offered the scrub.
+          If yours did, the private record still holds what it held, on the
+          audit basis above, and the way to reach it is a request to
+          <a href="mailto:privacy@palomar-registry.org">privacy@palomar-registry.org</a>
+          rather than a button. Starting a replacement submission for the same
+          repository also closes and scrubs the earlier one.
         </p>
         <p>
           <strong>Why registration is not the basis for publishing.</strong>
@@ -319,33 +361,85 @@
           looking for one. The reasoning is here, and this is the record of it.
           What is published about a submitter is deliberately small: the record
           names no submitter, no schema has a field for one, and registration
-          does not add one. What a record does carry about people is the kind of
-          thing a paper, a preprint server or a bibliography carries about the
-          same people, taken from a public repository, and Palomar does not
-          enrich it, profile anyone from it, or contact anyone from it. A
-          submitter arrives at registration having been told that it is meant to
-          be permanent, with withdrawal available up to the moment they ask.
-          The people whose position is weakest are the ones who never submitted
-          anything: co-authors, the authors of cited sources, responsible
-          maintainers, and everyone whose name and address sits in a preserved
-          commit history. They chose none of this, so for them the counterweight
-          is not a choice they made but the objection right below, and
-          suppression of the public projection where an objection or another
-          right requires it. Palomar does not claim this balance comes out its
-          way for every person and every record; it claims the reasoning is
-          stated, so you can tell it that it came out wrong for you.
+          does not add one. Beyond that the published personal data is of three
+          different kinds, and they do not balance the same way, so it would be
+          misleading to weigh them together as though a record were a
+          bibliography.
         </p>
         <p>
-          <strong>Objecting.</strong> Because publication, retention, and the
-          third-party data in a record rest on legitimate interests, Article 21
-          gives you the right to object to them on grounds relating to your
-          particular situation. You do not need to have submitted anything.
+          The first kind is repository metadata and preserved history: the
+          authors, maintainers and cited-source authors a project declares, with
+          their handles and ORCIDs, the account that owns the repository, and
+          the name and email address in every commit of the preserved fork. The
+          declared part really is what a paper or a bibliography carries about
+          the same people, from a public repository, and Palomar does not
+          enrich, index, profile or contact anyone from it. The commit history
+          is not: nobody puts an email address in a commit in order to be
+          catalogued by a registry. It is there because a preserved fork carries
+          the history it has, and preserving the exact source is what makes the
+          check re-runnable. That is a real interest and a real cost, and the
+          cost falls on people who never chose it.
+        </p>
+        <p>
+          The second is what a submitter typed: the authorization relationship
+          and the free-text evidence beside it. That names whoever the submitter
+          wrote into it, which may be someone who never saw the submission and
+          has not agreed to be named, and it is public from verification onward
+          rather than from registration. The submission form warns at the point
+          of typing. A warning to one person is not consent from another, so for
+          the person named there the weight rests on the objection right and on
+          suppression, not on anything they did.
+        </p>
+        <p>
+          The third is generated: the editorial review’s comments, published on
+          registration, which discuss the literature and so discuss its authors,
+          and which can repeat back what a submitter put in the private notes
+          field. Automated text about named people is the kind of processing
+          that deserves the least benefit of the doubt, which is why the review
+          is published redacted, why the page tells submitters to keep sensitive
+          material out of the notes, and why an inaccuracy here is a
+          rectification case and not only an objection.
+        </p>
+        <p>
+          A submitter arrives at registration having been told that it is meant
+          to be permanent, with withdrawal available up to the moment they ask.
+          The people whose position is weakest are the ones who never submitted
+          anything: co-authors, the authors of cited sources, responsible
+          maintainers, whoever a submitter named in their evidence, and everyone
+          whose name and address sits in a preserved commit history. They chose
+          none of this, so for them the counterweight is not a choice they made
+          but the objection right below, and suppression of the public
+          projection where an objection or another right requires it. Palomar
+          does not claim this balance comes out its way for every person and
+          every record; it claims the reasoning is stated, so you can tell it
+          that it came out wrong for you.
+        </p>
+        <p>
+          <strong>Objecting.</strong> Where processing rests on legitimate
+          interests, Article 21 lets anyone object to the processing of personal
+          data concerning them, on grounds relating to their particular
+          situation. Two limits are worth being exact about, because the loose
+          version of this right promises more than it is. It is a right over
+          your own personal data, not over a record: a mathematical result, a
+          repository, a commit and a verdict are not personal data about you,
+          and objecting does not give you a veto over what a record says about
+          mathematics. And it belongs to whoever the data is about, which for
+          most of what a record carries is not the submitter. Since a registry
+          record names no submitter, a submitter’s own objection reaches the
+          parts that are actually about them: the account and repository, the
+          evidence they wrote if it identifies them, and their name and address
+          in the preserved commit history. You do not need to have submitted
+          anything to object, and most people who do will not have.
           An objection is decided, not automatic: Palomar weighs the grounds you
           give against the interest above and stops the processing unless it can
           demonstrate compelling legitimate grounds that override your
           interests, rights and freedoms, or that the processing is needed for
-          legal claims. Being decided is not the same as being resisted. A
-          refusal, in whole or in part, names its legal ground, gives you the
+          legal claims. Being decided is not the same as being resisted. Where
+          an objection is upheld, suppressing the affected version is one of the
+          things that can follow, along with removing a field, deleting a
+          preserved fork, or correcting by a new version; it is an outcome the
+          decision may reach, not the measure of the right. A refusal, in whole
+          or in part, names its legal ground, gives you the
           assessment rather than a citation, and tells you that you may complain
           to a supervisory authority and go to court. Object by writing to
           <a href="mailto:privacy@palomar-registry.org">privacy@palomar-registry.org</a>.
@@ -362,13 +456,17 @@
           Palomar acts on. What you can do instead is register a further
           version, which is the ordinary way a registered record is corrected
           and leaves the earlier version resolvable; and make a data-protection
-          request, an Article 21 objection among them, which a named Moderator
-          decides and which can result in suppression of the public projection
-          with its date-only tombstone, in correction by a new version, or,
-          where an upheld right requires more than those defaults, in more. Those
-          routes are real and they are not a formality. They are also not the
-          same thing as revoking consent, and this page will not describe them
-          as though they were. Suppression also stops Palomar serving something
+          request, which a named Moderator decides and which can result in
+          suppression of the public projection with its date-only tombstone, in
+          correction by a new version, or, where an upheld right requires more
+          than those defaults, in more. Those routes are real and they are not a
+          formality. Be clear about what they are, though. They are not the same
+          thing as revoking consent, and this page will not describe them as
+          though they were. Nor is the objection right a submitter’s takedown
+          route by another name: it reaches personal data about the person
+          objecting, and a registry record is mostly not that. A submitter who
+          simply wants a result unpublished is not asking a data-protection
+          question, and will be told so. Suppression also stops Palomar serving something
           rather than recalling it; that limit, and what an upheld statutory
           right can reach, are under
           <a href="#after-registration">correction, takedown, and erasure</a>.
@@ -479,8 +577,12 @@
       <section id="withdrawing">
         <h2>Withdrawing before registration</h2>
         <p>
-          Until you register, you can withdraw, and withdrawal is not only a
-          change of status. It scrubs the current private record. It was applied
+          While a submission is still open you can withdraw, and withdrawal is
+          not only a change of status.
+          <a href="#lawful-bases">The basis for each purpose</a> says which
+          states count as still open, since a submission that has already closed
+          without being registered cannot be withdrawn either.
+          It scrubs the current private record. It was applied
           to the records withdrawn before it existed as well, so what it removes
           is absent from every withdrawn record in the state, not only from the
           ones withdrawn since.
@@ -546,9 +648,11 @@
           <a href="https://github.com/PalomarRegistry/PalomarPolicy/blob/main/docs/lawful-requests.md">docs/lawful-requests.md</a>
           in Palomar Policy. Send the request itself to
           <a href="mailto:privacy@palomar-registry.org">privacy@palomar-registry.org</a>.
-          An Article 21 objection to a record being served is one of the things
-          that route handles, and it is the route a submitter has once
-          registration has happened.
+          An Article 21 objection is one of the things that route handles: an
+          objection to Palomar’s continuing to process personal data about the
+          person objecting, which may be data a served record carries. Whether
+          upholding it suppresses that version, removes a field, or is answered
+          another way is part of the decision rather than given by the request.
         </p>
         <p>
           The two default outcomes are suppression of the public projection, so
@@ -687,16 +791,18 @@
           Under the UK GDPR and the EU GDPR you can ask for access to the
           personal data Palomar holds about you, for it to be corrected, for it
           to be erased, for its processing to be restricted, and for a copy in a
-          portable form. You can object to processing that rests on legitimate
-          interests, which includes serving a registered record, keeping it, and
-          everything in that record that is about somebody other than the
-          submitter;
-          <a href="#lawful-bases">the basis for each purpose</a> says what that
-          interest is and how an objection is decided. You can withdraw your
-          consent at any time while a submission is still in progress, which
-          ends the submission and scrubs the private record. Withdrawing after
-          registration reaches nothing, because publishing the record was never
-          based on that consent; the objection right is what covers it instead.
+          portable form. You can object, on grounds relating to your particular
+          situation, to legitimate-interest processing of personal data about
+          you. Most of what Palomar publishes rests on legitimate interests,
+          including serving and keeping a registered record, so the question is
+          usually not whether the right applies but which part of the material
+          is about you.
+          <a href="#lawful-bases">The basis for each purpose</a> says what the
+          interest is, how an objection is decided, and why the right is not a
+          general power to have a record withdrawn. You can withdraw your
+          consent while a submission is still open, which ends it and scrubs the
+          private record. Withdrawing later reaches nothing, because publishing
+          the record was never based on that consent.
         </p>
         <p>
           Ask by writing to

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -988,8 +988,8 @@ test("publication rests on legitimate interests, and the objection right is stat
   // being served afterwards. Those cannot both hold: consent must be as easy
   // to withdraw as to give, withdrawal has to stop the processing, and a
   // controller cannot move that same processing onto another basis once the
-  // consent fails. Withdrawal exists only before registration, so consent
-  // stops at that line and publication is a legitimate-interests case that has
+  // consent fails. Withdrawal exists only while a submission is open, so
+  // consent stops there and publication is a legitimate-interests case that has
   // to name its interest and carry the Article 21 right that comes with it.
   // A page can regress here silently, because nothing else in the site reads
   // this section.
@@ -1012,9 +1012,9 @@ test("publication rests on legitimate interests, and the objection right is stat
   assert.match(bases, /compelling legitimate grounds/);
   assert.match(bases, /mailto:privacy@palomar-registry\.org/);
   assert.match(bases, /PalomarPolicy\/blob\/main\/docs\/lawful-requests\.md/);
-  // Consent keeps the part where withdrawal genuinely stops the processing,
+  // Consent keeps the part where withdrawal really does stop the workflow,
   // and the page has to say plainly that registration ends that.
-  assert.match(bases, /Withdrawing it there genuinely stops the processing/);
+  assert.match(bases, /Withdrawing stops that ongoing consent-based workflow/);
   assert.match(bases, /After registration you cannot take it back yourself/);
   assert.match(bases, /no button that unpublishes it/);
   // No balancing assessment exists as a separate document, so the page must
@@ -1024,6 +1024,92 @@ test("publication rests on legitimate interests, and the objection right is stat
   // Rights and retention must not drift back into describing publication as
   // consent-based once this section stops doing so.
   assert.doesNotMatch(privacy, /withdraw consent at any\s+time, which stops future processing/);
+});
+
+test("consent is scoped to the submitter's own live submission", async () => {
+  // "Everything before registration rests on your consent" is the tidy
+  // sentence and the wrong one, in the direction that flatters the page. A
+  // submitter cannot consent for the co-authors and committers a record names,
+  // so their data is on legitimate interests from collection and never moves.
+  // Two more things outlive the consent: the dispatched verification run,
+  // which Palomar does not delete and withdrawal does not reach, and the
+  // retained audit history. Leaving those inside a consent that has been
+  // withdrawn would describe processing with no basis at all, which is the
+  // failure this whole section exists to avoid.
+  const privacy = await readFile(new URL("../privacy.html", import.meta.url), "utf8");
+  const bases = /<section id="lawful-bases">[\s\S]*?<\/section>/.exec(privacy)[0];
+  assert.doesNotMatch(
+    bases,
+    /Everything before registration rests on your\s+consent/,
+    "consent may not be claimed over everything before registration",
+  );
+  assert.match(bases, /because a\s+submitter cannot consent for them/);
+  assert.match(bases, /Personal data about anyone other than the submitter<\/strong>\s+rests on legitimate interests from the moment it is collected/);
+  assert.match(bases, /It is never on consent, at any\s+stage/);
+  assert.match(bases, /Keeping the public verification run public afterwards<\/strong>\s+rests on legitimate interests, and did from the moment it was\s+dispatched/);
+  assert.match(bases, /Palomar does not delete runs/);
+  assert.match(bases, /rests on\s+legitimate interests: a decision nobody can reconstruct/);
+  assert.match(bases, /not one Palomar reaches for when a consent ends/);
+});
+
+test("the page describes withdrawal from the states that actually allow it", async () => {
+  // PalomarServer refuses POST /withdraw for the four statuses in CLOSED, so
+  // "any state before registration" is wrong twice over: it promises the scrub
+  // to submissions that failed verification or were asked for changes, and it
+  // hides that Palomar's own faults deliberately keep withdrawal available.
+  // A submission can therefore close unregistered and unscrubbed, and the page
+  // has to say what is left for that person instead of implying a button.
+  const privacy = await readFile(new URL("../privacy.html", import.meta.url), "utf8");
+  const bases = /<section id="lawful-bases">[\s\S]*?<\/section>/.exec(privacy)[0];
+  assert.doesNotMatch(privacy, /withdraw from any state before\s+registration/);
+  assert.doesNotMatch(privacy, /Until you register, you can withdraw/);
+  assert.match(bases, /registered, already withdrawn, failed\s+mechanical verification, or a review that asked for changes/);
+  assert.match(bases, /a dispatch it lost, a review it could\s+not run, a registration that stalled/);
+  assert.match(bases, /a\s+submission can end without your ever having been offered the scrub/);
+});
+
+test("the objection right is scoped to personal data about the objector", async () => {
+  // Article 21 covers processing of personal data concerning the objector, on
+  // grounds relating to their situation. Described as a right over the record,
+  // it becomes a submitter takedown route the law does not provide, which is
+  // especially wrong here: the record names no submitter, so a submitter's own
+  // objection reaches comparatively little of it. Suppression is a thing an
+  // upheld objection can produce, not the extent of what may be objected to.
+  const privacy = await readFile(new URL("../privacy.html", import.meta.url), "utf8");
+  const bases = /<section id="lawful-bases">[\s\S]*?<\/section>/.exec(privacy)[0];
+  assert.match(bases, /object to the processing of personal\s+data concerning them/);
+  assert.match(bases, /It is a right over\s+your own personal data, not over a record/);
+  assert.match(bases, /objecting does not give you a veto over what a record says about\s+mathematics/);
+  assert.match(bases, /it is an outcome the\s+decision may reach, not the measure of the right/);
+  assert.match(bases, /Nor is the objection right a submitter’s takedown\s+route by another name/);
+  assert.match(privacy, /which part of the material\s+is about you/);
+  assert.doesNotMatch(
+    privacy,
+    /Article 21 objection to a record being served/,
+    "the objection right is not a right over a whole record",
+  );
+});
+
+test("the balancing account weighs each kind of published personal data", async () => {
+  // Calling the published data bibliography-like covers the declared authors
+  // and nothing else. The commit addresses in a preserved fork, the evidence a
+  // submitter typed about somebody who never saw the submission, and generated
+  // review comments that can repeat a private note are all published personal
+  // data of quite different weight, and a balance that averages them is not a
+  // balance anybody could check.
+  const privacy = await readFile(new URL("../privacy.html", import.meta.url), "utf8");
+  const bases = /<section id="lawful-bases">[\s\S]*?<\/section>/.exec(privacy)[0];
+  assert.match(bases, /published personal data is of three\s+different kinds/);
+  assert.match(bases, /name and email address in every commit of the preserved fork/);
+  assert.match(bases, /nobody puts an email address in a commit in order to be\s+catalogued by a registry/);
+  assert.match(bases, /the authorization relationship\s+and the free-text evidence beside it/);
+  assert.match(bases, /A warning to one person is not consent from another/);
+  assert.match(bases, /can repeat back what a submitter put in the private notes\s+field/);
+  assert.doesNotMatch(
+    bases,
+    /What a record does carry about people is the kind of\s+thing a paper/,
+    "the whole record may not be described as bibliography-like",
+  );
 });
 
 test("About describes both ways push access is proved", async () => {

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -982,6 +982,50 @@ test("both pages say the authorization evidence is public from verification", as
   assert.match(privacy, /deliberately kept out of the public verification\s+dispatch/);
 });
 
+test("publication rests on legitimate interests, and the objection right is stated", async () => {
+  // The first published version of this page based publishing a registry
+  // record on the submitter's consent while also saying the record keeps
+  // being served afterwards. Those cannot both hold: consent must be as easy
+  // to withdraw as to give, withdrawal has to stop the processing, and a
+  // controller cannot move that same processing onto another basis once the
+  // consent fails. Withdrawal exists only before registration, so consent
+  // stops at that line and publication is a legitimate-interests case that has
+  // to name its interest and carry the Article 21 right that comes with it.
+  // A page can regress here silently, because nothing else in the site reads
+  // this section.
+  const privacy = await readFile(new URL("../privacy.html", import.meta.url), "utf8");
+  const section = /<section id="lawful-bases">[\s\S]*?<\/section>/.exec(privacy);
+  assert.notEqual(section, null, "the privacy policy must keep its basis mapping");
+  const bases = section[0];
+  assert.match(bases, /Serving a registered record, and keeping it for as long as\s+the registry exists,<\/strong>\s+rest on legitimate interests/);
+  assert.doesNotMatch(
+    bases,
+    /Publishing a registry record<\/strong> rests on your consent/,
+    "publication may not be based on the submitter's consent",
+  );
+  // The interest has to be named rather than asserted, and the Article 21
+  // right has to say that an objection is decided and where to send it.
+  assert.match(bases, /permanence of a\s+certification record/);
+  assert.match(bases, /cannot support that claim\s+about the entries it still has/);
+  assert.match(bases, /Article 21/);
+  assert.match(bases, /An objection is decided, not automatic/);
+  assert.match(bases, /compelling legitimate grounds/);
+  assert.match(bases, /mailto:privacy@palomar-registry\.org/);
+  assert.match(bases, /PalomarPolicy\/blob\/main\/docs\/lawful-requests\.md/);
+  // Consent keeps the part where withdrawal genuinely stops the processing,
+  // and the page has to say plainly that registration ends that.
+  assert.match(bases, /Withdrawing it there genuinely stops the processing/);
+  assert.match(bases, /After registration you cannot take it back yourself/);
+  assert.match(bases, /no button that unpublishes it/);
+  // No balancing assessment exists as a separate document, so the page must
+  // not send anyone looking for one.
+  assert.match(bases, /There is\s+no separate balancing document/);
+  assert.doesNotMatch(bases, /legitimate interests assessment is available/i);
+  // Rights and retention must not drift back into describing publication as
+  // consent-based once this section stops doing so.
+  assert.doesNotMatch(privacy, /withdraw consent at any\s+time, which stops future processing/);
+});
+
 test("About describes both ways push access is proved", async () => {
   // A sign-in and the agent's tag-and-gist do not establish the same thing,
   // and step 3 used to name only the first.


### PR DESCRIPTION
This PR maps each purpose in the privacy policy to one lawful basis, and scopes consent to the processing a submitter can actually stop. Consent covers Palomar processing a submitter's own data to run a submission that is still open: intake, the push-access check, the dispatch, the editorial review, and the private submission record while any of that is live. Withdrawing ends that workflow, publishes no record and no review, and scrubs the private record in the same write that closes it. Everything that outlives a submission is on legitimate interests under Article 6(1)(f), and was from the start: the dispatched public verification run, the retained audit history, personal data about anyone other than the submitter, and, after registration, serving and keeping the record itself.

Consent must be as easy to withdraw as to give, and withdrawal must stop the processing. After registration it cannot: there is no submitter-facing ordinary takedown route, and a version leaves public view only by a Moderator decision under the lawful-request process. Basing publication on consent meant claiming a basis nobody could withdraw, and it meant one record claiming two bases for the same publication, since the co-authors, cited-source authors, maintainers and committers a record names never interacted with Palomar. A submitter cannot consent for them, so their data is on legitimate interests from collection and neither withdrawal nor registration moves it.

The interest is stated as the registry already argues it: the permanence of a certification record, and through that the integrity of every other entry, because a registry that can quietly lose an entry cannot support its claim about the entries it still has. The balancing reasoning is set out inline and says plainly that no separate balancing document exists. It weighs the three kinds of published personal data separately rather than as one bibliography-like whole: repository metadata and the names and addresses in preserved commit history, the authorization relationship and free-text evidence a submitter typed about somebody who may never have seen the submission, and generated review comments that discuss named people and can repeat a private note.

Article 21 is stated at its actual width. Anyone may object to legitimate-interest processing of personal data concerning them, on grounds relating to their situation; it is not a power over a mathematical record, and since a registry record names no submitter, a submitter's own objection reaches comparatively little of one. An objection is decided rather than automatic, a refusal names its ground, and suppression is an outcome an upheld objection may produce rather than the measure of the right.

The page says without softening that a submitter cannot unilaterally revoke a registration, and what is available instead. It also describes withdrawal at the availability the Server actually implements: available while a submission is open, including the states where Palomar itself has gone wrong, and unavailable in the four closed states, so a submission can end unregistered without the scrub ever being offered. About gains the matching sentence where it offers the choice between registering and withdrawing. Regression tests pin the mapping, the scope of consent, the withdrawal states, the objection right, the named interest, and the balancing account.

🤖 Prepared with Claude Code