### PR TITLE
Describe registered results without AI acceptance language

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           mkdir -p palomar-database/tests/fixtures
           curl --fail --silent --show-error --retry 3 \
-            "$PUBLIC_DATA_ORIGIN/schema-v2.json" \
-            --output palomar-database/schema-v2.json
+            "$PUBLIC_DATA_ORIGIN/schema-v3.json" \
+            --output palomar-database/schema-v3.json
           curl --fail --silent --show-error --retry 3 \
             "$PUBLIC_DATA_ORIGIN/recent.json" \
             --output palomar-database/tests/fixtures/recent.json

--- a/.github/workflows/publish-health.yml
+++ b/.github/workflows/publish-health.yml
@@ -64,8 +64,8 @@ jobs:
             "$DATA/source-availability-targets.json" |
             jq -e '.schema_version == 1 and (.targets | type == "array")' >/dev/null
           for forbidden in \
-            https://palomar-data-staging.palomar-server.workers.dev/schema-v2.json \
-            https://palomar-data.palomar-server.workers.dev/schema-v2.json; do
+            https://palomar-data-staging.palomar-server.workers.dev/schema-v3.json \
+            https://palomar-data.palomar-server.workers.dev/schema-v3.json; do
             if curl --fail --silent --show-error --max-time 10 "$forbidden" >/dev/null; then
               echo "::error::$forbidden is a second public front door"
               exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,8 @@ jobs:
         run: |
           mkdir -p palomar-database/tests/fixtures
           curl --fail --silent --show-error --retry 3 \
-            "$PUBLIC_DATA_ORIGIN/schema-v2.json" \
-            --output palomar-database/schema-v2.json
+            "$PUBLIC_DATA_ORIGIN/schema-v3.json" \
+            --output palomar-database/schema-v3.json
           curl --fail --silent --show-error --retry 3 \
             "$PUBLIC_DATA_ORIGIN/recent.json" \
             --output palomar-database/tests/fixtures/recent.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
     'export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=$(command -v chromium); npm run test:browser'
   ```
 
-- `npm test` reads `schema-v2.json` and `tests/fixtures/recent.json` out of a
+- `npm test` reads `schema-v3.json` and `tests/fixtures/recent.json` out of a
   PalomarDatabase checkout, from
   `PALOMAR_DATABASE_CHECKOUT` or a sibling `../PalomarDatabase/`. An
   unavailable contract is a failure rather than a skip, deliberately: the point
@@ -50,22 +50,18 @@
   every row the producer advertises. The traversal reconciles those surfaces;
   it cannot independently prove that their common producer omitted nothing.
 
-- Entry records have one contract: `schema_version: 2` in `schema-v2.json`.
-  Version 1 was an unused pre-launch draft; do not restore its validator,
-  preservation fallback, public schema download, or legacy presentation.
-  Deploy this consumer cleanup before the matching Database deletion: the live
-  data already contains only v2 entries and preservation-backed recent rows,
-  while the previous Web workflows still fetch `schema-v1.json` and would fail
-  as soon as Database publication removed it. This consumer-first ordering is
-  specific to deleting an artifact an old consumer still requests; shape
-  changes to documents the browser reads remain producer-first as above.
-  The consumer-first claim must be proved by `check-published.mjs --data`, which
+- Entry records have one contract: `schema_version: 3` in `schema-v3.json`.
+  Superseded drafts have no validator, preservation fallback, public schema
+  download, or legacy presentation. The schema-v3 review-language cutover was
+  deployed producer-first with its rewritten public data; do not infer an
+  endorsement from a legacy positive review value. The consumer contract must
+  be proved by `check-published.mjs --data`, which
   traverses every advertised browse page and per-ID version index and validates
   every advertised active entry before Pages artifact upload. A recent-only
   sample is not enough.
-  `recent.json`, versions, browse/search, source availability, and independent
-  render/evidence metadata intentionally retain their schema-v1 protocols;
-  entry-schema cleanup must not rewrite them.
+  `recent.json`, versions, and browse/search/subject projections use their
+  schema-v2 protocols. Source availability and independent render/evidence
+  metadata retain their own versioned contracts.
 
 - `source-availability.json` is normalized by PalomarDatabase's executable
   source-availability contract and consumed under the same per-endpoint

--- a/README.md
+++ b/README.md
@@ -108,19 +108,19 @@ in-flight/settled read. Each attempt has one 30-second deadline. A 404 is a
 stable page-scoped absence, while a timeout, transport failure, or invalid
 document is evicted so a later explicit consumer attempt can issue one retry.
 Validation builds a private lookup for the `R` availability rows, and source
-presentation builds one private lookup for each accepted record's preservation
+presentation builds one private lookup for each registered record's preservation
 rows—`D` rows in total across the page. Decorating its source controls therefore
 takes `O(R + D)` work for the page, with constant-time repository/revision
 lookups afterward, rather than rescanning both arrays for every dependency.
 These lookups and the exact fields they consume are captured in private
 `WeakMap` receipts at successful validation, so later mutation cannot change
-accepted presentation data. They do not alter the public JSON and are available
+validated presentation data. They do not alter the public JSON and are available
 only to documents that passed the current validators.
 
 The browser code keeps the data boundary separate from presentation:
 `security.mjs` validates registry and availability documents, owns endpoint
-freshness, and privately indexes accepted availability rows;
-`source-preservation.mjs` privately indexes each accepted preservation receipt,
+freshness, and privately indexes validated availability rows;
+`source-preservation.mjs` privately indexes each validated preservation receipt,
 matches its manifest observations, resolves repository locations, publishes the
 progressive entry result, and decorates existing source controls,
 `entry-pages.mjs` owns entry-route input and page-state
@@ -187,7 +187,7 @@ and 420 pixels, so the formal statement can be read without leaving the list.
 The preview is pointer-only: it is not raised by a keyboard or on a touch
 screen, where the card's own links remain the way to the statement. It frames
 the immutable artifact at its published content address and does not repeat the
-entry page's check that the render's declarations match the accepted record, so
+entry page's check that the render's declarations match the registered record, so
 the entry page remains the place a rendering is tied to its entry.
 
 A record that arrives carrying review scores is refused rather than rendered.
@@ -195,13 +195,12 @@ The scores are not published and are not in the record; a served record that had
 them would mean something upstream had gone wrong, and displaying it would be
 the worst moment to find out.
 
-The site accepts the sole current entry contract, `schema_version: 2`, and
-requires its source-preservation receipt. The unused pre-launch v1 draft has no
+The site accepts the sole current entry contract, `schema_version: 3`, and
+requires its source-preservation receipt. Superseded pre-launch drafts have no
 browser fallback; an obsolete or malformed record fails closed.
-The deployed data already contains only v2 entries and preservation-backed
-recent projections. The pre-launch removal therefore deploys this Web cleanup
-first, so its workflows stop fetching `schema-v1.json`; Database can then stop
-publishing and serving that obsolete document without breaking Web deployment.
+The review-language cutover deploys this strict consumer together with the
+schema-v3 producer and rewritten public data; it does not infer an endorsement
+from a legacy positive review value.
 That ordering is gated by a complete traversal of what the producer advertises:
 CI and Pages deployment walk the browse hierarchy, reconcile every advertised
 row with its per-result version index, and run the Web entry validator over each
@@ -214,10 +213,10 @@ It uses at most eight concurrent reads; each read gets at most three five-second
 attempts with short backoff. The hourly job has a fifteen-minute ceiling, and a
 new observation supersedes an older queued or stuck one.
 
-This cleanup does not renumber unrelated documents. `recent.json`, per-result
-version indexes, browse/search projections, and source availability remain
-their existing `schema_version: 1` protocols, as do independent render and
-evidence metadata formats. Only the accepted-entry contract is v2-only.
+The review-language cutover also moves `recent.json`, per-result version
+indexes, and browse, subject, and search projections to schema version 2.
+Source availability and independent render and evidence metadata keep their
+own versioned contracts. Only the registered-entry contract is v3-only.
 
 The website is a presentation layer only. Public data and schemas live at the
 machine-readable data origin. A permanent ID paired with an explicit integer
@@ -258,7 +257,7 @@ Entry pages list all active versions. Older pages display a prominent link
 to the current version. Each page renders the selected version's own authorship,
 statement, proof, trust information, and review comments; information is never
 borrowed from a newer record. The site provides links, not computed diffs.
-The statement and the acceptance callout come first; the verification table,
+The statement and the registration callout come first; the verification table,
 statement dependencies, proof, provenance, and review comments sit behind
 section disclosures that open when their heading is selected, and a fragment
 link into one (such as `#statement-dependencies`) opens it before scrolling,

--- a/about.html
+++ b/about.html
@@ -56,13 +56,13 @@
         </p>
       </section>
 
-      <section id="what-acceptance-means">
-        <h2>What does acceptance by Palomar mean?</h2>
+      <section id="what-registration-requires">
+        <h2>What does Palomar require for registration?</h2>
         <p>
-          In order for a repository version to be accepted by Palomar, three
-          checks must pass. One is mechanical and requires both
-          Lean’s kernel and the independent NanoDa kernel; the other two are
-          performed by a language model.
+          A repository version is registrable only after mechanical verification
+          succeeds and an automated review identifies no blocking problem. The
+          mechanical check uses both Lean’s kernel and the independent NanoDa
+          kernel; the other checks are performed by a language model.
         </p>
         <ol class="assertions">
           <li>
@@ -108,16 +108,17 @@
           </li>
         </ol>
         <p>
-          The passes the language model runs, the prompts it is given, and the
+          The checks the language model runs, the prompts it is given, and the
           report it must produce are published in
           <a href="https://github.com/PalomarRegistry/PalomarPolicy">PalomarPolicy</a>.
         </p>
         <p>
-          All three checks run automatically, and a submission that passes them
-          is accepted without further judgment. Palomar adds no human editorial
-          step: no one here reads the mathematics the way a referee would. The
-          submitter then sees the private review and chooses whether to register
-          the accepted result or withdraw it.
+          All three checks run automatically. The review is a filter: it may
+          identify a blocking problem, or it may find no blocking problem. It
+          does not accept, approve, or endorse a result. Palomar adds no human
+          editorial step: no one here reads the mathematics the way a referee
+          would. When no blocking problem is identified, the submitter sees the
+          private review and chooses whether to register or withdraw the result.
         </p>
         <p>
           Palomar asserts nothing beyond these three checks.
@@ -126,7 +127,8 @@
           For a registered result, the source and the review's comments are
           publicly visible, so that a reader can reach their own judgment on the
           work and verify it independently. The published review is redacted: it
-          carries the accepted outcome and every comment, but not the scores
+          records that no blocking problem was identified and carries every
+          comment, but not the scores
           behind them or how severe the review considered each one.
           <a href="https://github.com/PalomarRegistry/PalomarPolicy/blob/main/docs/specification.md#editorial-review">The
           protocol specification</a> defines what is published.
@@ -134,16 +136,18 @@
         <p>
           The scores behind that outcome are withheld deliberately. The same
           repository at the same commit has scored 5 and then 4 on one axis
-          across two runs of the same policy, with the same verdict both times,
+          across two runs of the same policy, with the same registerability
+          outcome both times,
           and a number that moves like that reads as a judgement it cannot
-          carry. The verdict is what a reader is shown instead.
+          carry. Readers are instead told whether the automated review
+          identified any blocking problem.
         </p>
       </section>
 
       <section id="disagreeing-with-the-review">
         <h2>I disagree with the review’s assessment of my result. What can I do?</h2>
         <p>
-          There is no appeal for an individual result: reopening a few decisions
+          There is no appeal for an individual result: reopening a few outcomes
           for whoever writes in would make the outcome depend on who complained.
           A rejected submission leaves no public record, and it can be revised
           and resubmitted after a waiting period. Repeated submissions lengthen
@@ -181,8 +185,9 @@
         <p>
           To record a result against newer versions, submit the updated commit
           and give the existing Palomar ID on the submission form. The new
-          submission is verified and reviewed from scratch, and if it is accepted
-          and you choose to register it, it becomes the next version of that same
+          submission is verified and reviewed from scratch. If the automated
+          review identifies no blocking problem and you choose to register it,
+          it becomes the next version of that same
           identifier. The repository, project directory, and Comparator
           configuration path must match the existing entry.
         </p>
@@ -247,9 +252,10 @@
             grade, or otherwise assess how significant a result is.
           </li>
           <li>
-            <strong>Palomar does not perform peer review.</strong> Acceptance is
-            decided by the automated checks above, and no expert reviews the
-            content of the repository itself.
+            <strong>Palomar does not perform peer review.</strong> The automated
+            checks above can block registration or identify no blocking problem;
+            they do not accept a result, and no expert reviews the content of the
+            repository itself.
           </li>
           <li>
             <strong>Palomar is not a journal.</strong> Registration of a
@@ -389,14 +395,14 @@
         </p>
       </section>
 
-      <section id="accepted-imports">
-        <h2>What external library imports are accepted?</h2>
+      <section id="permitted-imports">
+        <h2>What external library imports are permitted?</h2>
         <p>
           The statement — conventionally <code>Challenge.lean</code> — may import
           Lean core,
           <a href="https://github.com/leanprover-community/mathlib4">Mathlib</a>,
           and <a href="https://github.com/TauCetiProject/TauCeti">Tau Ceti</a>.
-          Importing Tau Ceti is accepted and marks the entry as having qualified
+          Importing Tau Ceti is permitted and marks the entry as having qualified
           statement dependencies. A project Palomar has already registered is not
           importable on that basis.
         </p>

--- a/assets/app.js
+++ b/assets/app.js
@@ -217,12 +217,12 @@ function categoryTokens(entry) {
 /**
  * The day this version was registered.
  *
- * Not `accepted_at`, which is the *result's* date: the identifier carries it,
+ * Not `first_registered_on`, which is the *result's* date: the identifier carries it,
  * every later version inherits it, and it is already on the card beside this.
  * So a v2 labelled by it named a day years before that version existed, and on
  * a page ordered by registration the visible dates ran out of order.
  *
- * There is no fallback to the review's date any more. A review's verdict and
+ * There is no fallback to the review's date any more. A review's outcome and
  * the registration it leads to are different moments, and the record carries
  * `registered_at` for exactly this.
  */
@@ -418,7 +418,7 @@ async function renderIndex() {
     if (!entries.length) {
       setLandingStatusHidden(false);
       status.textContent =
-        "The telescope is ready. No entries have been published yet; the first accepted database PR will appear here automatically.";
+        "The telescope is ready. No entries have been registered yet; the first registered result will appear here automatically.";
       status.classList.add("empty");
       return true;
     }
@@ -1013,9 +1013,9 @@ function licenceRow(entry, sourceAvailability) {
   return row;
 }
 
-function acceptanceCallout(entry, databaseBase) {
-  const callout = el("div", "acceptance-callout");
-  const check = el("span", "acceptance-check", "✓");
+function registrationCallout(entry, databaseBase) {
+  const callout = el("div", "registration-callout");
+  const check = el("span", "registration-check", "✓");
   check.setAttribute("aria-hidden", "true");
   const copy = el("div");
   const evidenceLinks = el("p", "certificate-evidence-links");
@@ -1026,7 +1026,7 @@ function acceptanceCallout(entry, databaseBase) {
     ),
     " · ",
     dataLink(
-      "Archived editorial review",
+      "Archived automated review",
       evidenceDataUrl(entry, databaseBase, "review.json"),
     ),
   );
@@ -1045,11 +1045,11 @@ function acceptanceCallout(entry, databaseBase) {
       el("code", "", "Solution.lean"),
       " proves the recorded formal ",
       el("code", "", "Challenge.lean"),
-      " under the listed axiom and dependency rules, and both Lean's kernel and NanoDa accepted the exported proof.",
+      " under the listed axiom and dependency rules, and both Lean's kernel and NanoDa checked the exported proof successfully.",
     ),
     assurance(
-      "Editorial assurance",
-      "an AI-mediated review judged whether that formal ",
+      "Automated review",
+      "an AI-mediated review checked whether that formal ",
       el("code", "", "Challenge.lean"),
       " matches the informal mathematical claim under the recorded policy. This is not human peer review or a novelty certificate.",
     ),
@@ -1227,13 +1227,10 @@ async function renderEntry(
   evidenceTitle.append(titleBlock);
   const evidenceDetails = el("details", "section-collapse evidence-collapse");
   evidenceDetails.append(el("summary", "", "Verification details"));
-  evidence.append(evidenceTitle, acceptanceCallout(entry, databaseBase), evidenceDetails);
+  evidence.append(evidenceTitle, registrationCallout(entry, databaseBase), evidenceDetails);
   const details = el("dl", "details");
   details.append(
-    // One date, not two. Acceptance and Lean verification have always been the
-    // same day, so the second row said nothing the first did not; what it cost
-    // was the time of day, which is now here.
-    detailRow("Verified and accepted", displayTimestamp(entry.verification.verified_at)),
+    detailRow("Mechanically verified", displayTimestamp(entry.verification.verified_at)),
     sourceDetailRow(
       "Fixed source version",
       `${entry.source.repository}@${entry.source.commit.slice(0, 12)}`,
@@ -1362,16 +1359,25 @@ async function renderEntry(
   editorialHeading.id = "review-heading";
   editorial.setAttribute("aria-labelledby", editorialHeading.id);
   editorialBlock.append(el("div", "eyebrow", "Editorial record"), editorialHeading);
-  editorialTitle.append(editorialBlock, el("span", "decision", "Accepted"));
+  editorialTitle.append(
+    editorialBlock,
+    el(
+      "span",
+      "decision",
+      entry.review.warnings.length
+        ? "No blocking problems identified"
+        : "No problems identified",
+    ),
+  );
   const editorialSummary = el("summary");
   editorialSummary.append(editorialTitle);
   editorialDisclosure.append(editorialSummary);
   editorial.append(editorialDisclosure);
-  // No scores. They decide whether a submission is accepted and they are kept
+  // No scores. They contribute to the filter outcome and are kept
   // beside the database, but they never reach here: the same repository at
   // the same commit has scored 5 and then 4 on the same axis across runs, and a
   // number that moves like that reads as a judgement it cannot support. What
-  // it can support is the decision, which is above.
+  // it can support is the plain-language outcome above.
   editorialDisclosure.append(
     el(
       "p",

--- a/assets/entry-history-presentation.mjs
+++ b/assets/entry-history-presentation.mjs
@@ -78,7 +78,7 @@ export function createEntryHistoryPresentation({ document, localPageUrl, window 
       el(
         "p",
         "version-history-intro",
-        "Every version is an immutable accepted snapshot. The authorship, statement, proof, review comments, and dependency information on this page belong to the selected version only.",
+        "Every version is an immutable registered snapshot. The authorship, statement, proof, review comments, and dependency information on this page belong to the selected version only.",
       ),
     );
 

--- a/assets/formalization-presentation.mjs
+++ b/assets/formalization-presentation.mjs
@@ -15,7 +15,7 @@ import {
  * Entry validation, source preservation, URL confinement, artifact metadata,
  * and page composition remain in their existing modules. This boundary owns
  * only the trust label and the statement/proof dependency DOM presented from
- * those accepted inputs.
+ * those validated inputs.
  */
 export function createFormalizationPresentation({ document }) {
   function el(tag, className, text) {
@@ -122,8 +122,8 @@ export function createFormalizationPresentation({ document }) {
     const sectionHeading = el("h2", "", "Verified proof");
     sectionHeading.id = "proof-heading";
     section.setAttribute("aria-labelledby", sectionHeading.id);
-    title.append(el("div", "eyebrow", "Accepted proof"), sectionHeading);
-    heading.append(title, el("span", "decision accepted-decision", "Accepted"));
+    title.append(el("div", "eyebrow", "Verified proof"), sectionHeading);
+    heading.append(title, el("span", "decision verification-status", "Verified"));
     const summary = el("summary");
     summary.append(heading);
     disclosure.append(summary);
@@ -132,7 +132,7 @@ export function createFormalizationPresentation({ document }) {
       el(
         "p",
         "solution-summary",
-        "Lean checked the accepted proof using the exact versions of the source files and libraries listed below.",
+        "Lean checked this proof using the exact versions of the source files and libraries listed below.",
       ),
     );
 

--- a/assets/presentation-text.mjs
+++ b/assets/presentation-text.mjs
@@ -1,4 +1,4 @@
-// Accepted entry records are immutable. This one record was registered before
+// Registered entry records are immutable. This one record was registered before
 // Palomar stopped using an AI review synthesis as an abstract fallback, so its
 // canonical bytes must remain available while reader-facing surfaces suppress
 // the text that was never supplied or endorsed by the submitter.

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -1,11 +1,11 @@
-export const VERSIONS_SCHEMA_VERSION = 1;
-export const RECENT_SCHEMA_VERSION = 1;
-export const BROWSE_SCHEMA_VERSION = 1;
+export const VERSIONS_SCHEMA_VERSION = 2;
+export const RECENT_SCHEMA_VERSION = 2;
+export const BROWSE_SCHEMA_VERSION = 2;
 // A result with five hundred registered versions is a bug, not a history, and
 // this is the one read surface whose size is not bounded by anything else.
 const MAX_VERSIONS_PER_ID = 500;
 // The publisher's cap on `recent.json`, and the reason to have it here too: the
-// document this replaced was the whole registry, and a reader that accepted an
+// document this replaced was the whole registry, and a reader that admitted an
 // unbounded one would let it come back without anything saying so.
 const RECENT_ITEMS = 200;
 const BROWSE_PAGE_SERIALS = 200;
@@ -26,7 +26,7 @@ const BROWSE_MAX_PAGE = Math.ceil(999_999 / BROWSE_PAGE_SERIALS);
 const yearTemplate = (directory) => `${directory}/{year}.json`;
 const pageTemplate = (directory) => `${directory}/{day}/{page}.json`;
 const BROWSE_DIRECTORY = "browse";
-export const ENTRY_SCHEMA_VERSION = 2;
+export const ENTRY_SCHEMA_VERSION = 3;
 // The endpoint, not a document. There is no whole-registry document to name
 // any more: every surface is derived from this prefix by the function that
 // knows which one it wants.
@@ -334,7 +334,7 @@ export function validateRecent(value) {
     const version = integer(summary.version, `${field}.version`);
     boundedString(summary.title, `${field}.title`, 300);
     boundedString(summary.abstract, `${field}.abstract`, 10_000);
-    if (summary.status !== "accepted") fail(`recent.entries[${position}].status is not accepted`);
+    if (summary.status !== "registered") fail(`recent.entries[${position}].status is not registered`);
     const expectedPath = `entries/${id}-v${version}.json`;
     if (summary.path !== expectedPath) {
       fail(`recent.entries[${position}].path must be ${expectedPath}`);
@@ -343,7 +343,7 @@ export function validateRecent(value) {
     const publishedAt = string(summary.published_at, `${field}.published_at`);
     // An instant, and only an instant. This is the record's `registered_at`,
     // which the schema requires of every version. A date was tolerated while a
-    // row could fall back to `accepted_at`, and a date read as an instant is
+    // row could fall back to `first_registered_on`, and a date read as an instant is
     // midnight, so such a row would sort ahead of everything registered that
     // day with nothing to say why.
     if (!TIMESTAMP_RE.test(publishedAt)) {
@@ -484,7 +484,7 @@ export function validateRecentRenders(value) {
     if (!SHA256_RE.test(treeHash)) fail(`${field}.artifact_tree_sha256 is malformed`);
     index.set(id, Object.freeze({ id, version, artifact_tree_sha256: treeHash }));
   }
-  // Captured by value while the document is accepted, so a lookup answers from
+  // Captured by value while the document is validated, so a lookup answers from
   // what was checked rather than from a public row that has since been written
   // over. Set only after the whole projection succeeds: a reference to an early
   // row of a later-rejected document must not become presentation data.
@@ -591,7 +591,7 @@ export function validateAvailability(manifest) {
     const key = `${row.source_repository.toLowerCase()}\0${row.commit}`;
     if (seen.has(key)) fail(`availability.repositories[${position}] is duplicated`);
     seen.add(key);
-    const accepted = {
+    const validated = {
       ...row,
       original: availabilityEndpoint(
         row.original,
@@ -602,20 +602,20 @@ export function validateAvailability(manifest) {
         `availability.repositories[${position}].archive`,
       ),
     };
-    repositories.push(accepted);
+    repositories.push(validated);
     // The private consequence of validation must not point back at mutable
     // public rows. Capture exactly the fields lookup can later return/use.
     index.set(key, Object.freeze({
-      source_repository: accepted.source_repository,
-      commit: accepted.commit,
-      fork_repository: accepted.fork_repository,
-      original: Object.freeze({ ...accepted.original }),
-      archive: Object.freeze({ ...accepted.archive }),
+      source_repository: validated.source_repository,
+      commit: validated.commit,
+      fork_repository: validated.fork_repository,
+      original: Object.freeze({ ...validated.original }),
+      archive: Object.freeze({ ...validated.archive }),
     }));
   }
-  const accepted = { ...document, repositories };
-  availabilityIndexes.set(accepted, { generatedAt, index });
-  return accepted;
+  const validated = { ...document, repositories };
+  availabilityIndexes.set(validated, { generatedAt, index });
+  return validated;
 }
 
 export function availabilityRecord(manifest, repository, revision, now = Date.now()) {
@@ -665,7 +665,7 @@ function validateEntrySummary(value, field) {
   if (!ID_RE.test(id)) fail(`${field}.id is malformed`);
   const version = integer(summary.version, `${field}.version`);
   boundedString(summary.title, `${field}.title`, 300);
-  if (summary.status !== "accepted") fail(`${field}.status is not accepted`);
+  if (summary.status !== "registered") fail(`${field}.status is not registered`);
   const expectedPath = `entries/${id}-v${version}.json`;
   if (summary.path !== expectedPath) fail(`${field}.path must be ${expectedPath}`);
   return summary;
@@ -1075,7 +1075,7 @@ export function validateSubjectPage(value, kind, code, day, page) {
   return { ...document, entries: rows };
 }
 
-export const SEARCH_SCHEMA_VERSION = 1;
+export const SEARCH_SCHEMA_VERSION = 2;
 // A word is lowercase, alphanumeric and short, and anything a word cannot be
 // was dropped by the indexer rather than escaped. That is what lets this
 // request be built straight from what somebody typed: there is no term
@@ -1320,19 +1320,19 @@ function safeDependencyPath(value, field) {
 
 function validateCanonicalRecordLinks(entry) {
   const identifier = ID_RE.exec(entry.id);
-  if (identifier[1] !== entry.accepted_at) fail("entry ID date does not match accepted_at");
+  if (identifier[1] !== entry.first_registered_on) fail("entry ID date does not match first_registered_on");
 
-  // `accepted_at` is the result's date, inherited by every later version, and
+  // `first_registered_on` is the result's date, inherited by every later version, and
   // `registered_at` is the version's own instant. They meet at version 1, and
   // there they must: one is in the identifier and decides which browse page
   // the result is on, the other decides where it appears among what is new. A
   // record where they have come apart renders perfectly well while being
   // browsed under one day and ordered under another.
   const registeredOn = entry.registered_at.slice(0, 10);
-  if (entry.version === 1 && registeredOn !== entry.accepted_at) {
-    fail("entry.accepted_at is not the day version 1 was registered");
+  if (entry.version === 1 && registeredOn !== entry.first_registered_on) {
+    fail("entry.first_registered_on is not the day version 1 was registered");
   }
-  if (registeredOn < entry.accepted_at) {
+  if (registeredOn < entry.first_registered_on) {
     fail("entry.registered_at is before the result entered the registry");
   }
 
@@ -1376,7 +1376,7 @@ export function validateEntry(entry, summary) {
   if (entry.schema_version !== ENTRY_SCHEMA_VERSION) {
     fail(`unsupported entry schema_version ${String(entry.schema_version)}`);
   }
-  if (entry.status !== "accepted") fail("entry status is not accepted");
+  if (entry.status !== "registered") fail("entry status is not registered");
   const id = string(entry.id, "entry.id");
   if (!ID_RE.test(id)) fail("entry.id is malformed");
   const version = integer(entry.version, "entry.version");
@@ -1388,11 +1388,11 @@ export function validateEntry(entry, summary) {
   }
   string(entry.title, "entry.title");
   string(entry.abstract, "entry.abstract");
-  const acceptedAt = string(entry.accepted_at, "entry.accepted_at");
-  if (!DATE_RE.test(acceptedAt)) fail("entry.accepted_at is malformed");
+  const firstRegisteredOn = string(entry.first_registered_on, "entry.first_registered_on");
+  if (!DATE_RE.test(firstRegisteredOn)) fail("entry.first_registered_on is malformed");
   // The version's own registration instant, which is what every ordering
   // surface reads and what the card is dated by. How it has to agree with
-  // `accepted_at` is in `validateCanonicalRecordLinks`, beside the rest of what
+  // `first_registered_on` is in `validateCanonicalRecordLinks`, beside the rest of what
   // a record derives from itself.
   const registeredAt = string(entry.registered_at, "entry.registered_at");
   if (!TIMESTAMP_RE.test(registeredAt) || Number.isNaN(Date.parse(registeredAt))) {
@@ -1707,7 +1707,7 @@ export function validateEntry(entry, summary) {
   const review = object(entry.review, "entry.review");
   string(review.reviewed_at, "entry.review.reviewed_at");
   commit(review.policy_commit, "entry.review.policy_commit");
-  if (review.verdict !== "accept") fail("entry.review.verdict is not accept");
+  if (review.outcome !== "neutral") fail("entry.review.outcome does not permit registration");
   digest(object(review.report, "entry.review.report").sha256, "entry.review.report.sha256");
   if (review.report.source_url !== undefined) {
     safeExternalUrl(string(review.report.source_url, "entry.review.report.source_url"));

--- a/assets/statement-preview.mjs
+++ b/assets/statement-preview.mjs
@@ -25,7 +25,7 @@ const MARGIN = 8;
  *
  * It is a preview and not the record. The entry page remains where a rendering
  * is presented with the pinned source, the dependency surface, and the checks
- * tying it to the accepted entry; this frames the same immutable artifact from
+ * tying it to the registered entry; this frames the same immutable artifact from
  * the same content address and says nothing further about it.
  *
  * Hover is the only trigger, which is a decision with consequences worth

--- a/assets/style.css
+++ b/assets/style.css
@@ -814,7 +814,7 @@ footer {
 /* Dense sections open on demand. The section heading is the summary, so the
    collapsed page reads as a list of section titles and the disclosure marker
    is the affordance; the verification table's toggle is the small text below
-   the acceptance callout instead. */
+   the registration callout instead. */
 .section-collapse > summary {
   display: flex;
   align-items: baseline;
@@ -993,7 +993,7 @@ footer {
   }
 }
 
-.acceptance-callout {
+.registration-callout {
   display: flex;
   gap: .8rem;
   margin-bottom: 1rem;
@@ -1002,7 +1002,7 @@ footer {
   background: var(--success-paper);
 }
 
-.acceptance-check {
+.registration-check {
   display: grid;
   flex: 0 0 2rem;
   width: 2rem;
@@ -1014,12 +1014,12 @@ footer {
   font: bold 1.25rem/1 var(--sans);
 }
 
-.acceptance-callout strong {
+.registration-callout strong {
   color: var(--success);
   font: bold 1rem/1.3 var(--sans);
 }
 
-.acceptance-callout p,
+.registration-callout p,
 .solution-summary {
   margin: .2rem 0 0;
 }
@@ -1034,7 +1034,7 @@ footer {
   font: .75rem/1.3 var(--sans);
 }
 
-.accepted-decision {
+.verification-status {
   color: var(--success);
 }
 

--- a/entry.html
+++ b/entry.html
@@ -9,7 +9,7 @@
     <title>Registry entry — Palomar</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="assets/style.css">
-    <link rel="alternate" type="application/rss+xml" title="Palomar accepted results" href="https://data.palomar-registry.org/feed.xml">
+    <link rel="alternate" type="application/rss+xml" title="Palomar registered results" href="https://data.palomar-registry.org/feed.xml">
   </head>
   <body data-page="entry">
     <a class="skip-link" href="#entry">Skip to entry</a>

--- a/how-to-submit.html
+++ b/how-to-submit.html
@@ -118,15 +118,15 @@
           1,000 lines and 100 KiB are hard limits; 300 lines and 32 KiB is the
           surface we would rather review. Its transitive imports must resolve
           to Lean core or the pinned, allowlisted Mathlib or Tau Ceti closure,
-          and to nothing else. Importing Tau Ceti is accepted and marks the
+          and to nothing else. Importing Tau Ceti is permitted and marks the
           entry as having qualified statement dependencies. A project Palomar
-          has already accepted is not importable on that basis: an entry fixes a
+          has already registered is not importable on that basis: an entry fixes a
           reviewable snapshot of its own statement, not a library for later
           submissions.
         </p>
         <p>
           Dependencies used only by the Solution may be arbitrary pinned Git
-          dependencies. Local/path dependencies are also accepted when their
+          dependencies. Local/path dependencies are also permitted when their
           targets remain within the same pinned repository checkout. Neither
           kind relaxes the stricter transitive Challenge-import rule.
         </p>
@@ -228,7 +228,7 @@
           them. Whether you later register is inferable from the registry.
         </p>
         <p>
-          Not public unless you register: the editorial review and the decision,
+          Not public unless you register: the automated review and its findings,
           and the registry record itself. If a review goes badly, or you simply
           change your mind, withdrawing leaves no public trace of either. The
           already-public verification run remains, and so does everything its
@@ -248,7 +248,7 @@
         <p>
           “Private” here means not public, not confidential. Reviews are
           readable by Palomar operators, by GitHub, and by the model provider,
-          and are retained indefinitely so that any decision can be audited. Do
+          and are retained indefinitely so that the review outcome can be audited. Do
           not put anything sensitive in the notes field.
         </p>
         <p>
@@ -273,16 +273,18 @@
         </p>
         <p>
           The review then appears on your status page, and nowhere else. It
-          gives the reasons, its comments, and any requested changes, not just a
-          decision. A request for changes means the work may be reconsidered
+          gives the reasons, its comments, and any requested changes, not just an
+          outcome. A request for changes means the work may be reconsidered
           after specific correctable problems are addressed; a rejection means
           the submission failed a fundamental semantic, provenance, or editorial
           requirement. Because every review is tied to an immutable commit,
           revised source is a new submission at a new full commit SHA.
         </p>
         <p>
-          Nothing is registered until you ask for it. If the review is an
-          acceptance, your status page offers two choices: register, or withdraw.
+          Nothing is registered until you ask for it. If the automated review
+          identifies no blocking problem, your status page offers two choices:
+          register, or withdraw. The automated review does not accept, approve,
+          or endorse a result.
           Asking to register is how you authorise the record to be served, and
           it is the last point at which the choice is yours alone. The
           <a href="/privacy#lawful-bases">privacy policy</a> explains that
@@ -298,9 +300,9 @@
           retains a minimal tombstone. What that rule does not do is override a
           legal obligation Palomar is under, and the
           <a href="/privacy#after-registration">privacy policy</a> describes
-          the process by which one reaches the ledger. Acceptance is not
-          registration; an accepted submission appears in the registry once the
-          corresponding database pull request is merged.
+          the process by which one reaches the ledger. Identifying no blocking
+          problem is not registration; a submission appears in the registry only
+          after the corresponding database pull request is merged.
         </p>
         <p>
           Corrections and dependency updates may be registered as new versions

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="assets/style.css">
     <link rel="manifest" href="site.webmanifest">
-    <link rel="alternate" type="application/rss+xml" title="Palomar accepted results" href="https://data.palomar-registry.org/feed.xml">
+    <link rel="alternate" type="application/rss+xml" title="Palomar registered results" href="https://data.palomar-registry.org/feed.xml">
   </head>
   <body data-page="index">
     <a class="skip-link" href="#registry">Skip to registry</a>
@@ -35,12 +35,12 @@
           statement, the libraries it uses, and the review's comments.
         </p>
         <div class="metric-row" aria-live="polite">
-          <span><strong id="metric-results">—</strong> accepted results</span>
+          <span><strong id="metric-results">—</strong> registered results</span>
           <span><strong id="metric-projects">—</strong> source projects</span>
         </div>
       </section>
 
-      <section class="registry-section" id="registry" aria-label="Accepted results">
+      <section class="registry-section" id="registry" aria-label="Registered results">
         <form id="registry-search" class="registry-search" role="search">
           <label for="query">Search the registry:</label>
           <input id="query" name="q" type="search" placeholder="title, author, abstract, theorem, or repository" autocomplete="off" spellcheck="false" maxlength="4096">

--- a/privacy.html
+++ b/privacy.html
@@ -269,8 +269,8 @@
           <li>
             <strong>Keeping the private submission state for audit,</strong>
             which is what remains once a submission has stopped moving, rests on
-            legitimate interests: a decision nobody can reconstruct is a
-            decision nobody can challenge, including the submitter who wants to
+            legitimate interests: a review outcome nobody can reconstruct is an
+            outcome nobody can challenge, including the submitter who wants to
             challenge it. This is the basis the record’s retained history has
             had from the start, not one Palomar reaches for when a consent ends.
           </li>
@@ -334,9 +334,10 @@
         <p>
           <strong>The interest, named.</strong> It is the permanence of a
           certification record, and through that the integrity of every other
-          entry. What Palomar asserts about a registered entry is that an
-          accepted result was accepted under a stated contract, by a review
-          recorded at an exact policy commit, on an exact source commit. A
+          entry. What Palomar asserts about a registered entry is that its exact
+          source passed mechanical verification and its automated review
+          identified no blocking problem under a stated contract recorded at an
+          exact policy commit. A
           registry that can quietly lose an entry cannot support that claim
           about the entries it still has, because nothing distinguishes a record
           that was never made from one that was removed. That is why the
@@ -409,7 +410,7 @@
           data concerning them, on grounds relating to their particular
           situation. Two limits matter. It is a right over
           your own personal data, not over a record: a mathematical result, a
-          repository, a commit and a verdict are not personal data about you,
+          repository, a commit and an automated review finding are not personal data about you,
           and objecting does not give you a veto over what a record says about
           mathematics. And it belongs to whoever the data is about, which for
           most of a record is not the submitter: since a record names no
@@ -480,8 +481,8 @@
           registered is inferable from the registry.
         </p>
         <p>
-          Public only if you register: the registry record and the editorial
-          review with its verdict. The record also carries the authorization
+          Public only if you register: the registry record and the automated
+          review with its outcome and findings. The record also carries the authorization
           relationship and the evidence, but those were already public from
           dispatch; what registration adds is permanence. Withdraw instead and
           no record and no review are published. The verification run that
@@ -537,7 +538,7 @@
         </p>
         <p>
           The submission state records themselves are kept indefinitely, so that
-          any decision can still be audited. Because that state lives in git,
+          any review outcome can still be audited. Because that state lives in git,
           its history keeps earlier values of the fields as well as the current
           ones: a value that has been changed or scrubbed is still in the
           history.
@@ -728,8 +729,8 @@
           runs on is kept as a workflow artifact for 90 days, and it is the
           review’s whole working directory: the private state record, the fully
           rendered prompts with the submitted material inlined, the raw model
-          event streams and final messages, the normalized per-pass results, the
-          spend record, the review as delivered, and, on a pass that goes on to
+          event streams and final messages, the normalized per-check results, the
+          spend record, the review as delivered, and, on a run that goes on to
           register, a sparse clone of the private database. It also holds a
           checkout of the submitted repository, which is not part of the
           exposure: a repository has to be public before it can be submitted. A

--- a/subject.html
+++ b/subject.html
@@ -9,7 +9,7 @@
     <title>Subject classification — Palomar</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="assets/style.css">
-    <link rel="alternate" type="application/rss+xml" title="Palomar accepted results" href="https://data.palomar-registry.org/feed.xml">
+    <link rel="alternate" type="application/rss+xml" title="Palomar registered results" href="https://data.palomar-registry.org/feed.xml">
   </head>
   <body data-page="subject">
     <a class="skip-link" href="#subject">Skip to results</a>

--- a/tests/appearance.test.js
+++ b/tests/appearance.test.js
@@ -71,9 +71,9 @@ for (const [mode, colours] of [["light", light], ["dark", dark]]) {
     }
   });
 
-  test(`${mode} acceptance mark meets text contrast`, () => {
+  test(`${mode} registration mark meets text contrast`, () => {
     const ratio = contrast(colours["--paper"], colours["--success-mark"]);
-    assert.ok(ratio >= 4.5, `${mode} acceptance mark is ${ratio.toFixed(2)}:1, needs 4.5`);
+    assert.ok(ratio >= 4.5, `${mode} registration mark is ${ratio.toFixed(2)}:1, needs 4.5`);
   });
 
   test(`${mode} filter states retain text contrast`, () => {

--- a/tests/challenge-presentation.test.mjs
+++ b/tests/challenge-presentation.test.mjs
@@ -98,7 +98,7 @@ function byClass(root, className) {
     String(node.className).split(" ").includes(className));
 }
 
-test("render metadata must correspond exactly to the accepted entry", async (t) => {
+test("render metadata must correspond exactly to the registered entry", async (t) => {
   const record = acceptedEntry();
   const current = renderMetadata();
   assert.equal(validateChallengeMetadata(record, current), current);

--- a/tests/check-published.test.js
+++ b/tests/check-published.test.js
@@ -42,7 +42,7 @@ function oneEntryRegistry() {
     id,
     version: 1,
     title: "One",
-    status: "accepted",
+    status: "registered",
     path: `entries/${id}-v1.json`,
   };
   const registeredAt = "2026-08-08T12:00:00Z";
@@ -144,7 +144,7 @@ test("live-data health traverses browse and history to validate every public per
     id: "PALOMAR-2026-08-08-000001",
     version: 1,
     title: "One",
-    status: "accepted",
+    status: "registered",
     path: "entries/PALOMAR-2026-08-08-000001-v1.json",
   };
   const second = {
@@ -324,7 +324,7 @@ test("live-data health fails closed when a version index omits or rewrites brows
     id,
     version: 1,
     title: "Browse title",
-    status: "accepted",
+    status: "registered",
     path: `entries/${id}-v1.json`,
   };
   const responses = new Map([

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -34,9 +34,9 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
         else {"arxiv": ["math.NT"], "msc2020": ["11N13"]}
     )
     record = {
-        "schema_version": 2,
+        "schema_version": 3,
         "id": identifier,
-        "accepted_at": "2026-07-29",
+        "first_registered_on": "2026-07-29",
         # The result's date is the day its version 1 was registered, and a
         # later version brings its own instant: a v2 is a new registration and
         # is news, where the result's date would file it beside its v1.
@@ -44,7 +44,7 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
             "2026-07-29T09:14:07Z" if version == 1 else f"2026-08-{version:02d}T09:14:07Z"
         ),
         "version": version,
-        "status": "accepted",
+        "status": "registered",
         "title": f"Fixture {identifier} version {version}",
         "abstract": "A browser confinement fixture for the registry, about the quasicoherent behaviour of a synthetic result.",
         "authors": [{"name": "Example"}],
@@ -119,7 +119,7 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
         "review": {
             "reviewed_at": "2026-07-29T08:53:02Z",
             "policy_commit": "5" * 40,
-            "verdict": "accept",
+            "outcome": "neutral",
             "reviewer_models": ["fixture:model"],
             "warnings": [],
             "report": {"sha256": "e" * 64},
@@ -262,7 +262,7 @@ def subject_row(record: dict) -> dict:
         "id": record["id"],
         "version": record["version"],
         "title": record["title"],
-        "status": "accepted",
+        "status": "registered",
         "path": f"entries/{record['id']}-v{record['version']}.json",
         "published_at": record["registered_at"],
         "classification": record["classification"],
@@ -340,7 +340,7 @@ def subject_documents() -> dict[str, dict]:
         for (year, day, page), page_rows in sorted(pages.items()):
             ordered = sorted(page_rows, key=lambda row: (row["id"], row["version"]))
             documents[f"{directory}/{day}/{page}.json"] = {
-                "schema_version": 1,
+                "schema_version": 2,
                 "day": day,
                 "page": page,
                 "entries": ordered,
@@ -360,7 +360,7 @@ def subject_documents() -> dict[str, dict]:
                     "versions": len(flat),
                 })
             documents[f"{directory}/{year}.json"] = {
-                "schema_version": 1,
+                "schema_version": 2,
                 "year": year,
                 "page_path": f"{directory}/{{day}}/{{page}}.json",
                 "days": day_rows,
@@ -372,7 +372,7 @@ def subject_documents() -> dict[str, dict]:
                 "versions": sum(row["versions"] for row in day_rows),
             })
         documents[f"{directory}.json"] = {
-            "schema_version": 1,
+            "schema_version": 2,
             "kind": kind,
             "code": code,
             "entries": rows[:SUBJECT_PAGE_ITEMS],
@@ -527,7 +527,7 @@ class Handler(SimpleHTTPRequestHandler):
             # `selection.latest_entries` orders them in the publisher.
             rows.sort(key=lambda row: (row["published_at"], row["id"]), reverse=True)
             self.send_bytes(
-                json.dumps({"schema_version": 1, "entries": rows}).encode(),
+                json.dumps({"schema_version": 2, "entries": rows}).encode(),
                 "application/json",
             )
             return
@@ -562,7 +562,7 @@ class Handler(SimpleHTTPRequestHandler):
             ]
             rows.sort(key=lambda row: row["id"])
             self.send_bytes(
-                json.dumps({"schema_version": 1, "renders": rows}).encode(),
+                json.dumps({"schema_version": 2, "renders": rows}).encode(),
                 "application/json",
             )
             return
@@ -579,7 +579,7 @@ class Handler(SimpleHTTPRequestHandler):
                     "id": item["id"],
                     "version": item["version"],
                     "title": item["title"],
-                    "status": "accepted",
+                    "status": "registered",
                     "path": f"entries/{item['id']}-v{item['version']}.json",
                 }
                 for item in ENTRIES.values()
@@ -590,7 +590,7 @@ class Handler(SimpleHTTPRequestHandler):
                 return
             self.send_bytes(
                 json.dumps({
-                    "schema_version": 1,
+                    "schema_version": 2,
                     "id": identifier,
                     "entries": sorted(rows, key=lambda row: row["version"]),
                 }).encode(),
@@ -603,7 +603,7 @@ class Handler(SimpleHTTPRequestHandler):
         if path == "/database/search/stopwords.json":
             self.send_bytes(
                 json.dumps(
-                    {"schema_version": 1, "stopwords": sorted(SEARCH_STOPWORDS)}
+                    {"schema_version": 2, "stopwords": sorted(SEARCH_STOPWORDS)}
                 ).encode(),
                 "application/json",
             )
@@ -624,7 +624,7 @@ class Handler(SimpleHTTPRequestHandler):
             ]
             if leaf == "head":
                 payload = {
-                    "schema_version": 1,
+                    "schema_version": 2,
                     "term": term,
                     "page_size": SEARCH_PAGE_SIZE,
                     "pages": len(pages),
@@ -632,7 +632,7 @@ class Handler(SimpleHTTPRequestHandler):
                 }
             elif int(leaf) < len(pages):
                 payload = {
-                    "schema_version": 1,
+                    "schema_version": 2,
                     "term": term,
                     "page": int(leaf),
                     "postings": pages[int(leaf)],

--- a/tests/fixtures/public-browse/index.json
+++ b/tests/fixtures/public-browse/index.json
@@ -1,6 +1,6 @@
 {
   "results": 1,
-  "schema_version": 1,
+  "schema_version": 2,
   "versions": 2,
   "year_path": "browse/{year}.json",
   "years": [

--- a/tests/fixtures/public-browse/page.json
+++ b/tests/fixtures/public-browse/page.json
@@ -4,18 +4,18 @@
     {
       "id": "PALOMAR-2026-08-08-000001",
       "path": "entries/PALOMAR-2026-08-08-000001-v1.json",
-      "status": "accepted",
+      "status": "registered",
       "title": "kim-em/erdos-unit-distance-comparator",
       "version": 1
     },
     {
       "id": "PALOMAR-2026-08-08-000001",
       "path": "entries/PALOMAR-2026-08-08-000001-v2.json",
-      "status": "accepted",
+      "status": "registered",
       "title": "kim-em/erdos-unit-distance-comparator",
       "version": 2
     }
   ],
   "page": 1,
-  "schema_version": 1
+  "schema_version": 2
 }

--- a/tests/fixtures/public-browse/year.json
+++ b/tests/fixtures/public-browse/year.json
@@ -9,6 +9,6 @@
     }
   ],
   "page_path": "browse/{day}/{page}.json",
-  "schema_version": 1,
+  "schema_version": 2,
   "year": "2026"
 }

--- a/tests/formalization-presentation.test.mjs
+++ b/tests/formalization-presentation.test.mjs
@@ -78,7 +78,7 @@ function texts(root, tagName) {
   return byTag(root, tagName).map((node) => node.textContent);
 }
 
-test("the trust badge and statement dependency section present the accepted trust record", () => {
+test("the trust badge and statement dependency section present the registered trust record", () => {
   const presentation = createFormalizationPresentation({ document: fakeDocument() });
   const high = entry();
   assert.equal(

--- a/tests/registry-fixture.mjs
+++ b/tests/registry-fixture.mjs
@@ -6,7 +6,7 @@ export function summary(overrides = {}) {
     id: "PALOMAR-2026-07-29-000123",
     version: 1,
     title: "Fixture theorem",
-    status: "accepted",
+    status: "registered",
     path: "entries/PALOMAR-2026-07-29-000123-v1.json",
     ...overrides,
   };
@@ -60,7 +60,7 @@ export function recentRow(overrides = {}) {
 }
 
 export function recent(entries = [recentRow()], overrides = {}) {
-  return { schema_version: 1, entries, ...overrides };
+  return { schema_version: 2, entries, ...overrides };
 }
 
 export function renderRow(overrides = {}) {
@@ -74,7 +74,7 @@ export function renderRow(overrides = {}) {
 }
 
 export function recentRenders(renders = [renderRow()], overrides = {}) {
-  return { schema_version: 1, renders, ...overrides };
+  return { schema_version: 2, renders, ...overrides };
 }
 
 export function availabilityEndpoint(overrides = {}) {
@@ -114,12 +114,12 @@ export function availabilityRow(overrides = {}) {
 export function entry(overrides = {}) {
   const evidenceTree = "c".repeat(64);
   const value = {
-    schema_version: 2,
+    schema_version: 3,
     id: "PALOMAR-2026-07-29-000123",
-    accepted_at: "2026-07-29",
+    first_registered_on: "2026-07-29",
     registered_at: "2026-07-29T09:14:07Z",
     version: 1,
-    status: "accepted",
+    status: "registered",
     title: "Fixture theorem",
     abstract: "A security fixture.",
     authors: [{ name: "Example" }],
@@ -209,7 +209,7 @@ export function entry(overrides = {}) {
     review: {
       reviewed_at: "2026-07-29T08:53:02Z",
       policy_commit: "5".repeat(40),
-      verdict: "accept",
+      outcome: "neutral",
       report: { sha256: "e".repeat(64) },
       reviewer_models: ["fixture:model"],
       warnings: [],

--- a/tests/registry-loading.test.mjs
+++ b/tests/registry-loading.test.mjs
@@ -231,7 +231,7 @@ test("the render companion is read once a page and caches only a stable absence"
 test("an unversioned entry read resolves and validates the current immutable record", async () => {
   const record = secondVersion();
   const versions = {
-    schema_version: 1,
+    schema_version: 2,
     id: ID,
     entries: [
       summary(),
@@ -288,7 +288,7 @@ test("verified entry loading does not await a never-settling availability read",
   });
   const routes = new Map([
     [`/versions/${ID}.json`, jsonResponse({
-      schema_version: 1,
+      schema_version: 2,
       id: ID,
       entries: [summary()],
     })],
@@ -315,7 +315,7 @@ test("verified entry loading does not await a never-settling availability read",
 });
 
 test("an inactive exact version resolves only through its validated tombstone", async () => {
-  const versions = { schema_version: 1, id: ID, entries: [summary()] };
+  const versions = { schema_version: 2, id: ID, entries: [summary()] };
   const tombstone = { id: ID, version: 2, taken_down_on: "2026-08-08" };
   const calls = [];
   const routes = new Map([
@@ -337,7 +337,7 @@ test("an inactive exact version resolves only through its validated tombstone", 
 test("an active exact version resolves through its immutable record", async () => {
   const record = secondVersion();
   const versions = {
-    schema_version: 1,
+    schema_version: 2,
     id: ID,
     entries: [
       summary(),
@@ -377,7 +377,7 @@ test("non-absence failures from version indexes and tombstones propagate", async
   const tombstoneFailure = createRegistryLoader({
     fetch: routedFetch(new Map([
       [`/versions/${ID}.json`, jsonResponse({
-        schema_version: 1,
+        schema_version: 2,
         id: ID,
         entries: [summary()],
       })],
@@ -412,7 +412,7 @@ test("an absent version index and tombstone produce the one public not-found err
 
 function subjectHead(overrides = {}) {
   return {
-    schema_version: 1,
+    schema_version: 2,
     kind: "arxiv",
     code: "math.CO",
     entries: [{
@@ -437,13 +437,13 @@ test("the subject reads resolve and validate all three levels of one code", asyn
     fetch: routedFetch(new Map([
       ["/subjects/arxiv/math.CO.json", jsonResponse(subjectHead())],
       ["/subjects/arxiv/math.CO/2026.json", jsonResponse({
-        schema_version: 1,
+        schema_version: 2,
         year: "2026",
         page_path: "subjects/arxiv/math.CO/{day}/{page}.json",
         days: [dayRow],
       })],
       ["/subjects/arxiv/math.CO/2026-07-29/1.json", jsonResponse({
-        schema_version: 1,
+        schema_version: 2,
         day: "2026-07-29",
         page: 1,
         entries: [archived],

--- a/tests/searching.test.js
+++ b/tests/searching.test.js
@@ -17,7 +17,7 @@ function posting(serial) {
 
 function head(term, results, pageSize) {
   return {
-    schema_version: 1,
+    schema_version: 2,
     term,
     page_size: pageSize,
     pages: Math.ceil(results / pageSize),
@@ -26,7 +26,7 @@ function head(term, results, pageSize) {
 }
 
 function page(term, number, postings) {
-  return { schema_version: 1, term, page: number, postings };
+  return { schema_version: 2, term, page: number, postings };
 }
 
 function wait(milliseconds) {
@@ -41,7 +41,7 @@ test("the distinct-term limit is a hard head-request bound", async () => {
   let headRequests = 0;
   const fetchJson = async (url) => {
     const path = new URL(url).pathname;
-    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/stopwords.json") return { schema_version: 2, stopwords: [] };
     if (path.endsWith("/head.json")) {
       headRequests += 1;
       const error = new Error("not indexed");
@@ -99,7 +99,7 @@ test("query validation checks characters first and deduplicates normalized terms
 test("search pipelines I/O but retains validated publisher order", async () => {
   const postings = [1, 2, 3, 4].map(posting);
   const responses = new Map([
-    ["/search/stopwords.json", { schema_version: 1, stopwords: [] }],
+    ["/search/stopwords.json", { schema_version: 2, stopwords: [] }],
     ["/search/t/alpha/head.json", head("alpha", 4, 2)],
     ["/search/t/beta/head.json", head("beta", 4, 2)],
     ["/search/t/alpha/0.json", page("alpha", 0, postings.slice(0, 2))],
@@ -154,7 +154,7 @@ test("failed pages and records yield only validated results and a degraded resul
   const postings = [1, 2, 3, 4].map(posting);
   const fetchJson = async (url) => {
     const path = new URL(url).pathname;
-    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/stopwords.json") return { schema_version: 2, stopwords: [] };
     if (path === "/search/t/alpha/head.json") return head("alpha", 4, 2);
     if (path === "/search/t/alpha/1.json") throw new Error("posting page unavailable");
     if (path === "/search/t/alpha/0.json") return page("alpha", 0, postings.slice(0, 2));
@@ -177,7 +177,7 @@ test("failed pages and records yield only validated results and a degraded resul
 test("one overall deadline bounds every search stage, including an abort-ignoring fetch", async () => {
   const fetchJson = async (url) => {
     const path = new URL(url).pathname;
-    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/stopwords.json") return { schema_version: 2, stopwords: [] };
     if (path === "/search/t/alpha/head.json") return head("alpha", 1, 1);
     if (path === "/search/t/alpha/0.json") return new Promise(() => {});
     throw new Error(`unexpected request ${path}`);
@@ -197,7 +197,7 @@ test("one overall deadline bounds every search stage, including an abort-ignorin
 test("a caller can abort the shared search deadline without reporting a timeout", async () => {
   const fetchJson = async (url) => {
     const path = new URL(url).pathname;
-    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/stopwords.json") return { schema_version: 2, stopwords: [] };
     if (path === "/search/t/alpha/head.json") return head("alpha", 1, 1);
     if (path === "/search/t/alpha/0.json") return new Promise(() => {});
     throw new Error(`unexpected request ${path}`);
@@ -219,7 +219,7 @@ test("a caller can abort the shared search deadline without reporting a timeout"
 test("one failed head degrades but does not discard exact results from a healthy driver", async () => {
   const fetchJson = async (url) => {
     const path = new URL(url).pathname;
-    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/stopwords.json") return { schema_version: 2, stopwords: [] };
     if (path === "/search/t/alpha/head.json") throw new Error("head unavailable");
     if (path === "/search/t/beta/head.json") return head("beta", 1, 1);
     if (path === "/search/t/beta/0.json") return page("beta", 0, [posting(1)]);
@@ -248,7 +248,7 @@ test("a non-404 stopword failure is reported and retried by the next search", as
         error.status = 503;
         throw error;
       }
-      return { schema_version: 1, stopwords: [] };
+      return { schema_version: 2, stopwords: [] };
     }
     if (path === "/search/t/alpha/head.json") return head("alpha", 1, 1);
     if (path === "/search/t/alpha/0.json") return page("alpha", 0, [posting(1)]);
@@ -270,7 +270,7 @@ test("a secondary term that cannot fit the remaining page budget is not partly r
   const postings = [posting(1), posting(2)];
   const fetchJson = async (url) => {
     const path = new URL(url).pathname;
-    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/stopwords.json") return { schema_version: 2, stopwords: [] };
     if (path === "/search/t/alpha/head.json") return head("alpha", 2, 1);
     if (path === "/search/t/beta/head.json") return head("beta", 2, 1);
     const match = path.match(/^\/search\/t\/(alpha|beta)\/([0-9]+)\.json$/);
@@ -303,7 +303,7 @@ test("matching versions of one result collapse to its newest matching version", 
   const requestedRecords = [];
   const fetchJson = async (url) => {
     const path = new URL(url).pathname;
-    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/stopwords.json") return { schema_version: 2, stopwords: [] };
     if (path === "/search/t/alpha/head.json") return head("alpha", 2, 2);
     if (path === "/search/t/alpha/0.json") {
       // Publisher order is lexical, so the consumer must compare versions as
@@ -329,7 +329,7 @@ test("a version group reports broken postings in order and continues to an older
   const id = "PALOMAR-2026-07-29-000001";
   const fetchJson = async (url) => {
     const path = new URL(url).pathname;
-    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/stopwords.json") return { schema_version: 2, stopwords: [] };
     if (path === "/search/t/alpha/head.json") return head("alpha", 3, 3);
     if (path === "/search/t/alpha/0.json") {
       return page("alpha", 0, [`${id}-v10`, `${id}-v8`, `${id}-v9`]);
@@ -356,7 +356,7 @@ test("a complete postings sequence remains incomplete when the candidate cap tru
   let recordRequests = 0;
   const fetchJson = async (url) => {
     const path = new URL(url).pathname;
-    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/stopwords.json") return { schema_version: 2, stopwords: [] };
     if (path === "/search/t/alpha/head.json") return head("alpha", 3, 3);
     if (path === "/search/t/alpha/0.json") return page("alpha", 0, postings);
     if (path.startsWith("/entries/")) {
@@ -387,7 +387,7 @@ test("page, candidate, and concurrency limits remain hard bounds", async () => {
   let recordRequests = 0;
   const fetchJson = async (url) => {
     const path = new URL(url).pathname;
-    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/stopwords.json") return { schema_version: 2, stopwords: [] };
     if (path === "/search/t/alpha/head.json") return head("alpha", 100, 5);
     const pageMatch = path.match(/^\/search\/t\/alpha\/([0-9]+)\.json$/);
     if (pageMatch) {
@@ -435,7 +435,7 @@ test("the record window stops with at most concurrency minus one speculative gro
   let recordRequests = 0;
   const fetchJson = async (url) => {
     const path = new URL(url).pathname;
-    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/stopwords.json") return { schema_version: 2, stopwords: [] };
     if (path === "/search/t/alpha/head.json") return head("alpha", 100, 100);
     if (path === "/search/t/alpha/0.json") return page("alpha", 0, postings);
     if (path.startsWith("/entries/")) {
@@ -466,7 +466,7 @@ test("the initial record window never exceeds the result limit", async () => {
   let recordRequests = 0;
   const fetchJson = async (url) => {
     const path = new URL(url).pathname;
-    if (path === "/search/stopwords.json") return { schema_version: 1, stopwords: [] };
+    if (path === "/search/stopwords.json") return { schema_version: 2, stopwords: [] };
     if (path === "/search/t/alpha/head.json") return head("alpha", 20, 20);
     if (path === "/search/t/alpha/0.json") return page("alpha", 0, postings);
     if (path.startsWith("/entries/")) {

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -190,10 +190,10 @@ test("what is new is read from the database prefix and nowhere else", () => {
 });
 
 test("recent validation rejects unsupported, rejected, and malformed rows", () => {
-  assert.throws(() => validateRecent(recent([], { schema_version: 2 })), /unsupported recent/);
+  assert.throws(() => validateRecent(recent([], { schema_version: 3 })), /unsupported recent/);
   assert.throws(
     () => validateRecent(recent([recentRow({ status: "draft" })])),
-    /status is not accepted/,
+    /status is not registered/,
   );
   assert.throws(
     () => validateRecent(recent([recentRow({ published_at: "yesterday" })])),
@@ -231,7 +231,7 @@ test("the render companion is one exact closed shape", () => {
 
   for (const mutate of [
     (document) => { document.entries = []; },
-    (document) => { document.schema_version = 2; },
+    (document) => { document.schema_version = 3; },
     (document) => { delete document.renders[0].version; },
     (document) => { document.renders[0].artifact_path = "renders/"; },
     (document) => { document.renders[0].id = "PALOMAR-2026-07-29-00012"; },
@@ -270,7 +270,7 @@ test("a rejected render companion leaves no row usable", () => {
 
 test("recent is one exact complete projection, not a legacy summary shape", () => {
   assert.throws(
-    () => validateRecent({ schema_version: 1, entries: [summary()] }),
+    () => validateRecent({ schema_version: 2, entries: [summary()] }),
     /invalid shape/,
   );
 
@@ -332,7 +332,7 @@ test("recent applies the canonical producer's cheap presentation bounds", () => 
 });
 
 test("a record must say when the version was registered, and agree with its result date", () => {
-  // The two are one fact written twice, in two repositories. `accepted_at` is
+  // The two are one fact written twice, in two repositories. `first_registered_on` is
   // the result's date: the identifier carries it, browsing pages by it, and
   // every later version inherits it. `registered_at` is the version's own
   // instant and is what the landing page, the feeds and the subject pages
@@ -348,11 +348,11 @@ test("a record must say when the version was registered, and agree with its resu
   );
   assert.throws(
     () => validateEntry(entry({ registered_at: "2026-07-30T09:14:07Z" }), summary()),
-    /accepted_at is not the day version 1 was registered/,
+    /first_registered_on is not the day version 1 was registered/,
   );
   assert.throws(
     () => validateEntry(entry({ registered_at: "2026-07-28T09:14:07Z" }), summary()),
-    /accepted_at is not the day version 1 was registered/,
+    /first_registered_on is not the day version 1 was registered/,
   );
 
   // A later version brings its own instant and inherits its result's date,
@@ -474,7 +474,7 @@ test("active-content and insecure data-derived links are never allowed", () => {
   );
 });
 
-test("a canonical accepted record validates", () => {
+test("a canonical registered record validates", () => {
   assert.equal(validateEntry(entry(), summary()).id, "PALOMAR-2026-07-29-000123");
 });
 
@@ -536,11 +536,11 @@ test("validated availability uses one private index for every later lookup", () 
     );
   }
 
-  assert.equal(rowReads, 0, "accepted availability rows are never traversed by lookup");
+  assert.equal(rowReads, 0, "validated availability rows are never traversed by lookup");
   assert.equal(JSON.stringify(manifest), serialized, "the private index does not alter JSON");
 });
 
-test("availability lookup uses the accepted snapshot rather than later row mutation", () => {
+test("availability lookup uses the validated snapshot rather than later row mutation", () => {
   const now = Date.parse("2026-08-08T12:00:00Z");
   const manifest = validateAvailability(availabilityManifest([
     availabilityRow({
@@ -744,10 +744,10 @@ test("withdrawn palomar-indexed provenance is rejected", () => {
   );
 });
 
-test("entry schema, acceptance state, verdict, and selected identity fail closed", () => {
+test("entry schema, registration state, verdict, and selected identity fail closed", () => {
   const unsupportedSchemas = [
-    entry({ schema_version: 1 }),
-    entry({ schema_version: 3 }),
+    entry({ schema_version: 2 }),
+    entry({ schema_version: 4 }),
     entry({ schema_version: true }),
     entry({ schema_version: "2" }),
   ];
@@ -757,10 +757,10 @@ test("entry schema, acceptance state, verdict, and selected identity fail closed
   for (const record of unsupportedSchemas) {
     assert.throws(() => validateEntry(record, summary()), /unsupported entry schema_version/);
   }
-  assert.throws(() => validateEntry(entry({ status: "draft" }), summary()), /not accepted/);
+  assert.throws(() => validateEntry(entry({ status: "draft" }), summary()), /not registered/);
   const rejected = entry();
-  rejected.review.verdict = "reject";
-  assert.throws(() => validateEntry(rejected, summary()), /verdict is not accept/);
+  rejected.review.outcome = "rejected";
+  assert.throws(() => validateEntry(rejected, summary()), /outcome does not permit registration/);
   assert.throws(
     () => validateEntry(entry(), summary({ id: "PALOMAR-2026-07-29-000124", path: "entries/PALOMAR-2026-07-29-000124-v1.json" })),
     /identity does not match/,
@@ -787,7 +787,7 @@ test("a record carrying review scores is refused, not rendered", () => {
 });
 
 test("record evidence links must agree with their canonical values", () => {
-  const wrongDate = entry({ accepted_at: "2026-07-30" });
+  const wrongDate = entry({ first_registered_on: "2026-07-30" });
   assert.throws(() => validateEntry(wrongDate, summary()), /ID date does not match/);
 
   const wrongSubmissionId = entry();
@@ -927,7 +927,7 @@ test("the public documentation describes the current review and version contract
   assert.match(about, /This is not a substitute for\s+expert review/);
   assert.match(guide, /Corrections and dependency updates may be registered as new versions/);
   assert.match(guide, /A new mathematical result receives a new ID/);
-  assert.match(guide, /Acceptance is not\s+registration/);
+  assert.match(guide, /does not accept, approve,\s+or endorse a result/);
   assert.doesNotMatch(guide, /durable-evidence schema \(version 5\)/);
   assert.match(guide, /review-failed/);
   assert.match(guide, /operational fault, not a decision/);
@@ -1123,7 +1123,7 @@ test("consent is scoped to the submitter's own live submission", async () => {
   assert.match(bases, /It is never on consent, at any\s+stage/);
   assert.match(bases, /Keeping the public verification run public afterwards<\/strong>\s+rests on legitimate interests, and did from the moment it was\s+dispatched/);
   assert.match(bases, /Palomar does not delete runs/);
-  assert.match(bases, /rests on\s+legitimate interests: a decision nobody can reconstruct/);
+  assert.match(bases, /rests on\s+legitimate interests: a review outcome nobody can reconstruct/);
   assert.match(bases, /not one Palomar reaches for when a consent ends/);
 });
 
@@ -1215,7 +1215,7 @@ test("every provenance value the schema allows has an explicit label", async () 
   // registry down, so an unavailable schema is a failure, not a skip.
   const checkout = databaseCheckout();
   const schema = JSON.parse(
-    await readFile(join(checkout, "schema-v2.json"), "utf8"),
+    await readFile(join(checkout, "schema-v3.json"), "utf8"),
   );
   const provenance = schema.properties.provenance.properties;
   for (const [field, labels] of [
@@ -1233,7 +1233,7 @@ test("every provenance value the schema allows has an explicit label", async () 
 test("the site requires the Database entry version and exact preservation shape", async () => {
   const checkout = databaseCheckout();
   const schema = JSON.parse(
-    await readFile(join(checkout, "schema-v2.json"), "utf8"),
+    await readFile(join(checkout, "schema-v3.json"), "utf8"),
   );
   assert.strictEqual(schema.properties.schema_version.const, ENTRY_SCHEMA_VERSION);
   assert.ok(schema.required.includes("preservation"));
@@ -1290,10 +1290,10 @@ test("a version index must be every version of the result it names", () => {
     id,
     version,
     title: "A result",
-    status: "accepted",
+    status: "registered",
     path: `entries/${id}-v${version}.json`,
   });
-  const document = { schema_version: 1, id, entries: [row(1), row(2)] };
+  const document = { schema_version: 2, id, entries: [row(1), row(2)] };
   assert.equal(validateVersions(structuredClone(document), id).entries.length, 2);
 
   assert.throws(() => validateVersions({ ...document, id: "PALOMAR-2026-07-29-000999" }, id),
@@ -1305,9 +1305,9 @@ test("a version index must be every version of the result it names", () => {
     /increasing version order/,
   );
   assert.throws(() => validateVersions({ ...document, entries: [] }, id), /carries no versions/);
-  assert.throws(() => validateVersions({ ...document, schema_version: 2 }, id), /schema_version/);
+  assert.throws(() => validateVersions({ ...document, schema_version: 3 }, id), /schema_version/);
 
-  const foreign = { id: "PALOMAR-2026-07-29-000999", version: 3, title: "t", status: "accepted",
+  const foreign = { id: "PALOMAR-2026-07-29-000999", version: 3, title: "t", status: "registered",
     path: "entries/PALOMAR-2026-07-29-000999-v3.json" };
   assert.throws(() => validateVersions({ ...document, entries: [row(1), foreign] }, id),
     /is a different result/);
@@ -1321,20 +1321,20 @@ test("a version index URL cannot leave the database origin", () => {
   assert.throws(() => versionsUrl("PALOMAR-2026-07-29-00012", base), /malformed/);
 });
 
-test("browse enumerates every schema-v1 history row without becoming an entry schema", () => {
-  assert.equal(RECENT_SCHEMA_VERSION, 1);
-  assert.equal(VERSIONS_SCHEMA_VERSION, 1);
-  assert.equal(BROWSE_SCHEMA_VERSION, 1);
+test("browse enumerates every schema-v2 history row without becoming an entry schema", () => {
+  assert.equal(RECENT_SCHEMA_VERSION, 2);
+  assert.equal(VERSIONS_SCHEMA_VERSION, 2);
+  assert.equal(BROWSE_SCHEMA_VERSION, 2);
   const row = {
     id: "PALOMAR-2026-07-29-000123",
     version: 1,
     title: "A result",
-    status: "accepted",
+    status: "registered",
     path: "entries/PALOMAR-2026-07-29-000123-v1.json",
   };
   const yearRow = { year: "2026", days: 1, results: 1, versions: 1 };
   const head = {
-    schema_version: 1,
+    schema_version: 2,
     results: 1,
     versions: 1,
     year_path: "browse/{year}.json",
@@ -1348,12 +1348,12 @@ test("browse enumerates every schema-v1 history row without becoming an entry sc
     versions: 1,
   };
   const year = {
-    schema_version: 1,
+    schema_version: 2,
     year: "2026",
     page_path: "browse/{day}/{page}.json",
     days: [dayRow],
   };
-  const page = { schema_version: 1, day: dayRow.day, page: 1, entries: [row] };
+  const page = { schema_version: 2, day: dayRow.day, page: 1, entries: [row] };
   assert.equal(validateBrowseHead(head), head);
   assert.equal(validateBrowseYear(year, yearRow), year);
   assert.equal(validateBrowsePage(page, dayRow.day, 1), page);
@@ -1371,7 +1371,7 @@ test("browse enumerates every schema-v1 history row without becoming an entry sc
     /identity does not match/,
   );
   assert.throws(
-    () => validateBrowsePage({ ...page, schema_version: 2 }, dayRow.day, 1),
+    () => validateBrowsePage({ ...page, schema_version: 3 }, dayRow.day, 1),
     /schema_version/,
   );
 });
@@ -1412,14 +1412,14 @@ test("the path a collection publishes for the level below is the one this reader
   // data origin chooses and this consumer follows.
   const yearRow = { year: "2026", days: 1, results: 1, versions: 1 };
   const head = {
-    schema_version: 1,
+    schema_version: 2,
     results: 1,
     versions: 1,
     year_path: "browse/{year}.json",
     years: [yearRow],
   };
   const year = {
-    schema_version: 1,
+    schema_version: 2,
     year: "2026",
     page_path: "browse/{day}/{page}.json",
     days: [{ day: "2026-07-29", first_page: 1, last_page: 1, results: 1, versions: 1 }],
@@ -1462,7 +1462,7 @@ function subjectRow(overrides = {}) {
     id: "PALOMAR-2026-07-29-000123",
     version: 1,
     title: "A result",
-    status: "accepted",
+    status: "registered",
     path: "entries/PALOMAR-2026-07-29-000123-v1.json",
     published_at: "2026-07-29T09:14:07Z",
     classification: { arxiv: ["math.CO"], msc2020: ["05C10"] },
@@ -1486,7 +1486,7 @@ function subjectFixture() {
     archived,
     yearRow,
     head: {
-      schema_version: 1,
+      schema_version: 2,
       kind: "arxiv",
       code: "math.CO",
       entries: [front, older],
@@ -1496,7 +1496,7 @@ function subjectFixture() {
       years: [yearRow],
     },
     year: {
-      schema_version: 1,
+      schema_version: 2,
       year: "2026",
       page_path: "subjects/arxiv/math.CO/{day}/{page}.json",
       days: [
@@ -1504,7 +1504,7 @@ function subjectFixture() {
         { day: "2026-07-29", first_page: 1, last_page: 1, results: 1, versions: 1 },
       ],
     },
-    page: { schema_version: 1, day: "2026-07-29", page: 1, entries: [archived] },
+    page: { schema_version: 2, day: "2026-07-29", page: 1, entries: [archived] },
   };
 }
 
@@ -1568,7 +1568,7 @@ test("a subject URL cannot leave its own directory or name a code that is not on
 });
 
 test("a subject document is refused unless it is about the code that was asked for", () => {
-  assert.equal(SUBJECT_SCHEMA_VERSION, 1);
+  assert.equal(SUBJECT_SCHEMA_VERSION, 2);
   const { head, year, yearRow, page, front, archived } = subjectFixture();
 
   assert.deepEqual(validateSubjectHead(head, "arxiv", "math.CO").entries.map((row) => row.id), [
@@ -1586,7 +1586,7 @@ test("a subject document is refused unless it is about the code that was asked f
     /is for a different classification code/,
   );
   assert.throws(
-    () => validateSubjectHead({ ...head, schema_version: 2 }, "arxiv", "math.CO"),
+    () => validateSubjectHead({ ...head, schema_version: 3 }, "arxiv", "math.CO"),
     /schema_version/,
   );
   // A row that is a perfectly good row, under a heading it has nothing to do
@@ -1665,7 +1665,7 @@ const SEARCH_BASE = "https://data.example.test/";
 
 function searchHead(overrides = {}) {
   return {
-    schema_version: 1,
+    schema_version: 2,
     term: "ring",
     page_size: 128,
     pages: 2,
@@ -1725,13 +1725,13 @@ test("a postings head must account for the pages it sends a reader after", () =>
     /more pages/,
   );
   assert.throws(() => validateSearchHead(searchHead({ page_size: 1025 }), "ring"), /page_size/);
-  assert.throws(() => validateSearchHead(searchHead({ schema_version: 2 }), "ring"), /schema_version/);
+  assert.throws(() => validateSearchHead(searchHead({ schema_version: 3 }), "ring"), /schema_version/);
 });
 
 test("a postings page must be the page it was asked for, in order, and no longer", () => {
   const head = searchHead({ page_size: 4, pages: 2, results: 8 });
   const page = (postings, overrides = {}) => ({
-    schema_version: 1,
+    schema_version: 2,
     term: "ring",
     page: 1,
     postings,
@@ -1761,7 +1761,7 @@ test("a postings page must be the page it was asked for, in order, and no longer
   );
   assert.throws(() => validateSearchPage(page(["PALOMAR-2026-07-29-000001"]), "ring", 1, head),
     /malformed/);
-  assert.throws(() => validateSearchPage(page(rows, { schema_version: 2 }), "ring", 1, head),
+  assert.throws(() => validateSearchPage(page(rows, { schema_version: 3 }), "ring", 1, head),
     /schema_version/);
 });
 
@@ -1788,26 +1788,26 @@ test("the published stopword list is read, and refused if it becomes a dictionar
     stopwordsUrl(SEARCH_BASE).href,
     "https://data.example.test/search/stopwords.json",
   );
-  const dropped = validateStopwords({ schema_version: 1, stopwords: ["the", "of"] });
+  const dropped = validateStopwords({ schema_version: 2, stopwords: ["the", "of"] });
   assert.ok(dropped.has("the") && !dropped.has("ring"));
 
   assert.throws(
-    () => validateStopwords({ schema_version: 1, stopwords: ["The"] }),
+    () => validateStopwords({ schema_version: 2, stopwords: ["The"] }),
     /not a word/,
   );
   assert.throws(
-    () => validateStopwords({ schema_version: 1, stopwords: [7] }),
+    () => validateStopwords({ schema_version: 2, stopwords: [7] }),
     /must be a non-empty string/,
   );
   assert.throws(
     () => validateStopwords({
-      schema_version: 1,
+      schema_version: 2,
       stopwords: Array.from({ length: 2001 }, (_unused, index) => `w${index}`),
     }),
     /term dictionary/,
   );
   assert.throws(
-    () => validateStopwords({ schema_version: 2, stopwords: [] }),
+    () => validateStopwords({ schema_version: 3, stopwords: [] }),
     /schema_version/,
   );
 });

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -1035,27 +1035,27 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   await expect(iframe).toHaveAttribute("data-height-adjusted", "true");
   const box = await iframe.boundingBox();
   expect(box.height).toBe(672);
-  await expect(page.locator(".acceptance-callout")).toContainText("Registered on");
-  await expect(page.locator(".acceptance-callout")).toContainText("29 July 2026");
-  await expect(page.locator(".acceptance-callout")).toContainText("Mechanical assurance");
-  await expect(page.locator(".acceptance-callout")).toContainText(
-    "Editorial assurance",
+  await expect(page.locator(".registration-callout")).toContainText("Registered on");
+  await expect(page.locator(".registration-callout")).toContainText("29 July 2026");
+  await expect(page.locator(".registration-callout")).toContainText("Mechanical assurance");
+  await expect(page.locator(".registration-callout")).toContainText(
+    "Automated review",
   );
-  await expect(page.locator(".acceptance-callout")).toContainText("AI-mediated review");
-  const mechanicalAssurance = page.locator(".acceptance-callout p", {
+  await expect(page.locator(".registration-callout")).toContainText("AI-mediated review");
+  const mechanicalAssurance = page.locator(".registration-callout p", {
     hasText: "Mechanical assurance",
   });
   await expect(mechanicalAssurance.locator("code")).toHaveText([
     "Solution.lean",
     "Challenge.lean",
   ]);
-  const editorialAssurance = page.locator(".acceptance-callout p", {
-    hasText: "Editorial assurance",
+  const automatedReview = page.locator(".registration-callout p", {
+    hasText: "Automated review",
   });
-  await expect(editorialAssurance.locator("code")).toHaveText("Challenge.lean");
+  await expect(automatedReview.locator("code")).toHaveText("Challenge.lean");
   await expect(page.getByRole("link", { name: "Archived mechanical report" })).toBeVisible();
   await expect(page.locator(".entry-evidence")).toContainText("Verification workflow commit");
-  await expect(page.getByRole("link", { name: "Archived editorial review" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Archived automated review" })).toBeVisible();
   await expect(page.getByRole("link", { name: "project/Comparator/Answer.lean", includeHidden: true }).first()).toHaveAttribute(
     "href",
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/project/Comparator/Answer.lean`,
@@ -1108,7 +1108,7 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   // coupling this assertion to how many lines of controls precede the frame.
 });
 
-test("a missing formatted Challenge leaves the accepted entry and pinned source usable", async ({ page }) => {
+test("a missing formatted Challenge leaves the registered entry and pinned source usable", async ({ page }) => {
   await page.route("**/challenge-metadata.json", (route) =>
     route.fulfill({ status: 404, body: "not published" }));
 
@@ -1369,7 +1369,7 @@ test("a code with nothing current under it answers, and one never used does not"
   await page.route(/\/database\/subjects\/msc\/05C10\.json$/, (route) => route.fulfill({
     contentType: "application/json",
     body: JSON.stringify({
-      schema_version: 1,
+      schema_version: 2,
       kind: "msc",
       code: "05C10",
       entries: [],
@@ -1400,7 +1400,7 @@ test("an entry shows the decision and the comments, never the scores", async ({ 
   const editorial = page.locator(".entry-editorial");
   await expect(editorial).toBeVisible();
 
-  // The scores decide acceptance and stay beside the database. Not shown, and
+  // The scores inform the filter outcome and stay beside the database. Not shown, and
   // as of the record-is-the-committed-file change, not served at all:
   // the same repository at the same commit scored 5 and then 4 on the same
   // axis across two runs, and a number that moves like that reads as a
@@ -1426,14 +1426,14 @@ test("what was checked is compressed without losing what it said", async ({ page
 
   // Both kinds of assurance are named, and the names stand out from the prose.
   await expect(evidence.locator("strong", { hasText: "Mechanical assurance" })).toBeVisible();
-  await expect(evidence.locator("strong", { hasText: "Editorial assurance" })).toBeVisible();
+  await expect(evidence.locator("strong", { hasText: "Automated review" })).toBeVisible();
 
   const labels = await evidence.locator(".details .detail-row dt").allTextContents();
 
-  // One date, to the minute. Acceptance and Lean verification were always the
-  // same day, so the second row said nothing the first did not.
-  expect(labels).toContain("Verified and accepted");
-  expect(labels).not.toContain("Acceptance date");
+  // The mechanical verification instant is shown once, to the minute; the
+  // registration date is already prominent in the callout above.
+  expect(labels).toContain("Mechanically verified");
+  expect(labels).not.toContain("Registration date");
   expect(labels).not.toContain("Lean verification date");
   await expect(evidence).toContainText("UTC");
 
@@ -1711,7 +1711,7 @@ test("transient and invalid availability responses are both retried", async ({ p
       return;
     }
     if (availabilityRequests === 2) {
-      await route.fulfill({ status: 200, json: { schema_version: 1 } });
+      await route.fulfill({ status: 200, json: { schema_version: 2 } });
       return;
     }
     await route.continue();

--- a/tests/source-preservation.test.mjs
+++ b/tests/source-preservation.test.mjs
@@ -265,7 +265,7 @@ test("validation's one receipt traversal serves every later source lookup", () =
   assert.equal(JSON.stringify(record), serialized, "the private index does not alter serialized data");
 });
 
-test("post-validation receipt-row mutation cannot change the accepted mapping", () => {
+test("post-validation receipt-row mutation cannot change the validated mapping", () => {
   const record = acceptedEntry();
   const acceptedFork = record.preservation.repositories[0].fork_repository;
   record.preservation.repositories[0].source_repository = "example/changed";

--- a/tests/statement-preview.test.mjs
+++ b/tests/statement-preview.test.mjs
@@ -355,7 +355,7 @@ test("an absent or unusable companion document leaves the listing alone", async 
     ["absent", null, null],
     ["naming no such result", recentRenders([renderRow({ id: "PALOMAR-2026-07-29-000999" })]), null],
     ["naming another version", recentRenders([renderRow({ version: 7 })]), null],
-    ["malformed", { schema_version: 1, renders: [{ id: "nope" }] }, /invalid registry data/],
+    ["malformed", { schema_version: 2, renders: [{ id: "nope" }] }, /invalid registry data/],
   ]) {
     await t.test(name, async () => {
       const browser = fakeBrowser();
@@ -393,7 +393,7 @@ test("without a pointer that can rest, nothing is registered or bound", async ()
 test("a lookup refuses a companion document that was never validated", () => {
   const raw = recentRenders();
   assert.throws(() => recentRenderRow(raw, raw.renders[0].id), /was not validated/);
-  const accepted = validateRecentRenders(recentRenders());
-  assert.equal(recentRenderRow(accepted, "PALOMAR-2026-07-29-000123").version, 1);
-  assert.equal(recentRenderRow(accepted, "PALOMAR-2026-07-29-000999"), null);
+  const validated = validateRecentRenders(recentRenders());
+  assert.equal(recentRenderRow(validated, "PALOMAR-2026-07-29-000123").version, 1);
+  assert.equal(recentRenderRow(validated, "PALOMAR-2026-07-29-000999"), null);
 });

--- a/tests/subject-pages.test.js
+++ b/tests/subject-pages.test.js
@@ -58,7 +58,7 @@ const ROW = (day, serial) => ({
   id: `PALOMAR-${day}-${String(serial).padStart(6, "0")}`,
   version: 1,
   title: `Result ${serial}`,
-  status: "accepted",
+  status: "registered",
   path: `entries/PALOMAR-${day}-${String(serial).padStart(6, "0")}-v1.json`,
   published_at: `${day}T09:00:${String(serial).padStart(2, "0")}Z`,
   classification: { arxiv: ["math.AG"], msc2020: ["14A10"] },
@@ -75,7 +75,7 @@ function archive({ versions = 4 } = {}) {
   const older = [ROW("2026-06-01", 1), ROW("2026-06-01", 2)];
   return {
     head: {
-      schema_version: 1,
+      schema_version: 2,
       kind: "arxiv",
       code: "math.AG",
       entries: [newer[1], newer[0]],
@@ -84,7 +84,7 @@ function archive({ versions = 4 } = {}) {
       years: [{ year: "2026", days: 2, results: 4, versions: 4 }],
     },
     year: {
-      schema_version: 1,
+      schema_version: 2,
       year: "2026",
       days: [
         { day: "2026-06-01", first_page: 1, last_page: 1, results: 2, versions: 2 },
@@ -92,8 +92,8 @@ function archive({ versions = 4 } = {}) {
       ],
     },
     pages: new Map([
-      ["2026-06-01:1", { schema_version: 1, day: "2026-06-01", page: 1, entries: older }],
-      ["2026-06-02:1", { schema_version: 1, day: "2026-06-02", page: 1, entries: newer }],
+      ["2026-06-01:1", { schema_version: 2, day: "2026-06-01", page: 1, entries: older }],
+      ["2026-06-02:1", { schema_version: 2, day: "2026-06-02", page: 1, entries: newer }],
     ]),
   };
 }
@@ -158,7 +158,7 @@ test("a code never used is absent, and a code with nothing current is empty", as
   // the one a reader can act on.
   const empty = subjectPage({
     loadSubjectHead: async () => ({
-      schema_version: 1,
+      schema_version: 2,
       kind: "arxiv",
       code: "math.AG",
       entries: [],


### PR DESCRIPTION
## What changed\n\n- Replace “accepted results” with “registered results” across public pages, feeds, and the homepage metric.\n- Report automated reviews as identifying no problems or no blocking problems.\n- Consume entry schema v3 and the renamed registration/review fields.\n- Retain the checkmark on entry pages and rename its styling from acceptance to registration.\n- Update browser and contract fixtures without including the separately merged clean-URL work.\n\n## Why\n\nThe automated review is a filter, not an acceptance or endorsement. Public wording should say what it actually established.\n\n## Impact\n\nThis is a coordinated consumer change for Database schema v3. Navigation and entry behavior are otherwise unchanged.\n\n## Checks\n\n- 239 Node tests passed.\n- 80 Playwright tests passed under Nix Chromium; 2 CI-only tests skipped as expected.\n- Cross-repository Database contract tests passed.\n- git diff --check passed.