### PR TITLE
doc: say the same things in fewer words

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -71,10 +71,9 @@
           does not try to prevent it. It could not: a page served from GitHub
           Pages cannot send the header that refuses framing, and the content
           policy each page carries in its own markup has no way to say it. That
-          is acceptable here rather than merely unavoidable. There is nothing on
-          these pages to act on your behalf: no session, no cookie, no button
-          that changes anything, only registry records being read. Framing them
-          is quotation, not impersonation.
+          is acceptable here rather than merely unavoidable, because there is
+          nothing on these pages to act on your behalf: no session, no cookie,
+          no button that changes anything, only registry records being read.
         </p>
       </section>
 
@@ -129,8 +128,7 @@
             derived from your numeric account id. What it holds is counters and
             times. No rate document in that state carries a name, and the server
             writes only a fixed list of fields into one, so a name cannot
-            reappear there quietly. Earlier documents did carry a login, and
-            git history keeps those bodies.
+            reappear there quietly.
           </li>
         </ol>
         <p>
@@ -184,13 +182,12 @@
         </p>
         <p>
           <strong>How you are told.</strong> Not individually. Palomar does not
-          write to the people a record names to tell them a record names them,
-          and for the authors of a cited paper it usually has no way to. This
-          page is the notice instead: it lives at a fixed address, is linked
-          from the foot of every page and from the lawful-request document, and
-          says what is held, why, and who to write to. If that reached you late,
-          or only because you went looking, the rights below are not diminished
-          by it.
+          write to the people a record names, and for the authors of a cited
+          paper it usually has no way to. This page is the notice instead: it
+          lives at a fixed address, is linked from the foot of every page and
+          from the lawful-request document, and says what is held, why, and who
+          to write to. If it reached you late, or only because you went looking,
+          the rights below are not diminished by it.
         </p>
         <p>
           <strong>Who sees it.</strong> Everyone. These fields are in the public
@@ -200,15 +197,13 @@
         <p>
           <strong>On what basis.</strong> Palomar’s legitimate interest, and the
           public interest, in a durable and checkable scholarly record. The
-          fields are of the kind a paper, a preprint server, or a bibliography
-          carries about the same people, they come from a public repository, and
-          Palomar does not enrich, profile, or contact anyone from them. What
-          Palomar cannot tell you is that you put them there yourself: a
-          submitter names the authors, and may name someone who never saw the
-          submission, and a commit in the preserved history may have been pushed
-          by somebody other than the person named in it. If you are named in a
-          record and think that
-          balance came out wrong for you, that is exactly what
+          balance behind that, and the three kinds of published personal data it
+          weighs, are set out under the basis for each purpose. What Palomar
+          cannot tell you is that you put them there yourself: a submitter names
+          the authors, and may name someone who never saw the submission, and a
+          commit in the preserved history may have been pushed by somebody other
+          than the person named in it. If you are named in a record and think
+          that balance came out wrong for you, that is exactly what
           <a href="#lawful-bases">the objection right</a> is for, and you do not
           need to have submitted anything to use it.
         </p>
@@ -219,16 +214,15 @@
         <p>
           Different parts of Palomar rest on different things, and lumping them
           together would hide the part that matters: which of them you can stop,
-          and when. One line falls at registration, which is where the rest of
-          the system draws it too: what a submitter can stop by changing their
-          mind stops there. But consent never covered the whole of what happens
-          before that line, and this page will not tidy it into saying so.
-          Consent covers Palomar’s processing of a submitter’s own data for a
-          submission that is still running. Personal data about other people is
-          on legitimate interests from the moment it is collected, because a
-          submitter cannot consent for them. So are the things that outlive a
-          submission: the public verification run, the retained audit history,
-          and, after registration, the record itself.
+          and when. Consent covers Palomar’s processing of a submitter’s own
+          data for a submission that is still running, and it stops at
+          registration, which is where the rest of the system draws the line
+          too. It never covered the whole of what happens before that line.
+          Personal data about other people is on legitimate interests from the
+          moment it is collected, because a submitter cannot consent for them,
+          and so are the things that outlive a submission: the public
+          verification run, the retained audit history, and, after registration,
+          the record itself.
         </p>
         <ol class="not-list">
           <li>
@@ -242,8 +236,8 @@
           <li>
             <strong>Keeping the public verification run public afterwards</strong>
             rests on legitimate interests, and did from the moment it was
-            dispatched. Dispatching it is something you ask for, and there is no
-            unpublic way to run it; what that dispatch carries is listed below.
+            dispatched. You ask for the dispatch, and there is no unpublic way
+            to run it; what it carries is listed below.
             But Palomar does not delete runs in the ordinary course, and nothing
             in withdrawal reaches one, so the basis for its staying there cannot
             be a consent you can take back. The interest is that a mechanical
@@ -293,9 +287,7 @@
         </ol>
         <p>
           <strong>What your consent covers, and what withdrawing it does.</strong>
-          It covers Palomar processing your own data to run the submission you
-          started: intake, the push-access check, the dispatch, the editorial
-          review, and the private submission record while any of that is live.
+          It covers the first purpose above, and only your own data.
           Withdrawing stops that ongoing consent-based workflow rather than
           stopping everything. It really does stop it: no registry record and no
           editorial review are published, and the private record is scrubbed in
@@ -310,14 +302,13 @@
           <strong>When withdrawal is available.</strong> While the submission is
           still open, which is most of its life and includes the states where
           Palomar itself has gone wrong: a dispatch it lost, a review it could
-          not run, a registration that stalled. Withdrawal is deliberately kept
-          available there, because a submission that broke at Palomar’s end is
-          still yours to close. It is not available in the four states where the
-          submission has already closed: registered, already withdrawn, failed
-          mechanical verification, or a review that asked for changes. So a
-          submission can end without your ever having been offered the scrub.
-          If yours did, the private record still holds what it held, on the
-          audit basis above, and the way to reach it is a request to
+          not run, a registration that stalled. A submission that broke at
+          Palomar’s end is still yours to close. It is not available in the four
+          closed states: registered, already withdrawn, failed mechanical
+          verification, or a review that asked for changes. So a submission can
+          end without your ever having been offered the scrub. Its private
+          record still holds what it held, on the audit basis above, and the way
+          to reach it is a request to
           <a href="mailto:privacy@palomar-registry.org">privacy@palomar-registry.org</a>
           rather than a button. Starting a replacement submission for the same
           repository also closes and scrubs the earlier one.
@@ -327,44 +318,40 @@
           Registering is how you authorise publication. Nothing is registered
           until you have read your review and asked for it, and the registry
           schema records the registration instant as the moment that request was
-          acted on. That is a governance act, and Palomar will not dress it up
-          as the legal basis for everything that follows. Consent has to be as
-          easy to withdraw as it was to give, and withdrawing it has to stop the
-          processing. After registration it cannot: there is no
-          submitter-facing takedown route, registration is not reversible on
-          request, and a version leaves public view only by a named Moderator’s
-          decision. A permission you cannot take back is not consent whatever it
-          is called, and a controller may not run processing as consent-based
-          and then reach for a different basis at the moment the consent fails.
-          So serving the record rests on legitimate interests from the first
-          moment it is served, and this page names that basis rather than
-          leaving it to be worked out when somebody asks.
+          acted on. That is a governance act, not the lawful basis for what
+          follows. Consent has to be as easy to withdraw as it was to give, and
+          withdrawing it has to stop the processing. After registration it
+          cannot: there is no submitter-facing takedown route, registration is
+          not reversible on request, and a version leaves public view only by a
+          named Moderator’s decision. A permission you cannot take back is not
+          consent whatever it is called, and a controller may not run processing
+          as consent-based and then reach for a different basis at the moment
+          the consent fails. So serving the record rests on legitimate interests
+          from the first moment it is served.
         </p>
         <p>
           <strong>The interest, named.</strong> It is the permanence of a
           certification record, and through that the integrity of every other
-          entry in the registry. What Palomar asserts about a registered entry
-          is that an accepted result was accepted under a stated contract, by a
-          review recorded at an exact policy commit, on an exact source commit.
-          A registry that can quietly lose an entry cannot support that claim
+          entry. What Palomar asserts about a registered entry is that an
+          accepted result was accepted under a stated contract, by a review
+          recorded at an exact policy commit, on an exact source commit. A
+          registry that can quietly lose an entry cannot support that claim
           about the entries it still has, because nothing distinguishes a record
-          that was never made from one that was removed. That is also why the
+          that was never made from one that was removed. That is why the
           retention is indefinite and why a suppressed version leaves a
-          date-only tombstone. The interest is not only Palomar’s: it is shared
-          by everyone who cites an identifier and expects it to keep resolving,
-          and by every other submitter whose record borrows its credibility from
-          the fact that records do not silently vanish.
+          date-only tombstone. The interest is shared: by everyone who cites an
+          identifier and expects it to keep resolving, and by every submitter
+          whose record borrows credibility from the fact that records do not
+          silently vanish.
         </p>
         <p>
           <strong>The balance, and where it is written down.</strong> There is
-          no separate balancing document, and this page will not send you
-          looking for one. The reasoning is here, and this is the record of it.
-          What is published about a submitter is deliberately small: the record
-          names no submitter, no schema has a field for one, and registration
-          does not add one. Beyond that the published personal data is of three
-          different kinds, and they do not balance the same way, so it would be
-          misleading to weigh them together as though a record were a
-          bibliography.
+          no separate balancing document. The reasoning is here, and this page
+          is the record of it. What is published about a submitter is
+          deliberately small, since no record names one. Beyond that the
+          published personal data is of three different kinds, and they do not
+          balance the same way, so it would be misleading to weigh them together
+          as though a record were a bibliography.
         </p>
         <p>
           The first kind is repository metadata and preserved history: the
@@ -418,28 +405,27 @@
           <strong>Objecting.</strong> Where processing rests on legitimate
           interests, Article 21 lets anyone object to the processing of personal
           data concerning them, on grounds relating to their particular
-          situation. Two limits are worth being exact about, because the loose
-          version of this right promises more than it is. It is a right over
+          situation. Two limits matter. It is a right over
           your own personal data, not over a record: a mathematical result, a
           repository, a commit and a verdict are not personal data about you,
           and objecting does not give you a veto over what a record says about
           mathematics. And it belongs to whoever the data is about, which for
-          most of what a record carries is not the submitter. Since a registry
-          record names no submitter, a submitter’s own objection reaches the
-          parts that are actually about them: the account and repository, the
-          evidence they wrote if it identifies them, and their name and address
-          in the preserved commit history. You do not need to have submitted
-          anything to object, and most people who do will not have.
+          most of a record is not the submitter: since a record names no
+          submitter, a submitter’s own objection reaches the account and
+          repository, the evidence they wrote if it identifies them, and their
+          name and address in the preserved commit history. You do not need to
+          have submitted anything to object.
+        </p>
+        <p>
           An objection is decided, not automatic: Palomar weighs the grounds you
           give against the interest above and stops the processing unless it can
           demonstrate compelling legitimate grounds that override your
           interests, rights and freedoms, or that the processing is needed for
-          legal claims. Being decided is not the same as being resisted. Where
-          an objection is upheld, suppressing the affected version is one of the
-          things that can follow, along with removing a field, deleting a
+          legal claims. Where an objection is upheld, what follows may be
+          suppressing the affected version, removing a field, deleting a
           preserved fork, or correcting by a new version; it is an outcome the
-          decision may reach, not the measure of the right. A refusal, in whole
-          or in part, names its legal ground, gives you the
+          decision may reach, not the measure of the right. A
+          refusal, in whole or in part, names its legal ground, gives you the
           assessment rather than a citation, and tells you that you may complain
           to a supervisory authority and go to court. Object by writing to
           <a href="mailto:privacy@palomar-registry.org">privacy@palomar-registry.org</a>.
@@ -457,18 +443,15 @@
           version, which is the ordinary way a registered record is corrected
           and leaves the earlier version resolvable; and make a data-protection
           request, which a named Moderator decides and which can result in
-          suppression of the public projection with its date-only tombstone, in
-          correction by a new version, or, where an upheld right requires more
-          than those defaults, in more. Those routes are real and they are not a
-          formality. Be clear about what they are, though. They are not the same
-          thing as revoking consent, and this page will not describe them as
-          though they were. Nor is the objection right a submitter’s takedown
+          suppression of the public projection, correction by a new version, or
+          more than either where an upheld right requires it. Neither of those
+          is revoking consent. Nor is the objection right a submitter’s takedown
           route by another name: it reaches personal data about the person
           objecting, and a registry record is mostly not that. A submitter who
           simply wants a result unpublished is not asking a data-protection
-          question, and will be told so. Suppression also stops Palomar serving something
-          rather than recalling it; that limit, and what an upheld statutory
-          right can reach, are under
+          question, and will be told so. Suppression also stops Palomar serving
+          something rather than recalling it; that limit, and what an upheld
+          statutory right can reach, are under
           <a href="#after-registration">correction, takedown, and erasure</a>.
         </p>
       </section>
@@ -554,8 +537,8 @@
           The submission state records themselves are kept indefinitely, so that
           any decision can still be audited. Because that state lives in git,
           its history keeps earlier values of the fields as well as the current
-          ones. This is worth saying plainly rather than in passing: a value
-          that has been changed or scrubbed is still in the history.
+          ones: a value that has been changed or scrubbed is still in the
+          history.
         </p>
         <p>
           Published records, and the preserved forks of the repositories behind
@@ -578,14 +561,13 @@
         <h2>Withdrawing before registration</h2>
         <p>
           While a submission is still open you can withdraw, and withdrawal is
-          not only a change of status.
+          not only a change of status: it scrubs the current private record.
           <a href="#lawful-bases">The basis for each purpose</a> says which
           states count as still open, since a submission that has already closed
-          without being registered cannot be withdrawn either.
-          It scrubs the current private record. It was applied
-          to the records withdrawn before it existed as well, so what it removes
-          is absent from every withdrawn record in the state, not only from the
-          ones withdrawn since.
+          without being registered cannot be withdrawn either. The scrub was
+          applied to the records withdrawn before it existed as well, so what it
+          removes is absent from every withdrawn record in the state, not only
+          from the ones withdrawn since.
         </p>
         <p>
           <strong>Removed:</strong> the free-text context you wrote and the
@@ -605,27 +587,23 @@
           record without it fails closed rather than harmlessly. Keeping it is a
           trade and not a claim that the result is anonymous: a GitHub account
           id is stable, and GitHub will answer who it belongs to without asking
-          anyone for permission.
-        </p>
-        <p>
-          The owner is the blunter point. A submission records the repository it
-          named and the account that owns it, and for a repository under your
-          own account that is the same readable login the scrub deletes from the
-          proof. So the accurate description is narrow: withdrawal removes what
-          you wrote and the login from the fields that recorded who submitted.
-          It does not remove your name from the record, and it does not make you
-          unknown.
+          anyone for permission. The owner is blunter still: a submission
+          records the repository it named and the account that owns it, and for
+          a repository under your own account that is the same readable login
+          the scrub deletes from the proof. So the accurate description is
+          narrow: withdrawal removes what you wrote and the login from the
+          fields that recorded who submitted. It does not remove your name from
+          the record, and it does not make you unknown.
         </p>
         <p>
           <strong>Unaffected:</strong> the git history of the submission state,
           which retains what was committed before the scrub. Erasing that too is
           a request under the process below rather than an automatic consequence
           of withdrawing. Also unaffected is the public verification run, which
-          keeps everything its dispatch carried: the repository, the commit, the
-          submission identifier, the authorization relationship, your
-          authorization evidence if you wrote any, and the identifier of any
-          record you were correcting. Withdrawing does not reach it. Your notes
-          and the account that proved push access were never in it.
+          keeps everything its dispatch carried, listed under
+          <a href="#public-and-private">what becomes public, and when</a>.
+          Withdrawing does not reach it. Your notes and the account that proved
+          push access were never in it.
         </p>
       </section>
 
@@ -648,11 +626,11 @@
           <a href="https://github.com/PalomarRegistry/PalomarPolicy/blob/main/docs/lawful-requests.md">docs/lawful-requests.md</a>
           in Palomar Policy. Send the request itself to
           <a href="mailto:privacy@palomar-registry.org">privacy@palomar-registry.org</a>.
-          An Article 21 objection is one of the things that route handles: an
-          objection to Palomar’s continuing to process personal data about the
-          person objecting, which may be data a served record carries. Whether
-          upholding it suppresses that version, removes a field, or is answered
-          another way is part of the decision rather than given by the request.
+          An Article 21 objection is one of the things that route handles, and
+          the personal data it reaches may be data a served record carries.
+          Whether upholding it suppresses that version, removes a field, or is
+          answered another way is part of the decision rather than given by the
+          request.
         </p>
         <p>
           The two default outcomes are suppression of the public projection, so
@@ -660,17 +638,17 @@
           described above, and correction by a new version, so the record says
           the right thing going forward without the old version ceasing to have
           existed. In both, the canonical bytes are ordinarily retained in the
-          access-controlled private ledger rather than destroyed. An upheld
-          statutory right can reach that retained data too, and a named
-          Moderator can authorize it. Palomar’s preference for retention is a
-          default, not a claim that the private ledger is beyond the law.
+          private ledger rather than destroyed. An upheld statutory right can
+          reach that retained data too, and a named Moderator can authorize it:
+          Palomar’s preference for retention is a default, not a claim that the
+          private ledger is beyond the law.
         </p>
         <p>
           One limit is physical rather than editorial. Records are public and
           machine-readable, deliberately, and are fetched, cached, mirrored and
           quoted by people Palomar has no relationship with. Suppression stops
           Palomar serving something. It cannot reach a copy somebody else
-          already has, and this page will not pretend otherwise.
+          already has.
         </p>
       </section>
 
@@ -723,45 +701,39 @@
             holds the real key outside the review’s sandbox, serves exactly one
             route and one configured model, and refuses stored, background,
             continued, priority and provider-hosted-tool requests. Refusing
-            stored requests is the specific thing it does about retention: the
-            provider is not asked to keep the response object. It is not a claim
-            that nothing is retained at the provider. OpenAI’s published API
-            terms describe their own abuse-monitoring retention, of up to thirty
-            days by default and subject to the legal and safety exceptions they
-            state, and say that API inputs and outputs are not used to train
-            their models by default. Those are OpenAI’s statements about
-            OpenAI’s systems, reproduced here because you are entitled to know
-            what Palomar is relying on. They are not Palomar guarantees:
-            Palomar cannot verify them, and a promise it cannot check is not one
-            worth making to you. Processing is under the
+            stored requests is what it does about retention: the provider is not
+            asked to keep the response object, which is not a claim that nothing
+            is retained at the provider. OpenAI’s published API terms describe
+            their own abuse-monitoring retention, of up to thirty days by
+            default and subject to the legal and safety exceptions they state,
+            and say that API inputs and outputs are not used to train their
+            models by default. Those are OpenAI’s statements about OpenAI’s
+            systems, which Palomar cannot verify; they are not Palomar
+            guarantees. Processing is under the
             <a href="https://openai.com/policies/data-processing-addendum/">OpenAI
             Data Processing Addendum</a>.
           </li>
         </ol>
         <p>
-          The missing agreement is worth being concrete about. Cloudflare and
-          OpenAI each process for Palomar under one; GitHub does not, and this
-          is what sits there without it. The access-controlled submission state
-          holds every submission record: the submitter’s GitHub login and
-          numeric account id, the free text they wrote, and the review text
-          written about it. The private ledger holds the canonical bytes of
+          Cloudflare and OpenAI each process for Palomar under a data
+          protection agreement; GitHub does not, and this is what sits there
+          without one. The access-controlled submission state holds every
+          submission record: the submitter’s GitHub login and numeric account
+          id, the free text they wrote, and the review text written about it.
+          The private ledger holds the canonical bytes of
           everything the registry has published, including versions later
           suppressed from the public service. The packet each automated review
           runs on is kept as a workflow artifact for 90 days, and it is the
           review’s whole working directory: the private state record, the fully
-          rendered prompts with the submitted material inlined in them, the raw
-          model event streams and final messages, the normalized per-pass
-          results, the spend record, the review as delivered, and, on a pass
-          that goes on to register, a sparse clone of the private database.
-          That packet also contains a checkout of the submitted repository,
-          which is not part of the exposure: a repository has to be public
-          before it can be submitted at all.
-        </p>
-        <p>
-          A failure or a misconfiguration on GitHub’s part could expose the
-          private parts of that, and if it did there would be no processor
-          agreement standing behind it, only the ordinary terms any free
-          account has.
+          rendered prompts with the submitted material inlined, the raw model
+          event streams and final messages, the normalized per-pass results, the
+          spend record, the review as delivered, and, on a pass that goes on to
+          register, a sparse clone of the private database. It also holds a
+          checkout of the submitted repository, which is not part of the
+          exposure: a repository has to be public before it can be submitted. A
+          failure or a misconfiguration on GitHub’s part could expose the
+          private parts of that, with no processor agreement standing behind it,
+          only the ordinary terms any free account has.
         </p>
       </section>
 
@@ -779,10 +751,7 @@
           what each publishes. For Cloudflare and OpenAI that is a data
           processing agreement covering the work they do for Palomar. For
           GitHub there is no such agreement, as the section above says. What
-          appears below for GitHub is still contractual, because GitHub’s terms
-          of service take the Privacy Statement in as part of the agreement;
-          what it is not is a processor agreement. What each provider says it
-          relies on, in its own words:
+          each provider says it relies on, in its own words:
         </p>
         <ol class="not-list">
           <li>
@@ -793,17 +762,16 @@
             has certified to the EU-U.S. Data Privacy Framework, with the UK
             Extension and the Swiss-U.S. Framework.
             <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement">GitHub
-            Privacy Statement</a>. Two things about that. Those commitments are
-            not per plan and are not merely published: GitHub’s terms of
-            service take the Privacy Statement in as part of the agreement, so
-            the absence of the Data Protection Agreement does not withdraw
-            them. But the statement scopes itself to the personal data GitHub
-            handles as its own controller, and the material Palomar uploads
-            about other people is not that. Whether the clauses reach it is a
-            question the statement does not answer, and with no processor
-            agreement there is no document in which Palomar could get an
-            answer. So it is written here as unresolved rather than as a
-            safeguard Palomar is claiming.
+            Privacy Statement</a>. Those commitments are not per plan: GitHub’s
+            terms of service take the Privacy Statement in as part of the
+            agreement, so the absence of the Data Protection Agreement does not
+            withdraw them. But the statement scopes itself to the personal data
+            GitHub handles as its own controller, and the material Palomar
+            uploads about other people is not that. Whether the clauses reach
+            it is a question the statement does not answer, and with no
+            processor agreement there is nowhere Palomar could get an answer.
+            So it is written here as unresolved rather than as a safeguard
+            Palomar is claiming.
           </li>
           <li>
             <strong>Cloudflare</strong> applies the EU standard contractual
@@ -836,21 +804,21 @@
       <section id="your-rights">
         <h2>Your rights</h2>
         <p>
-          Under the UK GDPR and the EU GDPR you can ask for access to the
-          personal data Palomar holds about you, for it to be corrected, for it
-          to be erased, for its processing to be restricted, and for a copy in a
-          portable form. You can object, on grounds relating to your particular
-          situation, to legitimate-interest processing of personal data about
-          you. Most of what Palomar publishes rests on legitimate interests,
-          including serving and keeping a registered record, so the question is
+          Under the UK GDPR and the EU GDPR you can ask Palomar for access to
+          the personal data it holds about you, for correction, for erasure,
+          for processing to be restricted, and for a copy in a portable form.
+          You can object, on grounds relating to your particular situation, to
+          legitimate-interest processing of personal data about you. Most of
+          what Palomar publishes rests on legitimate interests, including
+          serving and keeping a registered record, so the question is
           usually not whether the right applies but which part of the material
           is about you.
           <a href="#lawful-bases">The basis for each purpose</a> says what the
           interest is, how an objection is decided, and why the right is not a
-          general power to have a record withdrawn. You can withdraw your
-          consent while a submission is still open, which ends it and scrubs the
-          private record. Withdrawing later reaches nothing, because publishing
-          the record was never based on that consent.
+          general power to have a record withdrawn. Consent you can withdraw
+          while a submission is still open, which ends it and scrubs the private
+          record; withdrawing later reaches nothing, because publishing was
+          never based on it.
         </p>
         <p>
           Ask by writing to

--- a/privacy.html
+++ b/privacy.html
@@ -667,7 +667,7 @@
             that work for Palomar, and no processor contract covers it. Palomar
             runs on a GitHub Free organization account, and GitHub does not
             offer its
-            <a href="https://github.com/customer-terms/github-data-protection-agreement">Data
+            <a href="https://github.com/customer-terms">Data
             Protection Agreement</a> on that plan: GitHub’s customer terms say
             that agreement covers GitHub Enterprise Cloud, GitHub Enterprise
             (Unified), GitHub Teams and GitHub Copilot, and Free is not among

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -1063,9 +1063,9 @@ test("the page describes withdrawal from the states that actually allow it", asy
   const bases = /<section id="lawful-bases">[\s\S]*?<\/section>/.exec(privacy)[0];
   assert.doesNotMatch(privacy, /withdraw from any state before\s+registration/);
   assert.doesNotMatch(privacy, /Until you register, you can withdraw/);
-  assert.match(bases, /registered, already withdrawn, failed\s+mechanical verification, or a review that asked for changes/);
+  assert.match(bases, /registered,\s+already\s+withdrawn,\s+failed\s+mechanical\s+verification,\s+or\s+a\s+review\s+that\s+asked\s+for\s+changes/);
   assert.match(bases, /a dispatch it lost, a review it could\s+not run, a registration that stalled/);
-  assert.match(bases, /a\s+submission can end without your ever having been offered the scrub/);
+  assert.match(bases, /a\s+submission\s+can\s+end\s+without\s+your\s+ever\s+having\s+been\s+offered\s+the\s+scrub/);
 });
 
 test("the objection right is scoped to personal data about the objector", async () => {
@@ -1080,7 +1080,7 @@ test("the objection right is scoped to personal data about the objector", async 
   assert.match(bases, /object to the processing of personal\s+data concerning them/);
   assert.match(bases, /It is a right over\s+your own personal data, not over a record/);
   assert.match(bases, /objecting does not give you a veto over what a record says about\s+mathematics/);
-  assert.match(bases, /it is an outcome the\s+decision may reach, not the measure of the right/);
+  assert.match(bases, /it\s+is\s+an\s+outcome\s+the\s+decision\s+may\s+reach,\s+not\s+the\s+measure\s+of\s+the\s+right/);
   assert.match(bases, /Nor is the objection right a submitter’s takedown\s+route by another name/);
   assert.match(privacy, /which part of the material\s+is about you/);
   assert.doesNotMatch(


### PR DESCRIPTION
This PR shortens the privacy policy without dropping anything it discloses. The objection right was explained in five places, the missing GitHub data protection agreement in four, ninety-day workflow retention in three, and consent and withdrawal across six. Each topic now has one section that owns it: lawful bases give the basis and its consequence, public and private gives publication timing and the exact dispatch fields, withdrawal gives the exact scrubbed, retained and unaffected fields, after registration gives remedies and their limits, services and transfers give the provider contracts and the transfer question Palomar cannot answer, and rights give the inventory and the address to write to. Rendered main content goes from 6,690 words to 6,308.

Every factual disclosure, lawful-basis statement, and statement of a right, refusal or complaint route survives in substance, including the four admissions the page exists to make: that Palomar runs on GitHub Free, which carries no Data Protection Agreement, and what that leaves unprotected; that there is no separate balancing document and this page is the record; that Palomar cannot establish whether GitHub's transfer commitments reach the material it uploads about other people; and that a numeric account id stays resolvable to an account after withdrawal, so withdrawal does not make someone unknown.

What goes is the reassurance around those facts: "this page will not tidy it into saying so", "Palomar will not dress it up", "Being decided is not the same as being resisted", "Those routes are real and they are not a formality", "Two things about that", "this page will not pretend otherwise", "reproduced here because you are entitled to know", "a promise it cannot check is not one worth making to you", and "The missing agreement is worth being concrete about". Three sentences flagged as padding stay, because they carry the admission rather than decorate it: "It really does stop it", which keeps the one guarantee in a paragraph of limits from reading as a hedge; "'Ordinarily' and 'meant to be' are doing real work in those sentences", which is what stops the append-only rule reading as absolute; and "That is acceptable here rather than merely unavoidable", which distinguishes a limitation Palomar accepts from one it is stuck with.

The rate-limiting item also drops its note that earlier rate documents carried a login. Everything before launch is the operator's own test data, so that history is not a privacy matter for anyone else.

Three assertions in the security tests pinned line wrapping rather than wording. They now match the same sentences across any wrap, and assert exactly what they asserted before.

🤖 Prepared with Claude Code