### PR TITLE
Document source contributor roles in submission guide

### DIFF
--- a/how-to-submit.html
+++ b/how-to-submit.html
@@ -185,6 +185,16 @@
           commit.
         </p>
         <p>
+          Use <code>sources[].authors</code> only for bibliographic authorship.
+          To credit someone for another source role, use
+          <code>sources[].contributors</code>; each contributor has a
+          <code>name</code> and a free-form <code>role</code>, such as
+          <code>editor</code> or <code>problem proposer</code>. The
+          <a href="https://github.com/PalomarRegistry/PalomarTemplate/blob/main/formalization.yaml">starter metadata</a>
+          shows the exact YAML shape. Palomar publishes these credits with the
+          source and displays them on the registry entry.
+        </p>
+        <p>
           Submit only if you are a responsible author or maintainer of the
           substantive formalization, or have approval from one. For a thin
           wrapper this means the people responsible for the underlying

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -1048,6 +1048,20 @@ test("the extra-axioms FAQ names the standard three Lean axioms", async () => {
   assert.doesNotMatch(section[0], /comparator-configuration|current/i);
 });
 
+test("the submission guide distinguishes source authors from other contributors", async () => {
+  const guide = await readFile(new URL("../how-to-submit.html", import.meta.url), "utf8");
+  const section = /<h3 id="formalization-yaml">[\s\S]*?<\/section>/.exec(guide);
+  assert.notEqual(section, null);
+  assert.match(section[0], /sources\[\]\.authors/);
+  assert.match(section[0], /bibliographic authorship/);
+  assert.match(section[0], /sources\[\]\.contributors/);
+  assert.match(section[0], /free-form <code>role<\/code>/);
+  assert.match(section[0], /editor/);
+  assert.match(section[0], /problem proposer/);
+  assert.match(section[0], /PalomarTemplate\/blob\/main\/formalization\.yaml/);
+  assert.match(section[0], /displays them on the registry entry/);
+});
+
 test("the public documentation says what registration publishes, and what it does not", async () => {
   // About said the submitter's identity becomes public on registration. It
   // does not, the schema has no field for it, and that is the direction of


### PR DESCRIPTION
## Summary

- distinguish bibliographic source authors from other credited source roles in the public submission guide
- document `sources[].contributors` and its free-form `role`
- link the starter metadata containing the exact YAML shape
- state that contributor credits are published and displayed on registry entries

## Verification

- `PALOMAR_DATABASE_CHECKOUT=../PalomarDatabase npm test` (241 passed)
- targeted Playwright submission-guide test with Nixpkgs Chromium (1 passed)
- `git diff --check`
