### PR TITLE
Use extensionless public URLs

### DIFF
--- a/404.html
+++ b/404.html
@@ -27,7 +27,7 @@
     </main>
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="/privacy.html">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="/privacy">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
   </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Registry cards display the identifier, registration date, title, abstract,
 authors, theorems, arXiv and MSC2020 classifications, and source links, all
 without opening anything: a title here is a repository name, so the authors and
 the theorem are what identify a row while scanning. Every classification code is
-a link to `subject.html?kind=<arxiv|msc>&code=<code>`, glossed with its
+a link to `/subject?kind=<arxiv|msc>&code=<code>`, glossed with its
 description on hover and in the accessibility tree: a code is not a subject, and
 neither `52C10` nor `math.MG` says what it is. The two taxonomy tables are
 vendored under `assets/data/` from the snapshot PalomarSubmission validates
@@ -245,7 +245,7 @@ active history when older snapshots exist.
 An entry URL with both `id` and `version` identifies one immutable snapshot:
 
 ```text
-https://palomar-registry.org/entry.html?id={permanent-ID}&version={integer-version}
+https://palomar-registry.org/entry?id={permanent-ID}&version={integer-version}
 ```
 
 Its HTML canonical link points to that same official, explicit version,

--- a/about.html
+++ b/about.html
@@ -8,6 +8,7 @@
     <meta name="theme-color" content="#101216" media="(prefers-color-scheme: dark)">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>About — Palomar</title>
+    <link rel="canonical" href="https://palomar-registry.org/about">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="assets/style.css">
   </head>
@@ -17,9 +18,9 @@
       <a class="brand" href="./">Palomar</a>
       <nav aria-label="Main navigation">
         <a href="./">Registry</a>
-        <a href="statement.html">Statement</a>
-        <a class="active" href="about.html" aria-current="page">About</a>
-        <a href="how-to-submit.html">How to submit</a>
+        <a href="/statement">Statement</a>
+        <a class="active" href="/about" aria-current="page">About</a>
+        <a href="/how-to-submit">How to submit</a>
       </nav>
     </header>
 
@@ -402,7 +403,7 @@
         <p>
           The proof is not restricted this way: dependencies used only by the
           Solution may be arbitrary pinned Git repositories. The full rules are
-          under <a href="how-to-submit.html#comparator-requirements">what Comparator requires</a>.
+          under <a href="/how-to-submit#comparator-requirements">what Comparator requires</a>.
         </p>
       </section>
 
@@ -484,7 +485,7 @@
 
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="privacy.html">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="/privacy">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/about.js"></script>
   </body>

--- a/assets/app.js
+++ b/assets/app.js
@@ -311,7 +311,7 @@ function entryCard(
   );
   top.append(identity, trustBadge(entry));
   const title = el("h3");
-  const titleLink = internalLink(entry.title, localPageUrl("entry.html", entry));
+  const titleLink = internalLink(entry.title, localPageUrl("/entry", entry));
   // The card is built from a landing row on one grid and from a whole
   // validated record on the other. The preview is told which it has rather
   // than left to work it out from what is missing.
@@ -336,7 +336,7 @@ function entryCard(
   }
   const footer = el("div", "card-footer");
   const location = topSourceLocation(entry, null);
-  const historyUrl = new URL(localPageUrl("entry.html", entry));
+  const historyUrl = new URL(localPageUrl("/entry", entry));
   historyUrl.hash = "version-history";
   footer.append(
     externalLink(
@@ -344,7 +344,7 @@ function entryCard(
       pinnedRepositoryDirectoryUrl(entry.source.repository, entry.source.commit),
       "repo-link",
     ),
-    internalLink("View record", localPageUrl("entry.html", entry)),
+    internalLink("View record", localPageUrl("/entry", entry)),
   );
   footer.append(
     externalLink(
@@ -953,7 +953,7 @@ function localPageUrl(page, entry) {
 }
 
 function subjectPageUrl(kind, code) {
-  const target = new URL("subject.html", window.location.href);
+  const target = new URL("/subject", window.location.href);
   target.search = "";
   target.searchParams.set("kind", kind);
   target.searchParams.set("code", code);
@@ -1491,7 +1491,7 @@ function renderSubjectRows(rows, content) {
       el("span", "entry-date", `Registered ${displayDate(registrationDate(row.published_at))}`),
     );
     const title = el("h2");
-    title.append(internalLink(row.title, localPageUrl("entry.html", row)));
+    title.append(internalLink(row.title, localPageUrl("/entry", row)));
     article.append(identity, title);
     const abstract = presentationAbstract(row);
     if (abstract) article.append(el("p", "card-abstract", abstract));

--- a/assets/challenge-presentation.mjs
+++ b/assets/challenge-presentation.mjs
@@ -239,7 +239,7 @@ export function createChallengePresentation({ fetchJson, document, window, local
     // render page does not carry them, so from there it is a trip somewhere else.
     const dependencyRecordUrl = dependenciesOnThisPage
       ? new URL("#statement-dependencies", window.location.href)
-      : localPageUrl("entry.html", entry);
+      : localPageUrl("/entry", entry);
     if (!dependenciesOnThisPage) dependencyRecordUrl.hash = "statement-dependencies";
     const comparatorPath = entry.formalization.comparator_config_path;
     const challengePath = entry.formalization.challenge_path;
@@ -293,7 +293,7 @@ export function createChallengePresentation({ fetchJson, document, window, local
     if (!forceFrame && !inline) {
       links.append(
         " · ",
-        internalLink("Open formatted statement", localPageUrl("render.html", entry)),
+        internalLink("Open formatted statement", localPageUrl("/render", entry)),
       );
     }
     section.append(links);

--- a/assets/entry-history-presentation.mjs
+++ b/assets/entry-history-presentation.mjs
@@ -19,14 +19,14 @@ export function createEntryHistoryPresentation({ document, localPageUrl, window 
   function localLink(text, entry) {
     const node = el("a", "", text);
     node.href = safeInternalUrl(
-      localPageUrl("entry.html", entry),
+      localPageUrl("/entry", entry),
       window.location.href,
     ).href;
     return node;
   }
 
   function canonicalEntryPageUrl(entry) {
-    const target = new URL("entry.html", CANONICAL_WEB_BASE);
+    const target = new URL("entry", CANONICAL_WEB_BASE);
     target.searchParams.set("id", entry.id);
     target.searchParams.set("version", String(entry.version));
     return safeExternalUrl(target);

--- a/assets/entry-pages.mjs
+++ b/assets/entry-pages.mjs
@@ -66,7 +66,7 @@ export async function renderEntryPage({
     }
     const { entry } = loaded;
     if (version === null) {
-      const resolvedUrl = localPageUrl("entry.html", entry);
+      const resolvedUrl = localPageUrl("/entry", entry);
       resolvedUrl.hash = requestedHash;
       history.replaceState(null, "", resolvedUrl);
     }

--- a/entry.html
+++ b/entry.html
@@ -14,8 +14,8 @@
   <body data-page="entry">
     <a class="skip-link" href="#entry">Skip to entry</a>
     <header class="site-header">
-      <a class="brand" href="./">Palomar</a>
-      <nav aria-label="Main navigation"><a href="./">Registry</a><a href="statement.html">Statement</a><a href="about.html">About</a><a href="how-to-submit.html">How to submit</a></nav>
+      <a class="brand" href="/">Palomar</a>
+      <nav aria-label="Main navigation"><a href="/">Registry</a><a href="/statement">Statement</a><a href="/about">About</a><a href="/how-to-submit">How to submit</a></nav>
     </header>
     <main id="entry" class="entry-page">
       <div id="status" class="status">
@@ -31,7 +31,7 @@
     </main>
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="privacy.html">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="/privacy">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/app.js"></script>
   </body>

--- a/how-to-submit.html
+++ b/how-to-submit.html
@@ -8,6 +8,7 @@
     <meta name="theme-color" content="#101216" media="(prefers-color-scheme: dark)">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>How to submit — Palomar</title>
+    <link rel="canonical" href="https://palomar-registry.org/how-to-submit">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="assets/style.css">
   </head>
@@ -17,9 +18,9 @@
       <a class="brand" href="./">Palomar</a>
       <nav aria-label="Main navigation">
         <a href="./">Registry</a>
-        <a href="statement.html">Statement</a>
-        <a href="about.html">About</a>
-        <a class="active" href="how-to-submit.html" aria-current="page">How to submit</a>
+        <a href="/statement">Statement</a>
+        <a href="/about">About</a>
+        <a class="active" href="/how-to-submit" aria-current="page">How to submit</a>
       </nav>
     </header>
 
@@ -251,7 +252,7 @@
           not put anything sensitive in the notes field.
         </p>
         <p>
-          The <a href="privacy.html">privacy policy</a> completes this: which
+          The <a href="/privacy">privacy policy</a> completes this: which
           field is kept where, how long each is retained, what withdrawing
           before registration scrubs and what it leaves behind, and how to ask
           for something to be corrected or taken down.
@@ -284,7 +285,7 @@
           acceptance, your status page offers two choices: register, or withdraw.
           Asking to register is how you authorise the record to be served, and
           it is the last point at which the choice is yours alone. The
-          <a href="privacy.html#lawful-bases">privacy policy</a> explains that
+          <a href="/privacy#lawful-bases">privacy policy</a> explains that
           serving the record afterwards rests on Palomar's legitimate interests
           rather than on your consent, so withdrawing is not available once you
           have registered, and what you have instead is a further version or a
@@ -296,7 +297,7 @@
           not delete or rewrite the canonical record, and the public service
           retains a minimal tombstone. What that rule does not do is override a
           legal obligation Palomar is under, and the
-          <a href="privacy.html#after-registration">privacy policy</a> describes
+          <a href="/privacy#after-registration">privacy policy</a> describes
           the process by which one reaches the ledger. Acceptance is not
           registration; an accepted submission appears in the registry once the
           corresponding database pull request is merged.
@@ -322,7 +323,7 @@
 
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="privacy.html">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="/privacy">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/about.js"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <meta name="theme-color" content="#101216" media="(prefers-color-scheme: dark)">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Palomar — Lean-verified mathematics</title>
+    <link rel="canonical" href="https://palomar-registry.org/">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="assets/style.css">
     <link rel="manifest" href="site.webmanifest">
@@ -19,9 +20,9 @@
       <a class="brand" href="./" aria-label="Palomar home">Palomar</a>
       <nav aria-label="Main navigation">
         <a class="active" href="./" aria-current="page">Registry</a>
-        <a href="statement.html">Statement</a>
-        <a href="about.html">About</a>
-        <a href="how-to-submit.html">How to submit</a>
+        <a href="/statement">Statement</a>
+        <a href="/about">About</a>
+        <a href="/how-to-submit">How to submit</a>
       </nav>
     </header>
 
@@ -88,7 +89,7 @@
       <div class="footer-links">
         <a href="https://data.palomar-registry.org/feed.xml">RSS</a>
         <a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a>
-        <a href="privacy.html">Privacy</a>
+        <a href="/privacy">Privacy</a>
         <a href="https://data.palomar-registry.org/recent.json">Data</a>
         <a href="https://github.com/leanprover/comparator">Comparator</a>
         <a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a>

--- a/privacy.html
+++ b/privacy.html
@@ -8,6 +8,7 @@
     <meta name="theme-color" content="#101216" media="(prefers-color-scheme: dark)">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Privacy — Palomar</title>
+    <link rel="canonical" href="https://palomar-registry.org/privacy">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="assets/style.css">
   </head>
@@ -17,9 +18,9 @@
       <a class="brand" href="./">Palomar</a>
       <nav aria-label="Main navigation">
         <a href="./">Registry</a>
-        <a href="statement.html">Statement</a>
-        <a href="about.html">About</a>
-        <a href="how-to-submit.html">How to submit</a>
+        <a href="/statement">Statement</a>
+        <a href="/about">About</a>
+        <a href="/how-to-submit">How to submit</a>
       </nav>
     </header>
 
@@ -33,7 +34,7 @@
         that is about people: what a submitter hands over, what Palomar takes
         from the repository itself about people who never submitted anything,
         where all of it lives, and what can still be asked for afterwards.
-        <a href="how-to-submit.html#what-is-public">How to submit</a> describes the same
+        <a href="/how-to-submit#what-is-public">How to submit</a> describes the same
         arrangement from the submitter’s side; if the two ever disagree, that is
         a bug, and <a href="mailto:privacy@palomar-registry.org">tell us</a>.
       </p>
@@ -137,7 +138,7 @@
           by pushing a tag at the submitted commit and posting a gist carrying
           the same challenge. Both are artifacts on GitHub made by whichever
           account the agent used, and the gist is how that account names itself.
-          <a href="how-to-submit.html#how-to-submit">How to submit</a> explains why that route
+          <a href="/how-to-submit#how-to-submit">How to submit</a> explains why that route
           establishes less than a sign-in does.
         </p>
       </section>
@@ -461,7 +462,7 @@
         <h2>What becomes public, and when</h2>
         <p>
           This restates
-          <a href="how-to-submit.html#what-is-public">the same section of How to submit</a>,
+          <a href="/how-to-submit#what-is-public">the same section of How to submit</a>,
           which remains the fuller account.
         </p>
         <p>
@@ -842,7 +843,7 @@
           but what it decides about is a submitted repository at one commit
           rather than a person, and disagreeing with its mathematics is not a
           data-protection question.
-          <a href="about.html#disagreeing-with-the-review">About</a> says what to
+          <a href="/about#disagreeing-with-the-review">About</a> says what to
           do about that instead.
         </p>
       </section>
@@ -875,7 +876,7 @@
 
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="privacy.html">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="/privacy">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/about.js"></script>
   </body>

--- a/render.html
+++ b/render.html
@@ -13,8 +13,8 @@
   <body data-page="render">
     <a class="skip-link" href="#render">Skip to named compared declarations</a>
     <header class="site-header">
-      <a class="brand" href="./">Palomar</a>
-      <nav aria-label="Main navigation"><a href="./">Registry</a><a href="statement.html">Statement</a><a href="about.html">About</a><a href="how-to-submit.html">How to submit</a></nav>
+      <a class="brand" href="/">Palomar</a>
+      <nav aria-label="Main navigation"><a href="/">Registry</a><a href="/statement">Statement</a><a href="/about">About</a><a href="/how-to-submit">How to submit</a></nav>
     </header>
     <main id="render" class="entry-page render-page">
       <div id="status" class="status">Reading registry entry…</div>
@@ -22,7 +22,7 @@
     </main>
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="privacy.html">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="/privacy">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/app.js"></script>
   </body>

--- a/statement.html
+++ b/statement.html
@@ -8,6 +8,7 @@
     <meta name="theme-color" content="#101216" media="(prefers-color-scheme: dark)">
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
     <title>Statement — Palomar</title>
+    <link rel="canonical" href="https://palomar-registry.org/statement">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="assets/style.css">
   </head>
@@ -17,9 +18,9 @@
       <a class="brand" href="./">Palomar</a>
       <nav aria-label="Main navigation">
         <a href="./">Registry</a>
-        <a class="active" href="statement.html" aria-current="page">Statement</a>
-        <a href="about.html">About</a>
-        <a href="how-to-submit.html">How to submit</a>
+        <a class="active" href="/statement" aria-current="page">Statement</a>
+        <a href="/about">About</a>
+        <a href="/how-to-submit">How to submit</a>
       </nav>
     </header>
 
@@ -182,7 +183,7 @@
 
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="privacy.html">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="/privacy">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
   </body>
 </html>

--- a/subject.html
+++ b/subject.html
@@ -14,8 +14,8 @@
   <body data-page="subject">
     <a class="skip-link" href="#subject">Skip to results</a>
     <header class="site-header">
-      <a class="brand" href="./">Palomar</a>
-      <nav aria-label="Main navigation"><a href="./">Registry</a><a href="statement.html">Statement</a><a href="about.html">About</a><a href="how-to-submit.html">How to submit</a></nav>
+      <a class="brand" href="/">Palomar</a>
+      <nav aria-label="Main navigation"><a href="/">Registry</a><a href="/statement">Statement</a><a href="/about">About</a><a href="/how-to-submit">How to submit</a></nav>
     </header>
     <main id="subject" class="subject-page">
       <div id="status" class="status">
@@ -35,7 +35,7 @@
     </main>
     <footer>
       <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
-      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="privacy.html">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="/privacy">Privacy</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
     </footer>
     <script type="module" src="assets/app.js"></script>
   </body>

--- a/tests/appearance.test.js
+++ b/tests/appearance.test.js
@@ -110,8 +110,42 @@ test("every shipped page carries a footer link to the privacy policy", async () 
     assert.ok(footer, `${file} has no footer to carry the privacy link`);
     assert.match(
       footer,
-      /<a href="\/?privacy\.html">Privacy<\/a>/,
+      /<a href="\/privacy">Privacy<\/a>/,
       `${file} does not link the privacy policy from its footer`,
+    );
+  }
+});
+
+test("shipped navigation exposes routes rather than HTML filenames", async () => {
+  for (const file of htmlFiles) {
+    const html = await readFile(new URL(`../${file}`, import.meta.url), "utf8");
+    const hrefs = [...html.matchAll(/href="([^"]+)"/g)].map((match) => match[1]);
+    const implementationLinks = hrefs.filter((href) => {
+      const target = new URL(href, "https://palomar-registry.org/");
+      return target.origin === "https://palomar-registry.org" &&
+        /\.html$/.test(target.pathname);
+    });
+    assert.deepEqual(
+      implementationLinks,
+      [],
+      `${file} exposes HTML filenames in public links`,
+    );
+  }
+});
+
+test("fixed public pages declare extensionless canonical URLs", async () => {
+  const routes = new Map([
+    ["index.html", "/"],
+    ["about.html", "/about"],
+    ["how-to-submit.html", "/how-to-submit"],
+    ["privacy.html", "/privacy"],
+    ["statement.html", "/statement"],
+  ]);
+  for (const [file, route] of routes) {
+    const html = await readFile(new URL(`../${file}`, import.meta.url), "utf8");
+    assert.match(
+      html,
+      new RegExp(`<link rel="canonical" href="https://palomar-registry\\.org${route}">`),
     );
   }
 });
@@ -180,5 +214,5 @@ test("404.html addresses everything from the site root", async () => {
   );
   assert.match(html, /href="\/assets\/style\.css"/);
   assert.match(html, /<a href="\/">Return to the registry<\/a>/);
-  assert.match(html, /<a href="\/privacy\.html">Privacy<\/a>/);
+  assert.match(html, /<a href="\/privacy">Privacy<\/a>/);
 });

--- a/tests/challenge-presentation.test.mjs
+++ b/tests/challenge-presentation.test.mjs
@@ -278,7 +278,7 @@ test("a missing large entry render keeps its source controls and uses the missin
   assert.equal(byClass(result.section, "challenge-metadata").length, 0);
   const [fallback] = byClass(result.section, "challenge-fallback");
   assert.match(fallback.textContent, /formatted statement is not available/);
-  assert.deepEqual(pageCalls.map(([page]) => page), ["entry.html", "render.html"]);
+  assert.deepEqual(pageCalls.map(([page]) => page), ["/entry", "/render"]);
   assert.ok(byClass(result.section, "challenge-source")[0].href.startsWith("https://github.com/"));
   const [playground] = byClass(result.section, "challenge-playground");
   assert.equal(playground.textContent, "Open in Lean Playground");

--- a/tests/entry-history-presentation.test.mjs
+++ b/tests/entry-history-presentation.test.mjs
@@ -69,7 +69,7 @@ function localPageUrl(page, entry) {
   return url;
 }
 
-const window = { location: { href: "https://fixture.invalid/entry.html" } };
+const window = { location: { href: "https://fixture.invalid/entry" } };
 
 test("canonical entry links are inserted once and updated for the selected immutable version", () => {
   const document = fakeDocument();
@@ -86,7 +86,7 @@ test("canonical entry links are inserted once and updated for the selected immut
   assert.equal(document.head.children[0].rel, "canonical");
   assert.equal(
     document.head.children[0].href,
-    "https://palomar-registry.org/entry.html?id=PALOMAR-2026-08-08-000001&version=2",
+    "https://palomar-registry.org/entry?id=PALOMAR-2026-08-08-000001&version=2",
   );
 });
 
@@ -104,7 +104,7 @@ test("only a superseded version presents a labelled link to the current version"
   assert.equal(byTag(notice, "a")[0].textContent, "View current version 3");
   assert.equal(
     byTag(notice, "a")[0].href,
-    "https://fixture.invalid/entry.html?id=PALOMAR-2026-08-08-000001&version=3",
+    "https://fixture.invalid/entry?id=PALOMAR-2026-08-08-000001&version=3",
   );
 });
 
@@ -151,8 +151,8 @@ test("history is newest-first, identifies the selected snapshot, and leaves inpu
   assert.equal(byClass(list, "viewing-version").length, 1);
   assert.equal(byClass(list, "selected-version")[0].attributes.get("aria-current"), "true");
   assert.deepEqual(byTag(list, "a").map((node) => node.href), [
-    `https://fixture.invalid/entry.html?id=${id}&version=3`,
-    `https://fixture.invalid/entry.html?id=${id}&version=1`,
+    `https://fixture.invalid/entry?id=${id}&version=3`,
+    `https://fixture.invalid/entry?id=${id}&version=1`,
   ]);
   assert.deepEqual(versions, original);
 });

--- a/tests/entry-pages.test.js
+++ b/tests/entry-pages.test.js
@@ -71,7 +71,7 @@ function entryDependencies(overrides = {}) {
       location: { hash: "" },
       history: { replaceState() {} },
       loadEntry: async () => ({ tombstone: {} }),
-      localPageUrl: () => new URL("https://palomar-registry.org/entry.html"),
+      localPageUrl: () => new URL("https://palomar-registry.org/entry"),
       renderEntry: async () => {},
       renderExactTombstone: () => {},
       ...overrides,
@@ -132,9 +132,9 @@ test("unversioned entry routes expose content progressively then preserve and sc
       return loaded;
     },
     localPageUrl: (page, selected) => {
-      assert.equal(page, "entry.html");
+      assert.equal(page, "/entry");
       assert.equal(selected, entry);
-      return new URL(`https://palomar-registry.org/entry.html?id=${entry.id}&version=3`);
+      return new URL(`https://palomar-registry.org/entry?id=${entry.id}&version=3`);
     },
     renderEntry: async (...args) => {
       renderedArguments = args;
@@ -155,7 +155,7 @@ test("unversioned entry routes expose content progressively then preserve and sc
   assert.deepEqual(renderedArguments, [loaded, view.content]);
   assert.equal(replaced.state, null);
   assert.equal(replaced.title, "");
-  assert.equal(replaced.url.href, `https://palomar-registry.org/entry.html?id=${entry.id}&version=3#version-history`);
+  assert.equal(replaced.url.href, `https://palomar-registry.org/entry?id=${entry.id}&version=3#version-history`);
   assert.equal(scrolled, 1);
 });
 

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -462,6 +462,19 @@ class Handler(SimpleHTTPRequestHandler):
 
     def do_GET(self) -> None:  # noqa: N802 - inherited HTTP method name
         path = self.path.split("?", 1)[0]
+        clean_pages = {
+            "/about": "/about.html",
+            "/entry": "/entry.html",
+            "/how-to-submit": "/how-to-submit.html",
+            "/privacy": "/privacy.html",
+            "/render": "/render.html",
+            "/statement": "/statement.html",
+            "/subject": "/subject.html",
+        }
+        if path in clean_pages:
+            query = self.path[len(path) :]
+            self.path = clean_pages[path] + query
+            path = clean_pages[path]
         if path in {
             "/database/source-availability.json",
             "/database/source-availability-missing.json",

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -938,7 +938,7 @@ test("the public documentation describes the current review and version contract
   // though it outranked the law: an unqualified "permanent" would promise a
   // submitter something the lawful-request process can override.
   assert.match(guide, /does not do is override a\s+legal obligation/);
-  assert.match(guide, /href="privacy\.html#after-registration"/);
+  assert.match(guide, /href="\/privacy#after-registration"/);
   assert.doesNotMatch(guide, /Registration is permanent/);
 });
 

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -92,7 +92,7 @@ test("the render frame lands on the same paper as the page around it", async ({ 
   // agree, which is what is asserted on both sides of the boundary here.
   const paper = { dark: "rgb(16, 18, 22)", light: "rgb(255, 255, 255)" };
   await page.emulateMedia({ colorScheme: "dark" });
-  await page.goto(`/render.html?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`);
+  await page.goto(`/render?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`);
   const frame = page.locator(".challenge-presentation iframe");
   for (const scheme of ["dark", "light"]) {
     await page.emulateMedia({ colorScheme: scheme });
@@ -106,7 +106,7 @@ test("the render frame lands on the same paper as the page around it", async ({ 
 
 test("submission-guide headings expose hoverable links that copy their section URL", async ({ context, page }) => {
   await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-  await page.goto("/how-to-submit.html");
+  await page.goto("/how-to-submit");
 
   const sectionHeading = page.locator("#getting-ready h2");
   const sectionAnchor = sectionHeading.getByRole("link", { name: "Copy link to Getting ready to submit" });
@@ -119,9 +119,9 @@ test("submission-guide headings expose hoverable links that copy their section U
   await expect(sectionAnchor).toHaveCSS("opacity", "1");
 
   await sectionAnchor.click();
-  await expect(page).toHaveURL(/how-to-submit\.html#getting-ready$/);
+  await expect(page).toHaveURL(/how-to-submit#getting-ready$/);
   await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toMatch(
-    /how-to-submit\.html#getting-ready$/,
+    /how-to-submit#getting-ready$/,
   );
   await expect(page.getByRole("status")).toHaveText("Copied link to Getting ready to submit");
   await expect(sectionAnchor).toHaveClass(/copied/);
@@ -141,7 +141,7 @@ test("submission-guide headings expose hoverable links that copy their section U
 });
 
 test("every formalization.yaml mention in the submission guide links to its standard", async ({ page }) => {
-  await page.goto("/how-to-submit.html");
+  await page.goto("/how-to-submit");
   const standard = "https://github.com/mathlib-initiative/formalization.yaml";
   const result = await page.locator("main").evaluate((main, expected) => {
     const walker = document.createTreeWalker(main, NodeFilter.SHOW_TEXT);
@@ -180,7 +180,7 @@ test("landing cards show the registration date and dated identifier", async ({ p
   await expect(first.locator(".trust-badge")).toHaveText("Statement dependencies: Mathlib only");
   await expect(first.getByRole("link", { name: "2 versions" })).toHaveAttribute(
     "href",
-    /entry\.html\?.*version=2.*#version-history$/,
+    /\/entry\?.*version=2.*#version-history$/,
   );
   await expect(first.locator(".version-history-link")).toHaveAttribute(
     "aria-label",
@@ -387,22 +387,22 @@ test("an unversioned entry link resolves to the current immutable URL", async ({
   // feeds it used to link to were never published, so every one was a 404.
   await expect(page.locator(".entry-classification").getByRole("link", { name: "RSS" })).toHaveCount(0);
   const mscLink = page.locator(".entry-classification .category-link", { hasText: "05C10" });
-  await expect(mscLink).toHaveAttribute("href", /subject\.html\?kind=msc&code=05C10/);
+  await expect(mscLink).toHaveAttribute("href", /\/subject\?kind=msc&code=05C10/);
   await expect(
     page.locator(".entry-classification .category-link", { hasText: "math.CO" }),
-  ).toHaveAttribute("href", /subject\.html\?kind=arxiv&code=math\.CO/);
+  ).toHaveAttribute("href", /\/subject\?kind=arxiv&code=math\.CO/);
   // And a code nobody can read is glossed with what it means, in both
   // taxonomies: math.MG does not announce itself as metric geometry either.
   await expect(mscLink).toHaveAttribute("title", /05C10 — .+/);
   await expect(
     page.locator(".entry-classification .category-link", { hasText: "math.CO" }),
   ).toHaveAttribute("title", "math.CO — Combinatorics");
-  await expect(page).toHaveURL(/entry\.html\?id=PALOMAR-2026-07-29-000123&version=2&database=/);
+  await expect(page).toHaveURL(/\/entry\?id=PALOMAR-2026-07-29-000123&version=2&database=/);
   await expect(page).toHaveURL(/#version-history$/);
   await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
     "href",
-    "https://palomar-registry.org/entry.html?id=PALOMAR-2026-07-29-000123&version=2",
+    "https://palomar-registry.org/entry?id=PALOMAR-2026-07-29-000123&version=2",
   );
 });
 
@@ -830,7 +830,7 @@ test("entry pages list immutable versions and flag superseded snapshots", async 
   await expect(notice).toContainText("Version 2 is the current version");
   await expect(notice.getByRole("link", { name: "View current version 2" })).toHaveAttribute(
     "href",
-    /entry\.html\?.*version=2/,
+    /\/entry\?.*version=2/,
   );
 
   const history = page.locator("#version-history");
@@ -853,7 +853,7 @@ test("entry pages list immutable versions and flag superseded snapshots", async 
   );
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
     "href",
-    "https://palomar-registry.org/entry.html?id=PALOMAR-2026-07-29-000123&version=1",
+    "https://palomar-registry.org/entry?id=PALOMAR-2026-07-29-000123&version=1",
   );
 });
 
@@ -1158,7 +1158,7 @@ test("larger Challenge falls back to the dedicated wrapper", async ({ page }) =>
     "This statement is too large to display here",
   );
   await page.getByRole("link", { name: "Open formatted statement" }).click();
-  await expect(page).toHaveURL(/render\.html\?id=PALOMAR-2026-07-29-000124/);
+  await expect(page).toHaveURL(/\/render\?id=PALOMAR-2026-07-29-000124/);
   await expect(page.locator(".challenge-presentation iframe")).toHaveAttribute(
     "sandbox",
     "allow-scripts",
@@ -1168,7 +1168,7 @@ test("larger Challenge falls back to the dedicated wrapper", async ({ page }) =>
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/Challenge.lean`,
   );
   await page.getByRole("link", { name: "Inspect statement dependencies" }).click();
-  await expect(page).toHaveURL(/entry\.html\?.*#statement-dependencies$/);
+  await expect(page).toHaveURL(/\/entry\?.*#statement-dependencies$/);
   await expect(page.locator("#statement-dependencies")).toBeInViewport();
 });
 
@@ -1298,8 +1298,8 @@ test("a card's classifications are muted links, glossed on hover", async ({ page
 
   // The whole registry under that code, not the two hundred rows this page
   // happens to hold. Both taxonomies are glossed, so a row is not half live.
-  await expect(arxiv).toHaveAttribute("href", /subject\.html\?kind=arxiv&code=math\.CO/);
-  await expect(msc).toHaveAttribute("href", /subject\.html\?kind=msc&code=05C10/);
+  await expect(arxiv).toHaveAttribute("href", /\/subject\?kind=arxiv&code=math\.CO/);
+  await expect(msc).toHaveAttribute("href", /\/subject\?kind=msc&code=05C10/);
   await expect(arxiv).toHaveAttribute("title", "math.CO — Combinatorics");
   await expect(msc).toHaveAttribute("title", /^05C10 — Planar graphs/);
   // The description is a hover, not a second line: a card has no room for it
@@ -1347,7 +1347,7 @@ test("a subject page lists every current version under one code, newest first", 
   await expect(rows.first()).toContainText("PALOMAR-2026-06-03-000020");
   await expect(rows.first().locator("h2 a")).toHaveAttribute(
     "href",
-    /entry\.html\?id=PALOMAR-2026-06-03-000020&version=1/,
+    /\/entry\?id=PALOMAR-2026-06-03-000020&version=1/,
   );
   await expect(rows.last()).toContainText("PALOMAR-2026-06-01-000011");
 


### PR DESCRIPTION
## Summary

- publish internal navigation and canonical URLs without `.html` suffixes
- use extensionless routes for entry, subject, and render links
- retain the physical HTML files so existing `.html` bookmarks continue to work
- teach the local fixture server about the production-style clean routes and add regression coverage

## Why

GitHub Pages already serves these files through extensionless routes. Authoring links with physical filenames exposed a hosting implementation detail in public URLs and canonical metadata.

## Checks

- `PALOMAR_DATABASE_CHECKOUT=... npm test` (239 passed)
- `npm run test:browser` with system Chromium (79 passed, 2 skipped; one transient existing licence-copy failure passed immediately in isolation)