### PR TITLE
Restore statement links and add date

### DIFF
--- a/statement.html
+++ b/statement.html
@@ -74,20 +74,23 @@
         </p>
 
         <p>
-          With this in mind, we are establishing the Palomar Registry, a new public
+          With this in mind, we are establishing the
+          <a href="https://palomar-registry.org/">Palomar Registry</a>, a new public
           registry of Lean-verified mathematics.
         </p>
 
         <p>
-          Palomar, named after the Palomar Observatory Sky Survey, is a searchable
-          registry of Lean formalizations that have met certain requirements. The
-          role of the registry in the research publishing pipeline is similar to
-          that of a repository or preprint server: it provides a durable, indexable
-          record of formalizations of results of interest to the mathematical
-          research community. As is the case with repositories like arXiv, the
-          appearance of a work in the registry does not constitute a certificate of
-          novelty, nor a certification of relevance, nor a certification that the
-          verified statement matches the informal statement.
+          Palomar, named after the
+          <a href="http://astro.caltech.edu/~george/dposs/">Palomar Observatory Sky Survey</a>,
+          is a searchable registry of Lean formalizations that have met certain
+          requirements. The role of the registry in the research publishing
+          pipeline is similar to that of a repository or preprint server: it
+          provides a durable, indexable record of formalizations of results of
+          interest to the mathematical research community. As is the case with
+          repositories like arXiv, the appearance of a work in the registry does
+          not constitute a certificate of novelty, nor a certification of
+          relevance, nor a certification that the verified statement matches the
+          informal statement.
         </p>
 
         <p>
@@ -96,27 +99,31 @@
         </p>
         <ul class="statement-technologies">
           <li>
-            Every submission must use the comparator technology developed by the
-            Lean FRO, which ensures a clean separation of the statement of the
-            theorem and its proof, allowing readers of the Palomar record to know
-            exactly what they need to audit (the statement), and what is being
-            ensured by Lean. Further, comparator allows Palomar to securely check
-            the proof (even in the face of adversarial Lean proofs).
+            Every submission must use the
+            <a href="https://github.com/leanprover/comparator">comparator</a>
+            technology developed by the Lean FRO, which ensures a clean separation
+            of the statement of the theorem and its proof, allowing readers of the
+            Palomar record to know exactly what they need to audit (the statement),
+            and what is being ensured by Lean. Further, comparator allows Palomar
+            to securely check the proof (even in the face of adversarial Lean
+            proofs).
           </li>
           <li>
-            Every submission must have a formalization.yaml file. This is a recent
-            standard developed by the Mathlib Initiative, which provides a standard
-            structure for describing the provenance and status of a formal proof.
-            There are fields for recording collaborations (in particular with
-            authors of an original informal proof), for recording any use of AI
-            (including models and budgets), and for reporting adherence to social
-            standards (e.g. around licensing, referencing, and attribution).
+            Every submission must have a
+            <a href="https://github.com/mathlib-initiative/formalization.yaml">formalization.yaml</a>
+            file. This is a recent standard developed by the Mathlib Initiative,
+            which provides a standard structure for describing the provenance and
+            status of a formal proof. There are fields for recording collaborations
+            (in particular with authors of an original informal proof), for
+            recording any use of AI (including models and budgets), and for
+            reporting adherence to social standards (e.g. around licensing,
+            referencing, and attribution).
           </li>
           <li>
-            Palomar automatically uses Verso, the new documentation preparation
-            system developed by the Lean FRO, to render the main claimed formal
-            theorem into the web page, with inline hover information explaining the
-            meaning of Lean terms.
+            Palomar automatically uses <a href="https://verso.lean-lang.org/">Verso</a>,
+            the new documentation preparation system developed by the Lean FRO, to
+            render the main claimed formal theorem into the web page, with inline
+            hover information explaining the meaning of Lean terms.
           </li>
         </ul>
 
@@ -167,7 +174,8 @@
 
         <p class="statement-signatories">
           Jeremy Avigad, Matthew Ballard, Jaume De Dios, Nestor Guillen, Bryna Kra,
-          Kim Morrison, Terence Tao, Ravi Vakil, and Akshay Venkatesh.
+          Kim Morrison, Terence Tao, Ravi Vakil, and Akshay Venkatesh.<br>
+          <time datetime="2026-08-18">18 August 2026</time>
         </p>
       </article>
     </main>


### PR DESCRIPTION
## Summary

- restore the five hyperlinks embedded in the original Palomar statement PDF
- link comparator, `formalization.yaml`, Verso, the Palomar Registry, and the Palomar Observatory Sky Survey
- add 18 August 2026 beneath the signatories

## Why

The PDF-to-HTML conversion preserved the visible prose but dropped its link annotations, leaving important project and technology references as plain text. The signatory block also had no date.

## User impact

Readers can now follow every link carried by the source statement, and the statement records the date alongside its signatories.

## Checks

- `npm run build -- --output .site-test-statement-links --version statement-links`
- built-page assertion for all five URLs and the semantic `2026-08-18` date
- `npm test`: 234 passed, 3 producer-contract tests failed because the local sibling `PalomarDatabase` checkout no longer contains `schema-v2.json` and publishes a newer landing-card status; these failures are unrelated to this HTML-only change
