### PR TITLE
Add Lean Playground overlay to rendered challenges

### DIFF
--- a/assets/challenge-presentation.mjs
+++ b/assets/challenge-presentation.mjs
@@ -171,14 +171,24 @@ export function createChallengePresentation({ fetchJson, document, window, local
     );
   }
 
-  function challengeFrame(entry, renderBase) {
+  function challengeFrame(entry, renderBase, playgroundLink = null) {
     // An entry page mounts one of these and keeps it for the page's lifetime,
     // so it never disposes. A surface that mounts and discards them has to.
-    return createRenderFrame({
+    const frame = createRenderFrame({
       src: challengeArtifactUrl(entry, renderBase).href,
       title: `Named compared declarations for ${entry.id} version ${entry.version}`,
       lazy: true,
     }).frame;
+    const shell = el("div", "challenge-frame-shell");
+    shell.append(frame);
+    if (playgroundLink) {
+      playgroundLink.className += " challenge-playground-button";
+      playgroundLink.textContent = "Lean ↗";
+      playgroundLink.setAttribute("aria-label", "Open in Lean Playground");
+      playgroundLink.setAttribute("title", "Open in Lean Playground");
+      shell.append(playgroundLink);
+    }
+    return shell;
   }
 
   function metadataPanel(metadata) {
@@ -245,19 +255,20 @@ export function createChallengePresentation({ fetchJson, document, window, local
         "challenge-source",
       ),
     );
-    if (entry.trust.level === "high") {
-      links.append(
-        " · ",
-        sourceLink(
-          "Open in Lean Playground",
-          availability,
-          (manifest) => challengePlaygroundUrl(
-            entry,
-            topSourceLocation(entry, manifest).repository,
-          ),
-          "challenge-playground",
+    const playgroundLink = entry.trust.level === "high"
+      ? sourceLink(
+        "Open in Lean Playground",
+        availability,
+        (manifest) => challengePlaygroundUrl(
+          entry,
+          topSourceLocation(entry, manifest).repository,
         ),
-      );
+        "challenge-playground",
+      )
+      : null;
+    if (playgroundLink) {
+      playgroundLink.setAttribute("target", "_blank");
+      playgroundLink.setAttribute("rel", "noopener");
     }
     links.append(
       " · ",
@@ -271,6 +282,14 @@ export function createChallengePresentation({ fetchJson, document, window, local
       ),
     );
     const inline = isInlineChallenge(entry);
+    const showsFrame = forceFrame || inline;
+    let playgroundIsFallback = false;
+    const appendPlaygroundFallback = () => {
+      if (!playgroundLink || playgroundIsFallback) return;
+      links.append(" · ", playgroundLink);
+      playgroundIsFallback = true;
+    };
+    if (!showsFrame) appendPlaygroundFallback();
     if (!forceFrame && !inline) {
       links.append(
         " · ",
@@ -294,6 +313,7 @@ export function createChallengePresentation({ fetchJson, document, window, local
       );
     } catch (error) {
       if (error.status !== 404) throw error;
+      appendPlaygroundFallback();
       section.append(
         el(
           "p",
@@ -305,8 +325,8 @@ export function createChallengePresentation({ fetchJson, document, window, local
     }
     section.append(metadataPanel(metadata));
 
-    if (forceFrame || inline) {
-      section.append(challengeFrame(entry, renderBase));
+    if (showsFrame) {
+      section.append(challengeFrame(entry, renderBase, playgroundLink));
     } else {
       section.append(
         el(

--- a/assets/style.css
+++ b/assets/style.css
@@ -873,6 +873,50 @@ footer {
   background: var(--paper);
 }
 
+/* The playground control belongs to the trusted parent page, not to the
+   immutable sandboxed rendering. It sits over the frame like Zulip's code
+   playground affordance while remaining usable from the keyboard and on
+   devices without hover. */
+.challenge-frame-shell {
+  position: relative;
+}
+
+.challenge-playground-button {
+  position: absolute;
+  top: .5rem;
+  right: .5rem;
+  z-index: 1;
+  padding: .3rem .5rem;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  box-shadow: 0 1px 4px rgb(0 0 0 / 25%);
+  color: var(--ink);
+  font: bold .75rem/1.2 var(--sans);
+  opacity: 0;
+  pointer-events: none;
+  text-decoration: none;
+}
+
+.challenge-playground-button:visited {
+  color: var(--ink);
+}
+
+.challenge-frame-shell:hover .challenge-playground-button,
+.challenge-frame-shell:focus-within .challenge-playground-button {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.challenge-playground-button:hover,
+.challenge-playground-button:focus-visible {
+  color: var(--link);
+}
+
+.challenge-playground-button:focus-visible {
+  outline: 2px solid var(--link);
+  outline-offset: 2px;
+}
+
 /* Raised by resting on a card title, over the grid rather than in it, so the
    listing does not reflow under the pointer that asked for this. */
 .statement-preview {
@@ -900,6 +944,11 @@ footer {
      browser that answers the two differently. */
   .statement-preview {
     display: none;
+  }
+
+  .challenge-playground-button {
+    opacity: 1;
+    pointer-events: auto;
   }
 }
 

--- a/tests/challenge-presentation.test.mjs
+++ b/tests/challenge-presentation.test.mjs
@@ -152,7 +152,9 @@ test("an inline presentation keeps links confined and accepts height only from i
   assert.equal(byClass(result.section, "challenge-no-module-doc").length, 1);
   assert.equal(byClass(result.section, "challenge-fallback").length, 0);
   const [frame] = byClass(result.section, "challenge-frame");
+  const [shell] = byClass(result.section, "challenge-frame-shell");
   assert.ok(frame);
+  assert.deepEqual(shell.children, [frame, byClass(result.section, "challenge-playground")[0]]);
   assert.equal(frame.getAttribute("sandbox"), "allow-scripts");
   assert.equal(frame.getAttribute("scrolling"), "auto");
   assert.equal(frame.referrerPolicy, "no-referrer");
@@ -166,6 +168,13 @@ test("an inline presentation keeps links confined and accepts height only from i
     `https://github.com/example/challenge/blob/${record.source.commit}/Challenge.lean`,
   );
   const [playground] = byClass(result.section, "challenge-playground");
+  assert.equal(byClass(result.section, "challenge-playground-button").length, 1);
+  assert.equal(byClass(byClass(result.section, "challenge-links")[0], "challenge-playground").length, 0);
+  assert.equal(playground.textContent, "Lean ↗");
+  assert.equal(playground.getAttribute("aria-label"), "Open in Lean Playground");
+  assert.equal(playground.getAttribute("title"), "Open in Lean Playground");
+  assert.equal(playground.getAttribute("target"), "_blank");
+  assert.equal(playground.getAttribute("rel"), "noopener");
   assert.equal(
     playground.href,
     `https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2Fexample%2Fchallenge%2F${record.source.commit}%2FChallenge.lean`,
@@ -271,6 +280,10 @@ test("a missing large entry render keeps its source controls and uses the missin
   assert.match(fallback.textContent, /formatted statement is not available/);
   assert.deepEqual(pageCalls.map(([page]) => page), ["entry.html", "render.html"]);
   assert.ok(byClass(result.section, "challenge-source")[0].href.startsWith("https://github.com/"));
+  const [playground] = byClass(result.section, "challenge-playground");
+  assert.equal(playground.textContent, "Open in Lean Playground");
+  assert.equal(byClass(result.section, "challenge-playground-button").length, 0);
+  assert.equal(byClass(byClass(result.section, "challenge-links")[0], "challenge-playground").length, 1);
 });
 
 test("transport and correspondence failures remain fatal to the containing route", async (t) => {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -983,14 +983,23 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/project/Comparator/Task.lean`,
   );
   await expect(source).toHaveText("View full pinned statement file (Task.lean)");
-  await expect(
-    page.getByRole("link", { name: "Open in Lean Playground" }),
-  ).toHaveAttribute(
+  const playground = page.getByRole("link", { name: "Open in Lean Playground" });
+  await expect(playground).toHaveAttribute(
     "href",
     `https://live.lean-lang.org/#url=https%3A%2F%2Fraw.githubusercontent.com%2Fexample%2Fchallenge%2F${
       "1".repeat(40)
     }%2Fproject%2FComparator%2FTask.lean`,
   );
+  await expect(playground).toHaveAttribute("target", "_blank");
+  await expect(playground).toHaveAttribute("rel", "noopener");
+  await expect(playground).toHaveText("Lean ↗");
+  await expect(playground).toHaveCSS("opacity", "0");
+  const frameShell = page.locator(".challenge-frame-shell");
+  await frameShell.hover({ position: { x: 4, y: 4 } });
+  await expect(playground).toHaveCSS("opacity", "1");
+  await page.mouse.move(0, 0);
+  await playground.focus();
+  await expect(playground).toHaveCSS("opacity", "1");
   await expect(
     page.getByRole("link", { name: "Inspect statement dependencies" }),
   ).toHaveAttribute("href", /#statement-dependencies$/);
@@ -1115,7 +1124,23 @@ test("a missing formatted Challenge leaves the accepted entry and pinned source 
     "href",
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/project/Comparator/Task.lean`,
   );
+  const playground = page.getByRole("link", { name: "Open in Lean Playground" });
+  await expect(playground).toBeVisible();
+  await expect(playground).toHaveText("Open in Lean Playground");
+  await expect(playground).not.toHaveClass(/challenge-playground-button/);
   await expect(page.locator("#status")).toBeHidden();
+});
+
+test("the playground overlay remains visible without hover", async ({ browser }) => {
+  const context = await browser.newContext({ hasTouch: true, isMobile: false });
+  const page = await context.newPage();
+  await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`);
+
+  const playground = page.getByRole("link", { name: "Open in Lean Playground" });
+  await expect(playground).toHaveClass(/challenge-playground-button/);
+  await expect(playground).toHaveCSS("opacity", "1");
+  await expect(playground).toHaveCSS("pointer-events", "auto");
+  await context.close();
 });
 
 test("larger Challenge falls back to the dedicated wrapper", async ({ page }) => {


### PR DESCRIPTION
## Summary

- place the Mathlib playground link over the top-right of rendered Challenge statements
- reveal it on hover or keyboard focus and keep it visible on touch devices
- retain the ordinary text link when a render is unavailable or shown on its dedicated page
- preserve source-archive URL updates and cached-deployment compatibility

## Testing

- `npm test` (234 passed)
- `PALOMAR_PREVIOUS_REF=08533dd2de34bedfa534c8e627e0bc37a27d2b21 npm run test:browser` with Nixpkgs Chromium (82 passed)