### PR TITLE
feat: keep the subject filters on the toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,8 @@ ever used keeps answering after its last classifier is superseded, so an empty
 page is an answer and not a 404.
 
 The toolbar also filters the rows the landing page holds by text or trust, with
-the arXiv and MSC2020 subject inputs tucked behind a "Subject filters"
-disclosure until a deep link such as `?arxiv=math.AG` opens it; the opened
-inputs take room in the toolbar rather than floating over the rows below. The
-classification fields suggest codes represented by those rows but also accept
+the arXiv and MSC2020 subject inputs on its line, at its right edge, and a deep
+link such as `?arxiv=math.AG` fills them in. The classification fields suggest codes represented by those rows but also accept
 any exact code, so such a deep link produces a useful empty result even before
 that classification has an entry. That filter is over `recent.json`, which is
 the newest 200 current versions and not the registry, so it narrows what is on

--- a/assets/app.js
+++ b/assets/app.js
@@ -472,10 +472,10 @@ async function renderIndex() {
     };
     applyCategoryParameter(arxiv, "arxiv", 32);
     applyCategoryParameter(msc, "msc", 5);
-    // A deep link that filters by subject is a request to act on it, so the
-    // hidden-until-opened controls are opened by the parameters that use them.
-    // The fallback selector keeps cached HTML from the previous deployment
-    // (which has no disclosure) working unchanged.
+    // The subject inputs are always on the toolbar now. Cached HTML from a
+    // previous deployment still keeps them behind a disclosure, so a deep link
+    // that filters by subject opens it there rather than leaving the page
+    // filtered by controls the reader cannot see.
     const advancedFilters = document.querySelector(".advanced-filters");
     if (advancedFilters && (params.has("arxiv") || params.has("msc"))) {
       advancedFilters.open = true;

--- a/assets/style.css
+++ b/assets/style.css
@@ -323,46 +323,15 @@ button:focus-visible {
   gap: .35rem;
 }
 
-/* The opened inputs take a row of the toolbar rather than floating over the
-   rows below it: a panel that covers the first card hides part of the answer
-   a subject deep link was asking for. Its own row also keeps the toggle from
-   widening and squeezing the controls beside it. */
-.advanced-filters[open] {
-  flex-basis: 100%;
-}
-
-.advanced-filters summary {
-  width: fit-content;
-  min-height: 2rem;
-  padding: .25rem .5rem;
-  border: 1px solid var(--field);
-  border-radius: 0;
-  background: var(--control);
-  color: var(--ink);
-  cursor: pointer;
-  font: .8rem var(--sans);
-}
-
-.advanced-filters summary:hover {
-  background: var(--control-hover);
-}
-
-.advanced-filters[open] summary {
-  border-color: var(--ink);
-  background: var(--paper);
-  font-weight: bold;
-}
-
-.advanced-filters .category-filters {
-  margin-top: .35rem;
-  padding: .6rem .7rem;
-  border: 1px solid var(--line);
-  background: var(--paper);
-}
-
+/* The subject inputs are small enough to sit beside the trust filters, so they
+   stay on the toolbar's line rather than behind a disclosure. Aligning them to
+   the end keeps that line readable when the toolbar is wider than its
+   contents. */
 .category-filters {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
   gap: .45rem .75rem;
   font: .8rem var(--sans);
 }
@@ -1155,14 +1124,9 @@ pre {
     flex-wrap: wrap;
   }
 
-  .advanced-filters {
+  .category-filters {
+    justify-content: flex-start;
     width: 100%;
-  }
-
-  .advanced-filters .category-filters {
-    margin-top: .4rem;
-    padding: 0;
-    border: 0;
   }
 
   .card-top,

--- a/index.html
+++ b/index.html
@@ -54,19 +54,16 @@
             <button class="filter" type="button" data-trust="high" aria-pressed="false">Mathlib only</button>
             <button class="filter" type="button" data-trust="qualified" aria-pressed="false">Additional libraries</button>
           </div>
-          <details class="advanced-filters">
-            <summary>Subject filters</summary>
-            <div class="category-filters" role="group" aria-label="Subject filters">
-              <label>arXiv:
-                <input id="arxiv-query" type="search" list="arxiv-options" maxlength="32" placeholder="e.g. math.CO" autocomplete="off" spellcheck="false">
-              </label>
-              <datalist id="arxiv-options"></datalist>
-              <label>MSC:
-                <input id="msc-query" type="search" list="msc-options" maxlength="5" placeholder="e.g. 05C10" autocomplete="off" spellcheck="false">
-              </label>
-              <datalist id="msc-options"></datalist>
-            </div>
-          </details>
+          <div class="category-filters" role="group" aria-label="Subject filters">
+            <label>arXiv:
+              <input id="arxiv-query" type="search" list="arxiv-options" maxlength="32" placeholder="e.g. math.CO" autocomplete="off" spellcheck="false">
+            </label>
+            <datalist id="arxiv-options"></datalist>
+            <label>MSC:
+              <input id="msc-query" type="search" list="msc-options" maxlength="5" placeholder="e.g. 05C10" autocomplete="off" spellcheck="false">
+            </label>
+            <datalist id="msc-options"></datalist>
+          </div>
         </div>
 
         <div id="status" class="status" role="status">

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -310,9 +310,8 @@ test("an unavailable recent summary reports failure instead of emptiness", async
 
 test("registry entries can be filtered by arXiv and MSC classifications", async ({ page }) => {
   await page.goto(`/?database=${database}`);
-  // The subject inputs sit behind the toolbar's disclosure until opened.
-  await page.locator(".advanced-filters summary").click();
-  await expect(page.locator('.advanced-filters')).toHaveAttribute("open", "");
+  await expect(page.locator("#arxiv-query")).toBeVisible();
+  await expect(page.locator("#msc-query")).toBeVisible();
   await expect(page.locator('#arxiv-options option[value="math.NT"]')).toHaveCount(1);
   await expect(page.locator('#msc-options option[value="05C10"]')).toHaveCount(1);
 
@@ -332,8 +331,7 @@ test("registry entries can be filtered by arXiv and MSC classifications", async 
 
 test("classification filters apply from a deep link", async ({ page }) => {
   await page.goto(`/?database=${database}&arxiv=math.NT`);
-  // A linked subject filter opens the disclosure that holds its inputs.
-  await expect(page.locator(".advanced-filters")).toHaveAttribute("open", "");
+  await expect(page.locator("#arxiv-query")).toBeVisible();
   await expect(page.locator("#arxiv-query")).toHaveValue("math.NT");
   await expect(page.locator(".entry-card:visible")).toHaveCount(1);
   await expect(page.locator(".entry-card:visible")).toContainText("000124");
@@ -490,19 +488,24 @@ test("the licence caveat travels with the licence evidence it qualifies", async 
   await expect(collapse.locator("dl.details")).toContainText("Repository licence");
 });
 
-test("the subject filters make room in the toolbar instead of covering the list", async ({ page }) => {
+test("the subject filters share the toolbar's line, ending at its right edge", async ({ page }) => {
   await page.goto(`/?database=${database}`);
   const card = page.locator(".entry-card").first();
-  const top = await card.boundingBox();
 
-  await page.locator(".advanced-filters summary").click();
-  const inputs = await page.locator(".advanced-filters .category-filters").boundingBox();
-  const moved = await card.boundingBox();
+  const toolbar = await page.locator(".toolbar").boundingBox();
+  const trust = await page.locator(".filters").boundingBox();
+  const inputs = await page.locator(".category-filters").boundingBox();
+  const listed = await card.boundingBox();
 
-  // The opened panel pushes the list down; nothing it would otherwise float
-  // over, such as the first card's trust label, is hidden by it.
-  expect(inputs.y + inputs.height).toBeLessThanOrEqual(moved.y);
-  expect(moved.y).toBeGreaterThan(top.y);
+  // One line: the subject inputs start after the trust filters end, and their
+  // vertical centres agree.
+  expect(inputs.x).toBeGreaterThan(trust.x + trust.width);
+  expect(Math.abs((inputs.y + inputs.height / 2) - (trust.y + trust.height / 2)))
+    .toBeLessThan(4);
+  // Justified right, and still clear of the list below.
+  expect(Math.abs((inputs.x + inputs.width) - (toolbar.x + toolbar.width)))
+    .toBeLessThan(16);
+  expect(inputs.y + inputs.height).toBeLessThanOrEqual(listed.y);
 });
 
 test("a thin wrapper says where the mathematics is before anything else", async ({ page }) => {
@@ -762,7 +765,6 @@ test("a card says the original is unavailable exactly when the manifest says so"
   const card = page.locator(".entry-card").first();
   await expect(card).toHaveCount(1);
   await availabilityRequested;
-  await page.locator(".advanced-filters summary").click();
   await page.locator("#arxiv-query").fill("math.CO");
   await expect(page.locator(".entry-card:visible")).toHaveCount(1);
   await page.locator("#arxiv-query").evaluate((input) => input.focus());
@@ -2016,7 +2018,6 @@ test("a provisional match the index does not confirm is taken away", async ({ pa
 test("emptying the box gives the listing and its filters back", async ({ page }) => {
   await page.goto(`/?database=${database}`);
   // Set before searching, because a search takes the toolbar off the page.
-  await page.locator(".advanced-filters summary").click();
   await page.locator("#arxiv-query").fill("math.CO");
   await expect(page.locator(".entry-card:visible")).toHaveCount(1);
 
@@ -2146,9 +2147,8 @@ for (const scheme of ["light", "dark"]) {
     await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
     await readableTextOnly(page, `${scheme} listing`, 40);
 
-    await page.locator(".advanced-filters summary").click();
     await expect(page.locator("#arxiv-query")).toBeVisible();
-    await readableTextOnly(page, `${scheme} listing with the subject filters open`, 40);
+    await readableTextOnly(page, `${scheme} listing with the subject filters`, 40);
 
     // The state this check exists for. The provisional cards are drawn on their
     // own ground, and the first attempt at setting them apart faded them.


### PR DESCRIPTION
This PR puts the arXiv and MSC2020 inputs on the toolbar's line, at its right edge, instead of behind a "Subject filters" disclosure. The toolbar has room for them, so a reader who wants to narrow the listing by subject no longer has to discover a toggle first, and a deep link such as `?arxiv=math.AG` arrives with visible controls holding the value it set. Below 700px they wrap to their own row with the rest of the toolbar.

The disclosure-opening code stays for cached HTML from the previous deployment, which still has the toggle.

🤖 Prepared with Claude Code