### PR TITLE
feat: filter the registry by the beginning of an MSC code

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ The toolbar also filters the rows the landing page holds by text or trust, with
 the arXiv and MSC2020 subject inputs on its line, at its right edge, and a deep
 link such as `?arxiv=math.AG` fills them in. The classification fields suggest codes represented by those rows but also accept
 any exact code, so such a deep link produces a useful empty result even before
-that classification has an entry. That filter is over `recent.json`, which is
+that classification has an entry. The MSC2020 field takes the beginning of a
+code as well as a whole one, in either case: `11` keeps every code in number
+theory, `11P` narrows that to additive number theory, and `11P32` names one
+section. That filter is over `recent.json`, which is
 the newest 200 current versions and not the registry, so it narrows what is on
 the page rather than searching everything; the search box does the latter, a
 word at a time, over titles, abstracts and author names, and the subject pages

--- a/assets/app.js
+++ b/assets/app.js
@@ -39,7 +39,11 @@ import {
 
 const params = new URLSearchParams(window.location.search);
 const ARXIV_FILTER_RE = /^[a-z]+(?:-[a-z]+)*(?:\.[A-Za-z-]+)?$/;
-const MSC2020_FILTER_RE = /^[0-9]{2}(?:[A-Z][0-9]{2}|-[0-9]{2})$/;
+// Every MSC2020 code is five characters: two digits for the subject, then
+// either a letter or a hyphen, then two more digits. A reader knows the
+// subject long before the section, so the filter takes any prefix of that
+// shape ("11", "11P", "11P3") and matches every code that begins with it.
+const MSC2020_FILTER_RE = /^[0-9]{1,2}$|^[0-9]{2}[A-Z-][0-9]{0,2}$/;
 const FILTER_UPDATE_DELAY_MS = 200;
 // Longer than the classification filter above, because each registry search
 // costs a stopword read, a head read per word, posting pages, and up to sixty
@@ -488,7 +492,9 @@ async function renderIndex() {
     // can stay instant and local.
     const update = () => {
       const arxivValue = arxiv?.value.trim() || "";
-      const mscValue = msc?.value.trim() || "";
+      // Codes are written in upper case in the registry, and typing one in
+      // lower case is not a mistake worth an error message.
+      const mscValue = (msc?.value.trim() || "").toUpperCase();
       const arxivInvalid = Boolean(arxivValue && !ARXIV_FILTER_RE.test(arxivValue));
       const mscInvalid = Boolean(mscValue && !MSC2020_FILTER_RE.test(mscValue));
       let shown = 0;
@@ -496,7 +502,9 @@ async function renderIndex() {
         const visible =
           (trust === "all" || card.dataset.trust === trust) &&
           (!arxivValue || (!arxivInvalid && card.dataset.arxiv.split(" ").includes(arxivValue))) &&
-          (!mscValue || (!mscInvalid && card.dataset.msc.split(" ").includes(mscValue)));
+          (!mscValue ||
+            (!mscInvalid &&
+              card.dataset.msc.split(" ").some((code) => code.startsWith(mscValue))));
         card.hidden = !visible;
         if (visible) shown += 1;
       }

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
             </label>
             <datalist id="arxiv-options"></datalist>
             <label>MSC:
-              <input id="msc-query" type="search" list="msc-options" maxlength="5" placeholder="e.g. 05C10" autocomplete="off" spellcheck="false">
+              <input id="msc-query" type="search" list="msc-options" maxlength="5" placeholder="e.g. 05 or 05C10" autocomplete="off" spellcheck="false">
             </label>
             <datalist id="msc-options"></datalist>
           </div>

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -329,6 +329,44 @@ test("registry entries can be filtered by arXiv and MSC classifications", async 
   await expect(page.locator(".entry-card:visible")).toContainText("000123");
 });
 
+test("an MSC filter matches every code beginning with what was typed", async ({ page }) => {
+  await page.goto(`/?database=${database}`);
+  await expect(page.locator(".entry-card:visible")).toHaveCount(2);
+
+  // 000123 is 05C10, 000124 is 11N13.
+  await page.locator("#msc-query").fill("11");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(1);
+  await expect(page.locator(".entry-card:visible")).toContainText("000124");
+  await expect(page.locator("#status")).toBeHidden();
+
+  await page.locator("#msc-query").fill("11n");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(1);
+  await expect(page.locator(".entry-card:visible")).toContainText("000124");
+
+  await page.locator("#msc-query").fill("11N1");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(1);
+  await expect(page.locator(".entry-card:visible")).toContainText("000124");
+
+  await page.locator("#msc-query").fill("12");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(0);
+  await expect(page.locator("#status")).toHaveText(
+    "No registry entries match the current filters. Classification query: MSC2020 12.",
+  );
+
+  await page.locator("#msc-query").fill("1N");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(0);
+  await expect(page.locator("#status")).toHaveText(
+    "No registry entries match the current filters. Invalid classification code format: MSC2020.",
+  );
+});
+
+test("an MSC prefix applies from a deep link", async ({ page }) => {
+  await page.goto(`/?database=${database}&msc=11`);
+  await expect(page.locator("#msc-query")).toHaveValue("11");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(1);
+  await expect(page.locator(".entry-card:visible")).toContainText("000124");
+});
+
 test("classification filters apply from a deep link", async ({ page }) => {
   await page.goto(`/?database=${database}&arxiv=math.NT`);
   await expect(page.locator("#arxiv-query")).toBeVisible();


### PR DESCRIPTION
This PR lets the landing page's MSC2020 filter take the beginning of a code rather than only a whole one, so `11` keeps every code in number theory, `11P` narrows that to additive number theory, and `11P32` names one section. Typing the first two digits is how a reader who knows the subject but not the section reaches it, and until now it failed the five-character format check and answered with an invalid-code error. Case is no longer significant either, since `11p32` is a typing habit and not a mistake worth an error message.

A value that cannot begin any code, such as `1N`, is still an error. A well-formed prefix with nothing behind it, such as `12` on a page holding no number-theory results, gets the ordinary empty result and its classification query, which is what a deep link needs.

🤖 Prepared with Claude Code