### PR TITLE
Say why submissions must be hosted on GitHub

### DIFF
--- a/about.html
+++ b/about.html
@@ -455,6 +455,25 @@
         </p>
       </section>
 
+      <section id="repository-hosting">
+        <h2>Does a Palomar submission have to be hosted by GitHub?</h2>
+        <p>
+          Currently, yes, for technical reasons. Palomar requires a public
+          GitHub repository and a full commit SHA to initiate a submission:
+          GitHub also provides the account that proves write access to the
+          submitted repository, and the continuous integration that runs
+          mechanical verification. The proof project’s own dependencies are not
+          restricted this way — any pinned, publicly readable Git repository may
+          be used — but the submitted snapshot itself must be on GitHub.
+        </p>
+        <p>
+          We are open to supporting other hosts in future if there is enough
+          demand to merit the added code complexity. If you are interested,
+          please raise the issue in the
+          <a href="https://leanprover.zulipchat.com/#narrow/channel/621638-Palomar">Palomar channel on the Lean Zulip</a>.
+        </p>
+      </section>
+
       <section id="other-proof-assistants">
         <h2>What about other proof assistants?</h2>
         <p>

--- a/about.html
+++ b/about.html
@@ -460,9 +460,8 @@
         <p>
           Currently, yes, for technical reasons. Palomar requires a public
           GitHub repository and a full commit SHA to initiate a submission:
-          GitHub also provides the account that proves write access to the
-          submitted repository, and the continuous integration that runs
-          mechanical verification. The proof project’s own dependencies are not
+          We also query Github to ensure the submitter has write access
+          to the registered repository. The proof project’s own dependencies are not
           restricted this way — any pinned, publicly readable Git repository may
           be used — but the submitted snapshot itself must be on GitHub.
         </p>


### PR DESCRIPTION
The GitHub requirement is enforced in `submission_contract.py` (`normalize_repository` rejects anything but `https://github.com/owner/repo`) but stated nowhere on the site, so a reader currently meets it as a form error rather than as a documented constraint.

The reason is worth giving alongside it. GitHub supplies the account that proves write access and the CI that runs mechanical verification — not merely a place to fetch a commit — which is what makes a single host a simplification rather than an arbitrary preference.

The dependency carve-out is included because it is the immediate next question and the answer is the opposite of what the headline implies: `verify_submission.py` accepts any credential-free HTTPS Git URL pinned to a full SHA for Lake manifest packages, so only the submitted snapshot is constrained. (The challenge import surface is separately restricted, so a statement's transitive sources remain GitHub-bound in practice; that is already covered by the permitted-imports answer.)

Placed immediately before **What about other proof assistants?**, whose "currently … however, we are open to expanding" shape this follows, and whose Zulip pointer it reuses so that the demand this defers to has somewhere to be expressed.

Independent of #127 — both add an `about.html` section, but in different places, so they merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)