### PR TITLE
docs: clarify Comparator version identity

### DIFF
--- a/about.html
+++ b/about.html
@@ -182,7 +182,7 @@
           submission is verified and reviewed from scratch, and if it is accepted
           and you choose to register it, it becomes the next version of that same
           identifier. The repository, project directory, and Comparator
-          configuration must match the existing entry.
+          configuration path must match the existing entry.
         </p>
         <p>
           Every version stays permanently resolvable at


### PR DESCRIPTION
## Summary

Clarify that version updates must retain the Comparator configuration **path**, while the configuration contents may evolve with the submitted commit.

## Testing

- `PALOMAR_DATABASE_CHECKOUT=/home/kim/palomar/PalomarDatabase npm test`