### PR TITLE
Stop presenting Terry's AI review synthesis as an abstract

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -26,6 +26,7 @@ import { createFormalizationPresentation } from "./formalization-presentation.mj
 import { createRegistryLoader } from "./registry-loading.mjs";
 import { createStatementPreview } from "./statement-preview.mjs";
 import { renderSubjectPage } from "./subject-pages.mjs";
+import { presentationAbstract } from "./presentation-text.mjs";
 import {
   bindSourceControl,
   createSourceAvailabilityBinding,
@@ -279,7 +280,7 @@ function searchBlob(entry) {
   const categories = classification(entry);
   return [
     entry.title,
-    entry.abstract,
+    presentationAbstract(entry),
     authorNames(entry),
     theoremNames(entry),
     entry.source.repository,
@@ -316,7 +317,7 @@ function entryCard(
   // than left to work it out from what is missing.
   statementPreview.register(titleLink, entry);
   title.append(titleLink);
-  const abstract = el("p", "card-abstract", entry.abstract);
+  const abstract = presentationAbstract(entry);
   const meta = el("div", "card-meta");
   const authors = el("div");
   authors.append(el("small", "", "Authors"), el("span", "", authorNames(entry)));
@@ -361,7 +362,9 @@ function entryCard(
     historyLink.setAttribute("aria-label", `${versionCount} versions of ${entry.id}`);
     footer.append(historyLink);
   }
-  card.append(top, title, abstract, meta, footer);
+  card.append(top, title);
+  if (abstract) card.append(el("p", "card-abstract", abstract));
+  card.append(meta, footer);
   return card;
 }
 
@@ -1211,7 +1214,9 @@ async function renderEntry(
   const heading = el("header", "entry-heading");
   const top = el("div", "card-top");
   top.append(el("span", "entry-id", `${entry.id} v${entry.version}`), trustBadge(entry));
-  heading.append(top, el("h1", "", entry.title), el("p", "lede", entry.abstract));
+  heading.append(top, el("h1", "", entry.title));
+  const abstract = presentationAbstract(entry);
+  if (abstract) heading.append(el("p", "lede", abstract));
   const byline = el("p", "byline", `By ${authorNames(entry)}`);
   heading.append(byline);
 
@@ -1488,7 +1493,8 @@ function renderSubjectRows(rows, content) {
     const title = el("h2");
     title.append(internalLink(row.title, localPageUrl("entry.html", row)));
     article.append(identity, title);
-    if (row.abstract) article.append(el("p", "card-abstract", row.abstract));
+    const abstract = presentationAbstract(row);
+    if (abstract) article.append(el("p", "card-abstract", abstract));
     const subjects = el("div", "card-subjects");
     subjects.append(el("small", "", "Subjects"), categoryTokens(row));
     article.append(subjects);

--- a/assets/presentation-text.mjs
+++ b/assets/presentation-text.mjs
@@ -1,0 +1,13 @@
+// Accepted entry records are immutable. This one record was registered before
+// Palomar stopped using an AI review synthesis as an abstract fallback, so its
+// canonical bytes must remain available while reader-facing surfaces suppress
+// the text that was never supplied or endorsed by the submitter.
+const SUPPRESSED_ABSTRACTS = new Set([
+  "PALOMAR-2026-08-13-000001-v1",
+]);
+
+export function presentationAbstract(entry) {
+  const key = `${entry.id}-v${entry.version}`;
+  if (SUPPRESSED_ABSTRACTS.has(key)) return "";
+  return entry.abstract;
+}

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -21,6 +21,7 @@ const browserModuleFiles = [
   "entry-pages.mjs",
   "formalization-presentation.mjs",
   "loading.mjs",
+  "presentation-text.mjs",
   "registry-loading.mjs",
   "rendering.js",
   "searching.mjs",

--- a/tests/presentation-text.test.mjs
+++ b/tests/presentation-text.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { presentationAbstract } from "../assets/presentation-text.mjs";
+
+test("the accidentally published AI review synthesis is not presentation text", () => {
+  assert.equal(
+    presentationAbstract({
+      id: "PALOMAR-2026-08-13-000001",
+      version: 1,
+      abstract: "AI-generated editorial synthesis.",
+    }),
+    "",
+  );
+});
+
+test("submitter-authored abstracts and later corrected versions remain visible", () => {
+  assert.equal(
+    presentationAbstract({
+      id: "PALOMAR-2026-08-08-000001",
+      version: 3,
+      abstract: "A submitter-authored description.",
+    }),
+    "A submitter-authored description.",
+  );
+  assert.equal(
+    presentationAbstract({
+      id: "PALOMAR-2026-08-13-000001",
+      version: 2,
+      abstract: "A corrected submitter-authored description.",
+    }),
+    "A corrected submitter-authored description.",
+  );
+});


### PR DESCRIPTION
Terry's immutable v1 entry accidentally contains the AI review synthesis in its `abstract` field. Preserve the canonical record bytes, but suppress that text from reader-facing cards, the entry lede, subject rows, and local search.

Other submitter-authored abstracts remain visible. The actionable novelty warning remains in the explicitly labelled AI review comments section; the synthesis remains available only as part of the archived review evidence.

Tests:
- 232/232 Node tests
- Playwright with Nixpkgs Chromium: 79 passed, 2 expected skips