### PR TITLE
feat: order the registry by either of a result's dates, in a date range

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,17 @@
   entry page's render-metadata correspondence check; it is a preview of an
   immutable artifact at a content address, and the entry page remains where a
   rendering is tied to its accepted record.
+  `assets/registry-dates.mjs` owns the two dates a registered result has — the
+  first-registration day its identifier carries, and the instant the listed
+  version was registered — together with the order each one implies, the
+  inclusive day window the landing toolbar filters by, and which of the two a
+  card leads with. The first-registration day is read from the identifier and
+  not from a row field: the publisher requires an entry's `first_registered_on`
+  to equal its identifier's day, so ordering and filtering by it costs no
+  addition to the closed `recent.json` row contract. `app.js` wires those to
+  the toolbar and rearranges the cards the grid already holds rather than
+  rebuilding them, because a rebuilt card loses its hover-preview registration
+  and whatever the availability answer decorated it with;
   `assets/app.js` owns remaining page composition and controller wiring. Do not
   duplicate registry-document validation, source resolution, or route
   orchestration across those modules; the route module still rejects malformed

--- a/README.md
+++ b/README.md
@@ -58,9 +58,25 @@ any exact code, so such a deep link produces a useful empty result even before
 that classification has an entry. The MSC2020 field takes the beginning of a
 code as well as a whole one, in either case: `11` keeps every code in number
 theory, `11P` narrows that to additive number theory, and `11P32` names one
-section. That filter is over `recent.json`, which is
-the newest 200 current versions and not the registry, so it narrows what is on
-the page rather than searching everything; the search box does the latter, a
+section.
+
+A result has two dates and the toolbar's second line says which one it means. A
+result's identifier carries the day its version 1 was registered and every later
+version inherits it, while the card's own date is the instant that version was
+registered, so a new version of an old result is new by one date and old by the
+other. "Order by: latest version" arranges the page by the second, which is the
+publisher's own newest-first order; "first registration" arranges it by the
+first, which is what a reader looking for results that are new to the registry
+means. The `from` and `to` fields bound the same date, inclusively at both ends,
+and `?order=registered&from=2026-08-01` fills all three in from a link. A card
+leads with the day its listing is arranged by and names the other underneath
+when they differ, so the leading dates run down the page in the page's order.
+
+Those filters are over `recent.json`, which is
+the newest 200 current versions and not the registry, so they narrow what is on
+the page rather than searching everything: a range reaching back before the
+oldest row says so rather than answering for days the page does not hold. The
+search box searches everything, a
 word at a time, over titles, abstracts and author names, and the subject pages
 answer a code exactly.
 Search accepts at most 4,096 characters and 20 distinct normalized words. The

--- a/assets/app.js
+++ b/assets/app.js
@@ -28,6 +28,17 @@ import { createStatementPreview } from "./statement-preview.mjs";
 import { renderSubjectPage } from "./subject-pages.mjs";
 import { presentationAbstract } from "./presentation-text.mjs";
 import {
+  DEFAULT_ORDER,
+  FIRST_REGISTRATION_ORDER,
+  cardDates,
+  compareRows,
+  dayWindow,
+  normalizeOrder,
+  orderedDay,
+  registrationDay,
+  withinWindow,
+} from "./registry-dates.mjs";
+import {
   bindSourceControl,
   createSourceAvailabilityBinding,
   createSourceAvailabilityNotice,
@@ -218,25 +229,6 @@ function categoryTokens(entry) {
   return tokens;
 }
 
-/**
- * The day this version was registered.
- *
- * Not `first_registered_on`, which is the *result's* date: the identifier carries it,
- * every later version inherits it, and it is already on the card beside this.
- * So a v2 labelled by it named a day years before that version existed, and on
- * a page ordered by registration the visible dates ran out of order.
- *
- * There is no fallback to the review's date any more. A review's outcome and
- * the registration it leads to are different moments, and the record carries
- * `registered_at` for exactly this.
- */
-function registrationDate(value) {
-  if (!/^\d{4}-\d{2}-\d{2}T/.test(value || "")) {
-    throw new Error("entry is missing a valid registration date");
-  }
-  return value.slice(0, 10);
-}
-
 function displayDate(value) {
   return new Intl.DateTimeFormat("en-GB", {
     day: "numeric",
@@ -295,9 +287,34 @@ function searchBlob(entry) {
   ].join(" ").toLowerCase();
 }
 
+function dateSpans({ id, registeredAt }, order) {
+  return cardDates({ id, registeredAt }, order).map(({ className, label, day }) =>
+    el("span", className, `${label} ${displayDate(day)}`));
+}
+
+/**
+ * Date a card again after the grid is rearranged.
+ *
+ * The dates are rewritten rather than the card rebuilt: a card carries a hover
+ * preview registration and whatever the availability answer decorated it with,
+ * and neither survives being replaced by an equal one.
+ */
+function setCardDates(card, row, order) {
+  const identity = card.querySelector(".card-identity");
+  identity.replaceChildren(
+    identity.querySelector(".entry-id"),
+    ...dateSpans(row, order),
+  );
+}
+
 function entryCard(
   entry,
-  { versionCount = null, current = false, registeredAt = entry.registered_at } = {},
+  {
+    versionCount = null,
+    current = false,
+    registeredAt = entry.registered_at,
+    order = DEFAULT_ORDER,
+  } = {},
 ) {
   const categories = classification(entry);
   const card = el("article", "entry-card");
@@ -311,7 +328,7 @@ function entryCard(
   const identity = el("div", "card-identity");
   identity.append(
     el("span", "entry-id", `${entry.id} v${entry.version}${current ? " · current" : ""}`),
-    el("span", "entry-date", `Registered ${displayDate(registrationDate(registeredAt))}`),
+    ...dateSpans({ id: entry.id, registeredAt }, order),
   );
   top.append(identity, trustBadge(entry));
   const title = el("h3");
@@ -381,6 +398,16 @@ function setLandingStatusHidden(hidden) {
   if (status) status.hidden = landingSuppressed || hidden;
 }
 
+/** The day window the toolbar is holding, named by the date it applies to. */
+function describeWindow(dates, order) {
+  const subject = order === FIRST_REGISTRATION_ORDER ? "First registered" : "Registered";
+  if (dates.from && dates.to) {
+    return `${subject} between ${displayDate(dates.from)} and ${displayDate(dates.to)}`;
+  }
+  if (dates.from) return `${subject} on or after ${displayDate(dates.from)}`;
+  return `${subject} on or before ${displayDate(dates.to)}`;
+}
+
 function setLandingSuppressed(suppressed) {
   landingSuppressed = suppressed;
   // A panel outlives the card it was raised from unless something says so:
@@ -429,13 +456,48 @@ async function renderIndex() {
     setLandingStatusHidden(true);
     status.textContent = "";
     status.className = "status";
+    const orderControl = document.querySelector("#order-by");
+    const fromControl = document.querySelector("#date-from");
+    const toControl = document.querySelector("#date-to");
+    if (orderControl && params.has("order")) {
+      orderControl.value = normalizeOrder(params.get("order"));
+    }
+    for (const [control, name] of [[fromControl, "from"], [toControl, "to"]]) {
+      if (control && params.has(name)) control.value = params.get(name).slice(0, 10);
+    }
+    // A deployment's HTML and its JavaScript can be a moment apart on GitHub
+    // Pages, so the order is read from the control when the page has one and
+    // from the link when it does not.
+    let order = normalizeOrder(orderControl ? orderControl.value : params.get("order"));
     const cards = entries.map((entry) =>
       entryCard(entry, {
         versionCount: entry.versions,
         current: true,
         registeredAt: entry.published_at,
+        order,
       }));
-    grid.append(...cards);
+    // The rows the grid is arranged and filtered by, paired with the cards
+    // showing them, so that neither question has to read a card back.
+    const listed = entries.map((entry, index) => ({
+      card: cards[index],
+      row: { id: entry.id, registeredAt: entry.published_at },
+    }));
+    /**
+     * The cards, in the order asked for, dated by the day that order keys on.
+     *
+     * Appending a card already in the grid moves it, so this rearranges the
+     * cards rather than rebuilding them: a rebuilt card would lose its hover
+     * preview registration and whatever the availability answer decorated it
+     * with.
+     */
+    const arrange = () => {
+      statementPreview.close();
+      const ordered = [...listed].sort((left, right) =>
+        compareRows(left.row, right.row, order));
+      for (const item of ordered) setCardDates(item.card, item.row, order);
+      grid.append(...ordered.map((item) => item.card));
+    };
+    arrange();
     void availabilityPromise.then((availability) => {
       decorateCardSet(cards, entries, availability, "Landing card");
     }).catch((error) => {
@@ -497,18 +559,22 @@ async function renderIndex() {
       const mscValue = (msc?.value.trim() || "").toUpperCase();
       const arxivInvalid = Boolean(arxivValue && !ARXIV_FILTER_RE.test(arxivValue));
       const mscInvalid = Boolean(mscValue && !MSC2020_FILTER_RE.test(mscValue));
+      const dates = dayWindow({ from: fromControl?.value, to: toControl?.value });
       let shown = 0;
-      for (const card of grid.children) {
+      let oldest = null;
+      for (const { card, row } of listed) {
+        const day = orderedDay(row, order);
+        if (oldest === null || day < oldest) oldest = day;
         const visible =
           (trust === "all" || card.dataset.trust === trust) &&
           (!arxivValue || (!arxivInvalid && card.dataset.arxiv.split(" ").includes(arxivValue))) &&
           (!mscValue ||
             (!mscInvalid &&
-              card.dataset.msc.split(" ").some((code) => code.startsWith(mscValue))));
+              card.dataset.msc.split(" ").some((code) => code.startsWith(mscValue)))) &&
+          withinWindow(day, dates);
         card.hidden = !visible;
         if (visible) shown += 1;
       }
-      setLandingStatusHidden(shown !== 0);
       const classificationQuery = [
         arxivValue && `arXiv ${arxivValue}`,
         mscValue && `MSC2020 ${mscValue}`,
@@ -517,24 +583,54 @@ async function renderIndex() {
         arxivInvalid && "arXiv",
         mscInvalid && "MSC2020",
       ].filter(Boolean);
+      const classificationReason = invalidClassifications.length
+        ? `Invalid classification code format: ${invalidClassifications.join(", ")}.`
+        : classificationQuery.length
+        ? `Classification query: ${classificationQuery.join(", ")}.`
+        : "";
+      const dateReason = dates.malformed.length
+        ? `Invalid date: ${dates.malformed.join(", ")}.`
+        : dates.empty
+        ? "The date range ends before it begins."
+        : dates.active
+        ? `${describeWindow(dates, order)}.`
+        : "";
+      // This page is the newest results and not the whole registry, so a range
+      // that reaches past its oldest row reaches past what it can answer for.
+      // Said whether or not anything matched, because a reader who gets some of
+      // the range back has no way to tell that it was not all of it.
+      const reachesEarlier = Boolean(
+        dates.from && !dates.malformed.length && !dates.empty && oldest && dates.from < oldest,
+      );
+      const boundReason = reachesEarlier
+        ? `${order === FIRST_REGISTRATION_ORDER ? "Results first registered" : "Versions registered"} ` +
+          `before ${displayDate(oldest)} are not on this page.`
+        : "";
+      const reasons = [classificationReason, dateReason, boundReason].filter(Boolean);
       status.textContent = shown
-        ? ""
-        : invalidClassifications.length
-          ? `No registry entries match the current filters. Invalid classification code format: ${invalidClassifications.join(", ")}.`
-          : classificationQuery.length
-          ? `No registry entries match the current filters. Classification query: ${classificationQuery.join(", ")}.`
-          : "No registry entries match those filters.";
+        ? boundReason
+        : reasons.length
+        ? `No registry entries match the current filters. ${reasons.join(" ")}`
+        : "No registry entries match those filters.";
+      setLandingStatusHidden(Boolean(shown) && !boundReason);
     };
     let updateTimer;
     const scheduleUpdate = () => {
       window.clearTimeout(updateTimer);
       updateTimer = window.setTimeout(update, FILTER_UPDATE_DELAY_MS);
     };
-    for (const control of [arxiv, msc]) {
+    for (const control of [arxiv, msc, fromControl, toControl]) {
       for (const eventName of ["input", "change", "search"]) {
         control?.addEventListener(eventName, scheduleUpdate);
       }
     }
+    // Not on the delay the text fields use. Choosing an order is one act on a
+    // list, not a word being typed a letter at a time.
+    orderControl?.addEventListener("change", () => {
+      order = normalizeOrder(orderControl.value);
+      arrange();
+      update();
+    });
     document.querySelectorAll(".filter").forEach((button) => {
       button.addEventListener("click", () => {
         trust = button.dataset.trust;
@@ -1046,7 +1142,7 @@ function registrationCallout(entry, databaseBase) {
     ),
   );
   copy.append(
-    el("strong", "", `Registered on ${displayDate(registrationDate(entry.registered_at))}`),
+    el("strong", "", `Registered on ${displayDate(registrationDay(entry.registered_at))}`),
     assurance(
       "Mechanical assurance",
       "Comparator checked that the recorded ",
@@ -1511,7 +1607,7 @@ function renderSubjectRows(rows, content) {
     const identity = el("div", "card-identity");
     identity.append(
       el("span", "entry-id", `${row.id} v${row.version}`),
-      el("span", "entry-date", `Registered ${displayDate(registrationDate(row.published_at))}`),
+      el("span", "entry-date", `Registered ${displayDate(registrationDay(row.published_at))}`),
     );
     const title = el("h2");
     title.append(internalLink(row.title, localPageUrl("/entry", row)));

--- a/assets/registry-dates.mjs
+++ b/assets/registry-dates.mjs
@@ -1,0 +1,173 @@
+/**
+ * The two dates a registered result has, and what a listing does with them.
+ *
+ * A result's identifier carries the day its version 1 was registered, and
+ * every later version inherits it. A listing row's registration instant is the
+ * moment the version on the card was registered, which for a v2 is a later day
+ * than the identifier's. Both are real answers to "when": a reader looking for
+ * results that are new to the registry means the first, and a reader looking
+ * for what has changed since they last read means the second. Neither can
+ * stand in for the other, so this module owns both, the order each one
+ * implies, and the inclusive day window a toolbar filters by.
+ *
+ * The first-registration day is read from the identifier rather than from a
+ * row field, because that is where it is: the publisher requires an entry's
+ * `first_registered_on` to equal its identifier's day, and a landing row is
+ * projected from the same identity. Reading it here costs no addition to the
+ * closed landing-row contract.
+ */
+
+const ID_DAY_RE = /^PALOMAR-([0-9]{4}-[0-9]{2}-[0-9]{2})-[0-9]{6}$/;
+const DAY_RE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
+
+/** Order by the instant the listed version was registered. The publisher's own order. */
+export const LATEST_VERSION_ORDER = "updated";
+/** Order by the day the result first entered the registry, newest first. */
+export const FIRST_REGISTRATION_ORDER = "registered";
+
+export const ORDERS = [LATEST_VERSION_ORDER, FIRST_REGISTRATION_ORDER];
+export const DEFAULT_ORDER = LATEST_VERSION_ORDER;
+
+/**
+ * The requested order, or the default.
+ *
+ * Anything unrecognised is the default rather than an error: an order is a way
+ * of arranging what the page already holds, and a stale or mistyped link
+ * should still show the registry.
+ */
+export function normalizeOrder(value) {
+  return ORDERS.includes(value) ? value : DEFAULT_ORDER;
+}
+
+/**
+ * The day of a registration instant.
+ *
+ * A record's timestamps are UTC and the days derived from them are UTC days,
+ * so the slice is the answer and a local-time conversion would be a different
+ * question.
+ */
+export function registrationDay(value) {
+  if (!/^[0-9]{4}-[0-9]{2}-[0-9]{2}T/.test(value || "")) {
+    throw new Error("entry is missing a valid registration date");
+  }
+  return value.slice(0, 10);
+}
+
+/** The day version 1 of this result was registered, from its identifier. */
+export function firstRegistrationDay(id) {
+  const match = ID_DAY_RE.exec(String(id ?? ""));
+  if (!match) throw new Error("entry is missing a valid identifier");
+  return match[1];
+}
+
+/** The day a listing keys on under one order. */
+export function orderedDay({ id, registeredAt }, order) {
+  return normalizeOrder(order) === FIRST_REGISTRATION_ORDER
+    ? firstRegistrationDay(id)
+    : registrationDay(registeredAt);
+}
+
+/**
+ * Newest first, under either order.
+ *
+ * Under the latest-version order this is the instant, and identifiers break
+ * its ties, which is exactly the order the publisher writes its newest-first
+ * selection in: applying it to that document changes nothing.
+ *
+ * Under the first-registration order it is the identifier alone. Serials are
+ * allocated contiguously within a day in the order results are registered, so
+ * a whole identifier already sorts results by when they entered the registry,
+ * to a finer resolution than its day.
+ */
+export function compareRows(left, right, order) {
+  if (normalizeOrder(order) === FIRST_REGISTRATION_ORDER) {
+    return compareIdentifiers(left.id, right.id);
+  }
+  const difference = Date.parse(right.registeredAt) - Date.parse(left.registeredAt);
+  if (difference) return difference;
+  return compareIdentifiers(left.id, right.id);
+}
+
+function compareIdentifiers(left, right) {
+  if (left === right) return 0;
+  return left < right ? 1 : -1;
+}
+
+/**
+ * A calendar day, or null.
+ *
+ * `type="date"` inputs hold this shape or nothing, but a deep link holds
+ * whatever it was written with, and a browser without the control holds
+ * whatever was typed. A day that does not exist is not a day.
+ */
+export function parseDay(value) {
+  const day = String(value ?? "").trim();
+  if (!DAY_RE.test(day)) return null;
+  const when = new Date(`${day}T00:00:00Z`);
+  if (Number.isNaN(when.getTime())) return null;
+  return when.toISOString().slice(0, 10) === day ? day : null;
+}
+
+/**
+ * The window the two date controls describe.
+ *
+ * Both ends are inclusive: a reader who asks for the 3rd to the 5th means
+ * three days. An end that cannot be read is reported rather than dropped
+ * silently, because a filter that quietly does nothing shows a wider selection
+ * than the one that was asked for.
+ */
+export function dayWindow({ from, to } = {}) {
+  const parsed = { from: parseDay(from), to: parseDay(to) };
+  const malformed = [];
+  if (String(from ?? "").trim() && !parsed.from) malformed.push("from");
+  if (String(to ?? "").trim() && !parsed.to) malformed.push("to");
+  return {
+    from: parsed.from,
+    to: parsed.to,
+    malformed,
+    // Asked for and empty, which is not the same as not asked for.
+    empty: Boolean(parsed.from && parsed.to && parsed.from > parsed.to),
+    active: Boolean(parsed.from || parsed.to || malformed.length),
+  };
+}
+
+/**
+ * Whether a day is inside the window. An unasked-for end bounds nothing.
+ *
+ * A window that cannot be read matches nothing, as an unreadable classification
+ * code does: a filter the reader can see and the page ignores would show a
+ * wider selection than the one on screen claims to be.
+ */
+export function withinWindow(day, range) {
+  if (!range || !range.active) return true;
+  if (range.malformed.length || range.empty) return false;
+  if (range.from && day < range.from) return false;
+  if (range.to && day > range.to) return false;
+  return true;
+}
+
+/**
+ * The dates a card shows, in the order they are shown.
+ *
+ * The order's own day comes first, so that the leading date on every card runs
+ * down the page in the page's order: a card led by a day the page is not
+ * arranged by reads as though the listing were unsorted. The other day follows
+ * only when it differs, which for a single-version result is never.
+ */
+export function cardDates({ id, registeredAt }, order) {
+  const first = firstRegistrationDay(id);
+  const latest = registrationDay(registeredAt);
+  if (first === latest) {
+    return [{ className: "entry-date", label: "Registered", day: latest }];
+  }
+  if (normalizeOrder(order) === FIRST_REGISTRATION_ORDER) {
+    return [
+      { className: "entry-date", label: "First registered", day: first },
+      { className: "entry-origin-date", label: "Latest version", day: latest },
+    ];
+  }
+  return [
+    { className: "entry-date", label: "Registered", day: latest },
+    { className: "entry-origin-date", label: "First registered", day: first },
+  ];
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -353,6 +353,35 @@ button:focus-visible {
   font: .9rem var(--sans);
 }
 
+/* The dates read as one sentence — order by this, from here, to here — so they
+   take the toolbar's second line rather than competing with the filters above
+   for the end of the first. */
+.date-filters {
+  display: flex;
+  flex-basis: 100%;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: .45rem .5rem;
+  font: .8rem var(--sans);
+}
+
+.date-filters select,
+.date-filters input {
+  min-height: 2rem;
+  padding: .25rem .4rem;
+  border: 1px solid var(--field);
+  border-radius: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font: .9rem var(--sans);
+}
+
+.date-filters select:focus-visible,
+.date-filters input:focus-visible {
+  outline: 2px solid var(--link);
+  outline-offset: 2px;
+}
+
 /*
  * The Subjects row of a card. It had no rule of its own for a while and
  * inherited one meant for something else, which is how the codes came to run
@@ -1032,6 +1061,15 @@ footer {
 .entry-date {
   color: var(--muted);
   font: .75rem/1.3 var(--sans);
+}
+
+/* The result's other date, shown only when it differs from the one the listing
+   is arranged by. Quieter than that one, because it is context and not the
+   line's subject. */
+.entry-origin-date {
+  color: var(--muted);
+  font: .72rem/1.3 var(--sans);
+  opacity: .85;
 }
 
 .verification-status {

--- a/index.html
+++ b/index.html
@@ -66,6 +66,17 @@
             </label>
             <datalist id="msc-options"></datalist>
           </div>
+          <div class="date-filters" role="group" aria-label="Registration date">
+            <label for="order-by">Order by:</label>
+            <select id="order-by">
+              <option value="updated">latest version</option>
+              <option value="registered">first registration</option>
+            </select>
+            <label for="date-from">from</label>
+            <input id="date-from" type="date">
+            <label for="date-to">to</label>
+            <input id="date-to" type="date">
+          </div>
         </div>
 
         <div id="status" class="status" role="status">

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -24,6 +24,7 @@ const browserModuleFiles = [
   "formalization-presentation.mjs",
   "loading.mjs",
   "presentation-text.mjs",
+  "registry-dates.mjs",
   "registry-loading.mjs",
   "rendering.js",
   "searching.mjs",

--- a/tests/registry-dates.test.mjs
+++ b/tests/registry-dates.test.mjs
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_ORDER,
+  FIRST_REGISTRATION_ORDER,
+  LATEST_VERSION_ORDER,
+  cardDates,
+  compareRows,
+  dayWindow,
+  firstRegistrationDay,
+  normalizeOrder,
+  orderedDay,
+  parseDay,
+  registrationDay,
+  withinWindow,
+} from "../assets/registry-dates.mjs";
+
+const first = { id: "PALOMAR-2026-07-29-000123", registeredAt: "2026-08-02T09:14:07Z" };
+const second = { id: "PALOMAR-2026-07-29-000124", registeredAt: "2026-07-29T09:14:07Z" };
+const third = { id: "PALOMAR-2026-08-13-000001", registeredAt: "2026-08-13T11:00:00Z" };
+
+test("a result's first registration is the day in its identifier", () => {
+  assert.equal(firstRegistrationDay(first.id), "2026-07-29");
+  assert.equal(orderedDay(first, FIRST_REGISTRATION_ORDER), "2026-07-29");
+  assert.equal(orderedDay(first, LATEST_VERSION_ORDER), "2026-08-02");
+  assert.throws(() => firstRegistrationDay("PALOMAR-2026-07-29-12345"), /valid identifier/);
+  assert.throws(() => firstRegistrationDay(undefined), /valid identifier/);
+});
+
+test("a registration day is the UTC day of the instant", () => {
+  assert.equal(registrationDay("2026-08-02T23:59:59Z"), "2026-08-02");
+  assert.throws(() => registrationDay("2026-08-02"), /valid registration date/);
+  assert.throws(() => registrationDay(null), /valid registration date/);
+});
+
+test("an unrecognised order is the default rather than an error", () => {
+  assert.equal(DEFAULT_ORDER, LATEST_VERSION_ORDER);
+  assert.equal(normalizeOrder(FIRST_REGISTRATION_ORDER), FIRST_REGISTRATION_ORDER);
+  assert.equal(normalizeOrder("sideways"), LATEST_VERSION_ORDER);
+  assert.equal(normalizeOrder(undefined), LATEST_VERSION_ORDER);
+});
+
+test("the latest-version order is the instant, and identifiers break its ties", () => {
+  const rows = [second, first, third];
+  assert.deepEqual(
+    [...rows].sort((left, right) => compareRows(left, right, LATEST_VERSION_ORDER))
+      .map((row) => row.id),
+    [third.id, first.id, second.id],
+  );
+  const sameInstant = { id: "PALOMAR-2026-07-29-000200", registeredAt: second.registeredAt };
+  assert.deepEqual(
+    [second, sameInstant].sort((left, right) => compareRows(left, right, LATEST_VERSION_ORDER))
+      .map((row) => row.id),
+    [sameInstant.id, second.id],
+  );
+});
+
+test("the first-registration order is the identifier, day and serial together", () => {
+  // A new version of an older result does not move it ahead of a result that
+  // was registered after it, which is the whole point of asking for this order.
+  assert.deepEqual(
+    [first, second, third].sort((left, right) =>
+      compareRows(left, right, FIRST_REGISTRATION_ORDER)).map((row) => row.id),
+    [third.id, second.id, first.id],
+  );
+});
+
+test("a day is a calendar day or nothing", () => {
+  assert.equal(parseDay("2026-08-02"), "2026-08-02");
+  assert.equal(parseDay("  2026-08-02  "), "2026-08-02");
+  assert.equal(parseDay("2026-02-31"), null);
+  assert.equal(parseDay("2026-8-2"), null);
+  assert.equal(parseDay("last tuesday"), null);
+  assert.equal(parseDay(""), null);
+  assert.equal(parseDay(undefined), null);
+});
+
+test("both ends of the window are inclusive", () => {
+  const range = dayWindow({ from: "2026-08-02", to: "2026-08-13" });
+  assert.equal(range.active, true);
+  assert.equal(range.empty, false);
+  assert.deepEqual(range.malformed, []);
+  assert.equal(withinWindow("2026-08-02", range), true);
+  assert.equal(withinWindow("2026-08-13", range), true);
+  assert.equal(withinWindow("2026-08-01", range), false);
+  assert.equal(withinWindow("2026-08-14", range), false);
+});
+
+test("an open end bounds nothing, and no window bounds nothing", () => {
+  const from = dayWindow({ from: "2026-08-02", to: "" });
+  assert.equal(withinWindow("2026-12-31", from), true);
+  assert.equal(withinWindow("2026-08-01", from), false);
+  const to = dayWindow({ to: "2026-08-02" });
+  assert.equal(withinWindow("2020-01-01", to), true);
+  assert.equal(withinWindow("2026-08-03", to), false);
+  const none = dayWindow({});
+  assert.equal(none.active, false);
+  assert.equal(withinWindow("1999-12-31", none), true);
+});
+
+test("a window that cannot be read, or cannot contain a day, matches nothing", () => {
+  const malformed = dayWindow({ from: "yesterday", to: "2026-08-13" });
+  assert.deepEqual(malformed.malformed, ["from"]);
+  assert.equal(malformed.active, true);
+  assert.equal(withinWindow("2026-08-13", malformed), false);
+  const backwards = dayWindow({ from: "2026-08-13", to: "2026-08-02" });
+  assert.equal(backwards.empty, true);
+  assert.equal(withinWindow("2026-08-05", backwards), false);
+});
+
+test("a card leads with the day its listing is arranged by", () => {
+  assert.deepEqual(cardDates(first, LATEST_VERSION_ORDER), [
+    { className: "entry-date", label: "Registered", day: "2026-08-02" },
+    { className: "entry-origin-date", label: "First registered", day: "2026-07-29" },
+  ]);
+  assert.deepEqual(cardDates(first, FIRST_REGISTRATION_ORDER), [
+    { className: "entry-date", label: "First registered", day: "2026-07-29" },
+    { className: "entry-origin-date", label: "Latest version", day: "2026-08-02" },
+  ]);
+});
+
+test("a result registered once carries one date under either order", () => {
+  for (const order of [LATEST_VERSION_ORDER, FIRST_REGISTRATION_ORDER]) {
+    assert.deepEqual(cardDates(second, order), [
+      { className: "entry-date", label: "Registered", day: "2026-07-29" },
+    ]);
+  }
+});

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -360,6 +360,95 @@ test("an MSC filter matches every code beginning with what was typed", async ({ 
   );
 });
 
+test("the registry can be ordered by when a result first entered it", async ({ page }) => {
+  await page.goto(`/?database=${database}`);
+  // 000123 is a v2 registered on 2 August; 000124 is a v1 registered on 29
+  // July, the same day 000123 first entered the registry.
+  await expect(page.locator(".entry-card .entry-id")).toHaveText([
+    "PALOMAR-2026-07-29-000123 v2 · current",
+    "PALOMAR-2026-07-29-000124 v1 · current",
+  ]);
+  await expect(page.locator(".entry-card").first().locator(".entry-date"))
+    .toHaveText("Registered 2 August 2026");
+  await expect(page.locator(".entry-card").first().locator(".entry-origin-date"))
+    .toHaveText("First registered 29 July 2026");
+  // A result registered once has one date, whichever order the page is in.
+  await expect(page.locator(".entry-card").nth(1).locator(".entry-date"))
+    .toHaveText("Registered 29 July 2026");
+  await expect(page.locator(".entry-card").nth(1).locator(".entry-origin-date")).toHaveCount(0);
+
+  await page.locator("#order-by").selectOption("registered");
+  await expect(page.locator(".entry-card .entry-id")).toHaveText([
+    "PALOMAR-2026-07-29-000124 v1 · current",
+    "PALOMAR-2026-07-29-000123 v2 · current",
+  ]);
+  // The leading date is the one the page is arranged by, so it still runs down
+  // the page in the page's order.
+  await expect(page.locator(".entry-card").nth(1).locator(".entry-date"))
+    .toHaveText("First registered 29 July 2026");
+  await expect(page.locator(".entry-card").nth(1).locator(".entry-origin-date"))
+    .toHaveText("Latest version 2 August 2026");
+});
+
+test("a date range narrows the listing by the date it is ordered by", async ({ page }) => {
+  await page.goto(`/?database=${database}`);
+  await page.locator("#date-from").fill("2026-08-01");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(1);
+  await expect(page.locator(".entry-card:visible")).toContainText("000123");
+  await expect(page.locator("#status")).toBeHidden();
+
+  // The same range against the day each result first entered the registry:
+  // the August version is a new version of a July result, not a new result.
+  await page.locator("#order-by").selectOption("registered");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(0);
+  await expect(page.locator("#status")).toHaveText(
+    "No registry entries match the current filters. First registered on or after 1 August 2026.",
+  );
+
+  await page.locator("#date-from").fill("2026-07-29");
+  await page.locator("#date-to").fill("2026-07-29");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(2);
+});
+
+test("a range that cannot be read, or cannot hold a day, matches nothing and says so", async ({ page }) => {
+  await page.goto(`/?database=${database}`);
+  await page.locator("#date-from").fill("2026-08-13");
+  await page.locator("#date-to").fill("2026-08-02");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(0);
+  await expect(page.locator("#status")).toHaveText(
+    "No registry entries match the current filters. The date range ends before it begins.",
+  );
+
+  await page.locator("#date-from").fill("");
+  await page.locator("#date-to").fill("");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(2);
+  await expect(page.locator("#status")).toBeHidden();
+});
+
+test("a range reaching past the newest results says what the page cannot answer for", async ({ page }) => {
+  await page.goto(`/?database=${database}&from=2026-01-01`);
+  await expect(page.locator("#date-from")).toHaveValue("2026-01-01");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(2);
+  await expect(page.locator("#status")).toHaveText(
+    "Versions registered before 29 July 2026 are not on this page.",
+  );
+  await expect(page.locator("#status")).not.toHaveClass(/error/);
+});
+
+test("an order and a range apply from a deep link", async ({ page }) => {
+  await page.goto(`/?database=${database}&order=registered&from=2026-07-29&to=2026-07-29`);
+  await expect(page.locator("#order-by")).toHaveValue("registered");
+  await expect(page.locator(".entry-card:visible")).toHaveCount(2);
+  await expect(page.locator(".entry-card").first().locator(".entry-id"))
+    .toHaveText("PALOMAR-2026-07-29-000124 v1 · current");
+
+  // An order nothing offers is the default rather than an empty page.
+  await page.goto(`/?database=${database}&order=sideways`);
+  await expect(page.locator("#order-by")).toHaveValue("updated");
+  await expect(page.locator(".entry-card").first().locator(".entry-id"))
+    .toHaveText("PALOMAR-2026-07-29-000123 v2 · current");
+});
+
 test("an MSC prefix applies from a deep link", async ({ page }) => {
   await page.goto(`/?database=${database}&msc=11`);
   await expect(page.locator("#msc-query")).toHaveValue("11");


### PR DESCRIPTION
This PR adds an order control and an inclusive date range to the registry toolbar, so that a reader can ask for results that are new to the registry rather than for versions that are new.

A result has two dates. Its identifier carries the day its version 1 was registered, which every later version inherits, and its landing row carries the instant the listed version was registered. A new version of an old result is new by the second and old by the first, so a reader looking for what has changed and a reader looking for what has arrived want the page arranged differently. "Order by: latest version" is the publisher's own newest-first order; "first registration" is the identifier, whose serials are allocated contiguously within a day in registration order and so sort finer than the day. The `from` and `to` fields bound whichever date the order keys on, at both ends, and `?order=registered&from=2026-08-01` fills all three in from a link.

A card leads with the day its listing is arranged by and names the other underneath when they differ, so the leading dates run down the page in the page's order under either setting and a v2 no longer reads as a result registered on the day of its latest version.

The first-registration day is read from the identifier rather than from a row field. The publisher requires an entry's `first_registered_on` to equal its identifier's day, so ordering and filtering by it costs no addition to the closed `recent.json` row contract and needs no producer-first deployment. The filters remain over `recent.json`, which is the newest 200 current versions and not the registry, so a range reaching back before its oldest row now says so rather than answering for days the page does not hold.

`assets/registry-dates.mjs` owns the two dates, the order each implies, the window, and the labels; `app.js` wires them to the toolbar and moves the cards the grid already holds rather than rebuilding them, because a rebuilt card loses its hover-preview registration and its source-availability decoration.

Requested by Yakov Pechersky.

🤖 Prepared with Claude Code