### PR TITLE
Gate inline statements only by line count

### DIFF
--- a/assets/rendering.js
+++ b/assets/rendering.js
@@ -1,5 +1,4 @@
 export const INLINE_CHALLENGE_MAX_LINES = 100;
-export const INLINE_CHALLENGE_MAX_BYTES = 32 * 1024;
 
 // A constant of the render format rather than a field to read. A record still
 // declares it, and is refused below if it declares anything else.
@@ -11,19 +10,11 @@ const SHA256 = /^[0-9a-f]{64}$/;
 const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 
 export function isInlineChallenge(entry) {
-  const formalization = entry?.formalization;
   const trust = entry?.trust;
-  const theoremNames = formalization?.theorem_names;
-  const definitionNames = formalization?.definition_names;
-  if (!Array.isArray(theoremNames) || !Array.isArray(definitionNames)) return false;
   return (
-    theoremNames.length + definitionNames.length === 1 &&
     Number.isInteger(trust?.challenge_lines) &&
     trust.challenge_lines >= 0 &&
-    trust.challenge_lines <= INLINE_CHALLENGE_MAX_LINES &&
-    Number.isInteger(trust?.challenge_bytes) &&
-    trust.challenge_bytes >= 0 &&
-    trust.challenge_bytes <= INLINE_CHALLENGE_MAX_BYTES
+    trust.challenge_lines <= INLINE_CHALLENGE_MAX_LINES
   );
 }
 

--- a/tests/rendering.test.js
+++ b/tests/rendering.test.js
@@ -43,16 +43,16 @@ function entry(overrides = {}) {
   return Object.assign(value, overrides);
 }
 
-test("inline policy includes both size limits and exactly one declaration", () => {
+test("inline policy is based only on the statement line count", () => {
   assert.equal(isInlineChallenge(entry()), true);
   assert.equal(isInlineChallenge(entry({ trust: { challenge_lines: 101, challenge_bytes: 1 } })), false);
   assert.equal(
     isInlineChallenge(entry({ trust: { challenge_lines: 1, challenge_bytes: 32 * 1024 + 1 } })),
-    false,
+    true,
   );
   const two = entry();
   two.formalization.definition_names.push("Example.definition");
-  assert.equal(isInlineChallenge(two), false);
+  assert.equal(isInlineChallenge(two), true);
 });
 
 test("artifact URL is derived only from the content-addressed registry fields", () => {


### PR DESCRIPTION
## Summary
- remove the declaration-count restriction from inline statement rendering
- remove the byte-size restriction so the 100-line limit is the sole eligibility rule
- update the policy regression test for multi-declaration and over-32-KiB statements

## Tests
- npm test (230 passed)
- browser suite with Nixpkgs Chromium (79 passed, 2 skipped)