### PR TITLE
doc: note the dual-kernel replay on the statement page

### DIFF
--- a/statement.html
+++ b/statement.html
@@ -107,7 +107,9 @@
             Palomar record to know exactly what they need to audit (the statement),
             and what is being ensured by Lean. Further, comparator allows Palomar
             to securely check the proof (even in the face of adversarial Lean
-            proofs).
+            proofs). Palomar also replays every exported proof through a second,
+            independently implemented kernel (<code>nanoda</code>) as well as
+            Lean’s own, and publishes the exact commit of each with the entry.
           </li>
           <li>
             Every submission must have a


### PR DESCRIPTION
This PR adds one sentence to the comparator bullet on the statement page, recording that every exported proof is replayed through an independently implemented kernel as well as Lean's own, and that the exact commit of each is published with the entry.

The page's three-technologies list described comparator's separation of statement from proof but stopped short of the independent replay, which is the strongest guarantee the mechanical check offers. `about.html` already documents it, `schema-v3.json` requires `verification.nanoda_commit`, `security.mjs` validates it, and `app.js` renders it on every entry page, so the claim is already backed by published data on every record.

🤖 Prepared with Claude Code