### PR TITLE
feat: add a core-notation statement audit view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,16 @@
   schema-v2 protocols. Source availability and independent render/evidence
   metadata retain their own versioned contracts.
 
+- Challenge render metadata is versioned independently inside each immutable,
+  content-addressed render bundle. A version widening deploys the Web consumer
+  first; PalomarSubmission may emit the new metadata version only after that
+  consumer is live, because the previous consumer rejects unknown versions.
+  This is different from replacing the shape of a closed projection at one
+  version, which remains producer-first. `check-published.mjs --data` must read
+  and validate every available render metadata document in its advertised
+  entry traversal; a missing historical render retains the pinned-source
+  fallback, but malformed metadata fails the deployment.
+
 - `source-availability.json` is normalized by PalomarDatabase's executable
   source-availability contract and consumed under the same per-endpoint
   freshness rules here. A known answer is authoritative only from five minutes

--- a/README.md
+++ b/README.md
@@ -144,8 +144,13 @@ matches its manifest observations, resolves repository locations, publishes the
 progressive entry result, and decorates existing source controls,
 `entry-pages.mjs` owns entry-route input and page-state
 transitions, `challenge-presentation.mjs` owns the named-declarations artifact's
-entry correspondence, source and Mathlib playground controls, and presentation
-states, `formalization-presentation.mjs`
+entry correspondence, source and Mathlib playground controls, core-notation
+audit disclosure, and presentation states. Render-metadata schema v3 carries an
+`audit_declarations` row for every compared declaration, in the same order as
+`declarations`; each row has exactly `name` and `declaration`, and the browser
+refuses a v3 document whose rows do not correspond to the accepted entry.
+Historical v1/v2 render metadata remains readable but does not claim to provide
+an audit view. `formalization-presentation.mjs`
 owns statement trust labels and the statement/proof dependency presentation,
 `entry-history-presentation.mjs` owns the entry page's canonical link,
 supersession notice, and immutable version-history section;

--- a/README.md
+++ b/README.md
@@ -150,7 +150,17 @@ audit disclosure, and presentation states. Render-metadata schema v3 carries an
 `declarations`; each row has exactly `name` and `declaration`, and the browser
 refuses a v3 document whose rows do not correspond to the accepted entry.
 Historical v1/v2 render metadata remains readable but does not claim to provide
-an audit view. `formalization-presentation.mjs`
+an audit view. A render-metadata version widening deploys Web first and the
+Submission producer may emit the new version only after that consumer is live;
+this is the reverse of a closed projection's producer-first shape replacement,
+because the existing Web consumer rejects a version it does not know.
+`check-published.mjs --data` reads and validates every available render metadata
+document in the advertised entry traversal before deployment. The audit view
+closes author-defined notation and macro spoofing, but it does not expose
+misleading instances, inserted coercions, or definitions whose names hide the
+wrong meaning. If Lean reaches a pretty-printer resource limit, it marks the
+omitted subterm with `⋯` rather than silently inventing text.
+`formalization-presentation.mjs`
 owns statement trust labels and the statement/proof dependency presentation,
 `entry-history-presentation.mjs` owns the entry page's canonical link,
 supersession notice, and immutable version-history section;

--- a/assets/challenge-presentation.mjs
+++ b/assets/challenge-presentation.mjs
@@ -54,7 +54,7 @@ export function validateChallengeMetadata(entry, metadata) {
     Array.isArray(left) && left.length === right.length &&
       left.every((value, index) => value === right[index]);
   if (
-    ![1, 2].includes(metadata?.schema_version) ||
+    ![1, 2, 3].includes(metadata?.schema_version) ||
     !sameArray(metadata.declarations, expectedDeclarations) ||
     !sameArray(metadata.imports, expectedImports) ||
     !(metadata.module_doc === null ||
@@ -69,6 +69,31 @@ export function validateChallengeMetadata(entry, metadata) {
       !metadata.solution_imports.every((item) => typeof item === "string" && item.length > 0))
   ) {
     throw new Error("Challenge render metadata contains invalid Solution imports");
+  }
+  if (metadata.schema_version >= 3) {
+    const audit = metadata.audit_declarations;
+    let auditCharacters = 0;
+    if (
+      !Array.isArray(audit) ||
+      audit.length !== expectedDeclarations.length ||
+      !audit.every((item, index) => {
+        if (
+          !item ||
+          typeof item !== "object" ||
+          Array.isArray(item) ||
+          Object.keys(item).sort().join(",") !== "declaration,name" ||
+          item.name !== expectedDeclarations[index] ||
+          typeof item.declaration !== "string" ||
+          item.declaration.trim().length === 0
+        ) {
+          return false;
+        }
+        auditCharacters += item.declaration.length;
+        return auditCharacters <= 512 * 1024;
+      })
+    ) {
+      throw new Error("Challenge render metadata contains invalid audit declarations");
+    }
   }
   return metadata;
 }
@@ -211,6 +236,35 @@ export function createChallengePresentation({ fetchJson, document, window, local
     return panel;
   }
 
+  function auditPanel(metadata) {
+    if (metadata.schema_version < 3) return null;
+    const panel = el("details", "challenge-audit");
+    panel.append(
+      el("summary", "", "View core-notation audit"),
+      el(
+        "p",
+        "challenge-audit-intro",
+        "These declarations were printed from their elaborated terms using only Lean's core notation, without imported delaborators or unexpanders. Author-defined notation and macros therefore cannot disguise this view.",
+      ),
+    );
+    for (const item of metadata.audit_declarations) {
+      const declaration = el("section", "challenge-audit-declaration");
+      declaration.append(
+        el("h3", "", item.name),
+        el("pre", "", item.declaration),
+      );
+      panel.append(declaration);
+    }
+    panel.append(
+      el(
+        "p",
+        "challenge-audit-limits",
+        "This view does not reveal misleading instances, silently inserted coercions, or definitions whose names hide the wrong meaning. Those still require inspection of the pinned statement and its dependencies.",
+      ),
+    );
+    return panel;
+  }
+
   return async function challengePresentation(
     entry,
     renderBase,
@@ -336,6 +390,8 @@ export function createChallengePresentation({ fetchJson, document, window, local
         ),
       );
     }
+    const audit = auditPanel(metadata);
+    if (audit) section.append(audit);
     return { section, metadata };
   };
 }

--- a/assets/challenge-presentation.mjs
+++ b/assets/challenge-presentation.mjs
@@ -237,21 +237,26 @@ export function createChallengePresentation({ fetchJson, document, window, local
   }
 
   function auditPanel(metadata) {
-    if (metadata.schema_version < 3) return null;
+    if (metadata.schema_version < 3 || metadata.audit_declarations.length === 0) return null;
     const panel = el("details", "challenge-audit");
     panel.append(
       el("summary", "", "View core-notation audit"),
       el(
         "p",
         "challenge-audit-intro",
-        "These declarations were printed from their elaborated terms using only Lean's core notation, without imported delaborators or unexpanders. Author-defined notation and macros therefore cannot disguise this view.",
+        "Palomar's renderer printed these declarations from their elaborated terms using only Lean's core notation, without imported delaborators or unexpanders. Author-defined notation and macros therefore cannot disguise this view. The text is pinned in the same content-addressed render bundle as the formatted view above.",
       ),
     );
-    for (const item of metadata.audit_declarations) {
+    for (const [index, item] of metadata.audit_declarations.entries()) {
       const declaration = el("section", "challenge-audit-declaration");
+      const heading = el("h3", "", item.name);
+      heading.id = `challenge-audit-declaration-${index}`;
+      declaration.setAttribute("aria-labelledby", heading.id);
+      const source = el("pre", "", item.declaration);
+      source.setAttribute("tabindex", "0");
       declaration.append(
-        el("h3", "", item.name),
-        el("pre", "", item.declaration),
+        heading,
+        source,
       );
       panel.append(declaration);
     }
@@ -259,7 +264,7 @@ export function createChallengePresentation({ fetchJson, document, window, local
       el(
         "p",
         "challenge-audit-limits",
-        "This view does not reveal misleading instances, silently inserted coercions, or definitions whose names hide the wrong meaning. Those still require inspection of the pinned statement and its dependencies.",
+        "This view does not reveal misleading instances, silently inserted coercions, or definitions whose names hide the wrong meaning. Lean marks an omitted subterm with ⋯ if it reaches a printer resource limit. Those cases still require inspection of the pinned statement and its dependencies.",
       ),
     );
     return panel;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1185,7 +1185,14 @@ body[data-page="not-found"] main a {
   border: 1px solid var(--line);
   background: var(--paper);
   color: var(--ink);
-  white-space: pre;
+  font-size: .9rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.challenge-audit-declaration pre:focus-visible {
+  outline: 2px solid var(--link);
+  outline-offset: 2px;
 }
 
 .challenge-audit-limits {

--- a/assets/style.css
+++ b/assets/style.css
@@ -1153,6 +1153,47 @@ body[data-page="not-found"] main a {
   color: var(--muted);
 }
 
+.challenge-audit {
+  margin-top: .65rem;
+  color: var(--muted);
+  font-size: .85rem;
+}
+
+.challenge-audit > summary {
+  width: fit-content;
+  cursor: pointer;
+  color: var(--link);
+  font: .78rem/1.3 var(--sans);
+}
+
+.challenge-audit-intro,
+.challenge-audit-limits {
+  max-width: 72rem;
+}
+
+.challenge-audit-declaration h3 {
+  margin: .8rem 0 .3rem;
+  color: var(--ink);
+  font: bold .78rem/1.3 var(--mono);
+}
+
+.challenge-audit-declaration pre {
+  max-height: 24rem;
+  margin: 0;
+  overflow: auto;
+  padding: .65rem;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  color: var(--ink);
+  white-space: pre;
+}
+
+.challenge-audit-limits {
+  margin-bottom: .2rem;
+  padding-left: .7rem;
+  border-left: 2px solid var(--caution);
+}
+
 .challenge-frame {
   display: block;
   width: 100%;

--- a/scripts/check-published.mjs
+++ b/scripts/check-published.mjs
@@ -14,6 +14,8 @@
 import { readFile } from "node:fs/promises";
 
 import { shippedFiles } from "./build-site.mjs";
+import { validateChallengeMetadata } from "../assets/challenge-presentation.mjs";
+import { challengeMetadataUrl } from "../assets/rendering.js";
 import {
   entryRecordUrl,
   recentValidationIssues,
@@ -118,6 +120,7 @@ async function fetchJson(url, fetcher, policy) {
       ]);
       if (!response.ok) {
         const error = new Error(`${url} responded ${response.status}`);
+        error.status = response.status;
         error.retryable = response.status === 408 || response.status === 425 ||
           response.status === 429 || response.status >= 500;
         throw error;
@@ -136,6 +139,7 @@ async function fetchJson(url, fetcher, policy) {
 
 const PUBLIC_VALIDATORS = {
   recentValidationIssues,
+  validateChallengeMetadata,
   validateBrowseHead,
   validateBrowsePage,
   validateBrowseYear,
@@ -239,6 +243,22 @@ export async function publicDataState(
         return [summary.path, entry];
       },
     );
+    await mapBounded(fetchedEntries, async ([_path, entry]) => {
+      try {
+        const metadata = await fetchJson(
+          challengeMetadataUrl(entry, base),
+          fetcher,
+          policy,
+        );
+        validators.validateChallengeMetadata(entry, metadata);
+      } catch (error) {
+        // A historical entry may have no formatted artifact, which the entry
+        // page already presents as a pinned-source fallback. Any render
+        // metadata that is served must still satisfy the same correspondence
+        // contract before deployment as it does in a reader's browser.
+        if (error.status !== 404) throw error;
+      }
+    });
     const entriesByPath = new Map(fetchedEntries);
     const historiesById = new Map(histories.map((history) => [history.id, history.entries]));
     const rendersById = new Map(recentRenders.renders.map((row) => [row.id, row]));

--- a/tests/challenge-presentation.test.mjs
+++ b/tests/challenge-presentation.test.mjs
@@ -22,11 +22,15 @@ function acceptedEntry() {
 
 function renderMetadata(overrides = {}) {
   return {
-    schema_version: 2,
+    schema_version: 3,
     declarations: ["Example.theorem"],
     imports: ["Mathlib"],
     solution_imports: [],
     module_doc: "A module note.",
+    audit_declarations: [{
+      name: "Example.theorem",
+      declaration: "theorem Example.theorem : Eq Nat.zero Nat.zero",
+    }],
     ...overrides,
   };
 }
@@ -102,18 +106,27 @@ test("render metadata must correspond exactly to the registered entry", async (t
   const record = acceptedEntry();
   const current = renderMetadata();
   assert.equal(validateChallengeMetadata(record, current), current);
+  const versionTwo = renderMetadata({ schema_version: 2 });
+  delete versionTwo.audit_declarations;
+  assert.equal(validateChallengeMetadata(record, versionTwo), versionTwo);
   const versionOne = renderMetadata({ schema_version: 1 });
   delete versionOne.solution_imports;
+  delete versionOne.audit_declarations;
   assert.equal(validateChallengeMetadata(record, versionOne), versionOne);
 
   for (const [name, mutate, message] of [
     ["boolean schema", (value) => { value.schema_version = true; }, /does not match/],
-    ["future schema", (value) => { value.schema_version = 3; }, /does not match/],
+    ["future schema", (value) => { value.schema_version = 4; }, /does not match/],
     ["different declaration", (value) => { value.declarations = ["Other.theorem"]; }, /does not match/],
     ["different import", (value) => { value.imports = ["Batteries"]; }, /does not match/],
     ["oversized module note", (value) => { value.module_doc = "x".repeat(256 * 1024 + 1); }, /does not match/],
     ["missing Solution imports", (value) => { delete value.solution_imports; }, /invalid Solution imports/],
     ["non-string Solution import", (value) => { value.solution_imports = [true]; }, /invalid Solution imports/],
+    ["missing audit declarations", (value) => { delete value.audit_declarations; }, /invalid audit declarations/],
+    ["misordered audit declaration", (value) => { value.audit_declarations[0].name = "Other.theorem"; }, /invalid audit declarations/],
+    ["empty audit declaration", (value) => { value.audit_declarations[0].declaration = " \n"; }, /invalid audit declarations/],
+    ["extra audit field", (value) => { value.audit_declarations[0].source = "submitted"; }, /invalid audit declarations/],
+    ["oversized audit", (value) => { value.audit_declarations[0].declaration = "x".repeat(512 * 1024 + 1); }, /invalid audit declarations/],
   ]) {
     await t.test(name, () => {
       const malformed = renderMetadata();
@@ -151,6 +164,12 @@ test("an inline presentation keeps links confined and accepts height only from i
   assert.equal(byClass(result.section, "challenge-metadata").length, 1);
   assert.equal(byClass(result.section, "challenge-no-module-doc").length, 1);
   assert.equal(byClass(result.section, "challenge-fallback").length, 0);
+  const [audit] = byClass(result.section, "challenge-audit");
+  assert.ok(audit);
+  assert.equal(audit.children[0].textContent, "View core-notation audit");
+  assert.match(byClass(audit, "challenge-audit-intro")[0].textContent, /without imported delaborators or unexpanders/);
+  assert.equal(byClass(audit, "challenge-audit-declaration")[0].children[1].textContent, "theorem Example.theorem : Eq Nat.zero Nat.zero");
+  assert.match(byClass(audit, "challenge-audit-limits")[0].textContent, /misleading instances/);
   const [frame] = byClass(result.section, "challenge-frame");
   const [shell] = byClass(result.section, "challenge-frame-shell");
   assert.ok(frame);
@@ -193,6 +212,26 @@ test("an inline presentation keeps links confined and accepts height only from i
   assert.equal(frame.dataset.heightAdjusted, "true");
   onMessage({ source: frame.contentWindow, data: { type: "palomar-render-height", height: 1_000 } });
   assert.equal(frame.style.height, "672px");
+});
+
+test("historical render metadata does not invent an audit view", async () => {
+  const browser = fakeBrowser();
+  const record = acceptedEntry();
+  const metadata = renderMetadata({ schema_version: 2 });
+  delete metadata.audit_declarations;
+  const present = createChallengePresentation({
+    ...browser,
+    fetchJson: async () => metadata,
+    localPageUrl: () => assert.fail("the inline entry view should not build another page URL"),
+  });
+
+  const result = await present(
+    record,
+    new URL("http://127.0.0.1:4173/database/"),
+    { dependenciesOnThisPage: true },
+  );
+
+  assert.equal(byClass(result.section, "challenge-audit").length, 0);
 });
 
 test("late availability updates statement source controls in place", async () => {

--- a/tests/challenge-presentation.test.mjs
+++ b/tests/challenge-presentation.test.mjs
@@ -136,6 +136,48 @@ test("render metadata must correspond exactly to the registered entry", async (t
   }
 });
 
+test("audit metadata corresponds and stays bounded across multiple declarations", async (t) => {
+  const record = acceptedEntry();
+  record.formalization.definition_names = ["Example.definition"];
+  const rows = () => [
+    {
+      name: "Example.theorem",
+      declaration: "theorem Example.theorem : Eq Nat.zero Nat.zero",
+    },
+    {
+      name: "Example.definition",
+      declaration: "def Example.definition : Nat := Nat.zero",
+    },
+  ];
+  const metadata = () => renderMetadata({
+    declarations: ["Example.theorem", "Example.definition"],
+    audit_declarations: rows(),
+  });
+  assert.equal(validateChallengeMetadata(record, metadata()).audit_declarations.length, 2);
+
+  for (const [name, mutate] of [
+    ["transposed rows", (value) => { value.audit_declarations.reverse(); }],
+    ["missing row", (value) => { value.audit_declarations.pop(); }],
+    ["extra row", (value) => { value.audit_declarations.push(rows()[0]); }],
+    ["null row", (value) => { value.audit_declarations[1] = null; }],
+    ["string row", (value) => { value.audit_declarations[1] = "declaration"; }],
+    ["array row", (value) => { value.audit_declarations[1] = []; }],
+    ["cumulative limit", (value) => {
+      value.audit_declarations[0].declaration = "x".repeat(300 * 1024);
+      value.audit_declarations[1].declaration = "y".repeat(300 * 1024);
+    }],
+  ]) {
+    await t.test(name, () => {
+      const malformed = metadata();
+      mutate(malformed);
+      assert.throws(
+        () => validateChallengeMetadata(record, malformed),
+        /invalid audit declarations/,
+      );
+    });
+  }
+});
+
 test("an inline presentation keeps links confined and accepts height only from its frame", async () => {
   const browser = fakeBrowser();
   const record = acceptedEntry();
@@ -167,9 +209,17 @@ test("an inline presentation keeps links confined and accepts height only from i
   const [audit] = byClass(result.section, "challenge-audit");
   assert.ok(audit);
   assert.equal(audit.children[0].textContent, "View core-notation audit");
-  assert.match(byClass(audit, "challenge-audit-intro")[0].textContent, /without imported delaborators or unexpanders/);
-  assert.equal(byClass(audit, "challenge-audit-declaration")[0].children[1].textContent, "theorem Example.theorem : Eq Nat.zero Nat.zero");
+  assert.match(byClass(audit, "challenge-audit-intro")[0].textContent, /same content-addressed render bundle/);
+  const auditDeclaration = byClass(audit, "challenge-audit-declaration")[0];
+  const auditSource = auditDeclaration.children[1];
+  assert.equal(auditSource.textContent, "theorem Example.theorem : Eq Nat.zero Nat.zero");
+  assert.equal(auditSource.getAttribute("tabindex"), "0");
+  assert.equal(
+    auditDeclaration.getAttribute("aria-labelledby"),
+    "challenge-audit-declaration-0",
+  );
   assert.match(byClass(audit, "challenge-audit-limits")[0].textContent, /misleading instances/);
+  assert.match(byClass(audit, "challenge-audit-limits")[0].textContent, /printer resource limit/);
   const [frame] = byClass(result.section, "challenge-frame");
   const [shell] = byClass(result.section, "challenge-frame-shell");
   assert.ok(frame);
@@ -219,6 +269,26 @@ test("historical render metadata does not invent an audit view", async () => {
   const record = acceptedEntry();
   const metadata = renderMetadata({ schema_version: 2 });
   delete metadata.audit_declarations;
+  const present = createChallengePresentation({
+    ...browser,
+    fetchJson: async () => metadata,
+    localPageUrl: () => assert.fail("the inline entry view should not build another page URL"),
+  });
+
+  const result = await present(
+    record,
+    new URL("http://127.0.0.1:4173/database/"),
+    { dependenciesOnThisPage: true },
+  );
+
+  assert.equal(byClass(result.section, "challenge-audit").length, 0);
+});
+
+test("metadata with no compared declarations does not claim an audit view", async () => {
+  const browser = fakeBrowser();
+  const record = acceptedEntry();
+  record.formalization.theorem_names = [];
+  const metadata = renderMetadata({ declarations: [], audit_declarations: [] });
   const present = createChallengePresentation({
     ...browser,
     fetchJson: async () => metadata,

--- a/tests/check-published.test.js
+++ b/tests/check-published.test.js
@@ -12,6 +12,7 @@ const page = (version) =>
   `<html><head><script type="module" src="assets/app.js?v=${version}"></script></head></html>`;
 
 const registryValidators = {
+  validateChallengeMetadata: (value) => value,
   validateRecent: (value) => value,
   validateRecentRenders: (value) => value,
   validateBrowseHead: (value) => value,
@@ -23,6 +24,15 @@ const registryValidators = {
 };
 
 const CLASSIFICATION = { arxiv: ["math.CO"], msc2020: ["05C10"] };
+
+function challengeRender(id, version, digest) {
+  return {
+    format: "verso-html",
+    artifact_path: `renders/${id}-v${version}/${digest}/`,
+    entrypoint: "Challenge/index.html",
+    artifact_tree_sha256: digest,
+  };
+}
 
 function subjectHead(kind, code, rows, registeredAt = "2026-08-08T12:00:00Z") {
   return {
@@ -67,10 +77,12 @@ function oneEntryRegistry() {
   const digest = "a".repeat(64);
   const entry = {
     id,
+    version: 1,
     registered_at: registeredAt,
     classification: CLASSIFICATION,
-    challenge_render: { artifact_tree_sha256: digest },
+    challenge_render: challengeRender(id, 1, digest),
   };
+  const metadata = { schema_version: 2, declarations: ["Example.theorem"] };
   const renders = { renders: [{ id, version: 1, artifact_tree_sha256: digest }] };
   return {
     entry,
@@ -89,17 +101,22 @@ function oneEntryRegistry() {
       ["https://data.example/browse/2026-08-08/1.json", browsePage],
       [`https://data.example/versions/${id}.json`, history],
       [`https://data.example/entries/${id}-v1.json`, entry],
+      [`https://data.example/renders/${id}-v1/${digest}/challenge-metadata.json`, metadata],
       ["https://data.example/subjects/arxiv/math.CO.json", subjectHead("arxiv", "math.CO", [row])],
       ["https://data.example/subjects/msc/05C10.json", subjectHead("msc", "05C10", [row])],
     ]),
   };
 }
 
-const responseFrom = (responses) => async (url) => ({
-  ok: true,
-  status: 200,
-  async json() { return responses.get(String(url)); },
-});
+const responseFrom = (responses) => async (url) => {
+  const href = String(url);
+  const found = responses.has(href);
+  return {
+    ok: found,
+    status: found ? 200 : 404,
+    async json() { return responses.get(href); },
+  };
+};
 
 test("a page built from the expected commit is fresh", () => {
   const state = publishState(page(sha), sha);
@@ -183,16 +200,26 @@ test("live-data health traverses browse and history to validate every public per
       entries: [first, second],
     }],
     ["https://data.example/entries/PALOMAR-2026-08-08-000001-v1.json", {
-      id: "one-v1",
+      id: first.id,
+      version: 1,
+      fixture_name: "one-v1",
       registered_at: "2026-08-08T11:00:00Z",
       classification: CLASSIFICATION,
-      challenge_render: { artifact_tree_sha256: "b".repeat(64) },
+      challenge_render: challengeRender(first.id, 1, "b".repeat(64)),
     }],
     ["https://data.example/entries/PALOMAR-2026-08-08-000001-v2.json", {
-      id: "one-v2",
+      id: first.id,
+      version: 2,
+      fixture_name: "one-v2",
       registered_at: registeredAt,
       classification: CLASSIFICATION,
-      challenge_render: { artifact_tree_sha256: "a".repeat(64) },
+      challenge_render: challengeRender(first.id, 2, "a".repeat(64)),
+    }],
+    [`https://data.example/renders/${first.id}-v1/${"b".repeat(64)}/challenge-metadata.json`, {
+      fixture_name: "audit-v1",
+    }],
+    [`https://data.example/renders/${first.id}-v2/${"a".repeat(64)}/challenge-metadata.json`, {
+      fixture_name: "audit-v2",
     }],
     ["https://data.example/recent-renders.json", {
       renders: [{ id: first.id, version: 2, artifact_tree_sha256: "a".repeat(64) }],
@@ -234,7 +261,10 @@ test("live-data health traverses browse and history to validate every public per
       return page;
     },
     validateEntry(value, summary) {
-      validated.push(`${value.id}:${summary.path}`);
+      validated.push(`${value.fixture_name}:${summary.path}`);
+    },
+    validateChallengeMetadata(entry, metadata) {
+      validated.push(`${metadata.fixture_name}:${entry.version}`);
     },
     validateSubjectHead(page, kind, code) {
       validated.push(`subject:${kind}/${code}`);
@@ -252,6 +282,8 @@ test("live-data health traverses browse and history to validate every public per
     "https://data.example/versions/PALOMAR-2026-08-08-000001.json",
     "https://data.example/entries/PALOMAR-2026-08-08-000001-v1.json",
     "https://data.example/entries/PALOMAR-2026-08-08-000001-v2.json",
+    `https://data.example/renders/${first.id}-v1/${"b".repeat(64)}/challenge-metadata.json`,
+    `https://data.example/renders/${first.id}-v2/${"a".repeat(64)}/challenge-metadata.json`,
     "https://data.example/subjects/arxiv/math.CO.json",
     "https://data.example/subjects/msc/05C10.json",
   ]);
@@ -264,6 +296,8 @@ test("live-data health traverses browse and history to validate every public per
     `versions:${first.id}`,
     `one-v1:${first.path}`,
     `one-v2:${second.path}`,
+    "audit-v1:1",
+    "audit-v2:2",
     "subject:arxiv/math.CO",
     "subject:msc/05C10",
   ]);
@@ -271,6 +305,42 @@ test("live-data health traverses browse and history to validate every public per
     state.reason,
     /all 2 active entry versions across 1 results and 2 classification codes/,
   );
+});
+
+test("live-data health validates every available render metadata document", async () => {
+  const fixture = oneEntryRegistry();
+  const state = await publicDataState(
+    "https://data.example",
+    responseFrom(fixture.responses),
+    {
+      ...registryValidators,
+      validateChallengeMetadata() {
+        throw new Error("Challenge render metadata contains invalid audit declarations");
+      },
+    },
+  );
+
+  assert.equal(state.healthy, false);
+  assert.match(state.reason, /invalid audit declarations/);
+});
+
+test("live-data health retains the historical missing-render fallback", async () => {
+  const fixture = oneEntryRegistry();
+  for (const href of fixture.responses.keys()) {
+    if (href.endsWith("/challenge-metadata.json")) fixture.responses.delete(href);
+  }
+  const state = await publicDataState(
+    "https://data.example",
+    responseFrom(fixture.responses),
+    {
+      ...registryValidators,
+      validateChallengeMetadata() {
+        assert.fail("missing historical metadata must not be validated");
+      },
+    },
+  );
+
+  assert.equal(state.healthy, true, state.reason);
 });
 
 test("live-data health refuses a subject page naming what is not a current version", async () => {

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -709,11 +709,19 @@ html, body {{ background: var(--palomar-paper); color: var(--palomar-ink); }}
             path,
         ):
             metadata = {
-                "schema_version": 2,
+                "schema_version": 3,
                 "imports": ["Mathlib"],
                 "module_doc": "# Fixture module\n\nParsed outside the Verso renderer.",
                 "declarations": ["Example.theorem"],
                 "solution_imports": ["ExampleDependency"],
+                "audit_declarations": [
+                    {
+                        "name": "Example.theorem",
+                        "declaration": (
+                            "theorem Example.theorem : Eq Nat.zero Nat.zero"
+                        ),
+                    }
+                ],
             }
             self.send_bytes(json.dumps(metadata).encode(), "application/json")
             return

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -1451,14 +1451,26 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   await expect(audit.locator("summary")).toHaveText("View core-notation audit");
   await expect(audit.locator(".challenge-audit-declaration")).not.toBeVisible();
   await audit.locator("summary").click();
-  await expect(audit.locator(".challenge-audit-declaration pre")).toHaveText(
+  const auditSource = audit.locator(".challenge-audit-declaration pre");
+  await expect(auditSource).toHaveText(
     "theorem Example.theorem : Eq Nat.zero Nat.zero",
+  );
+  await expect(auditSource).toHaveAttribute("tabindex", "0");
+  await expect(audit.locator(".challenge-audit-declaration")).toHaveAttribute(
+    "aria-labelledby",
+    "challenge-audit-declaration-0",
+  );
+  await expect(audit.locator(".challenge-audit-declaration")).toHaveAccessibleName(
+    "Example.theorem",
   );
   await expect(audit.locator(".challenge-audit-intro")).toContainText(
     "without imported delaborators or unexpanders",
   );
   await expect(audit.locator(".challenge-audit-limits")).toContainText(
     "misleading instances, silently inserted coercions, or definitions",
+  );
+  await expect(audit.locator(".challenge-audit-limits")).toContainText(
+    "omitted subterm with ⋯",
   );
   const rendered = page.frameLocator(".challenge-presentation iframe");
   await expect(rendered.locator(".docstring")).toHaveText("The theorem doc-string.");

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -1447,6 +1447,19 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   await expect(page.locator(".challenge-module-doc summary")).toHaveText("Notes from the statement file");
   await page.locator(".challenge-module-doc summary").click();
   await expect(page.locator(".challenge-module-doc pre")).toContainText("Parsed outside the Verso renderer");
+  const audit = page.locator(".challenge-audit");
+  await expect(audit.locator("summary")).toHaveText("View core-notation audit");
+  await expect(audit.locator(".challenge-audit-declaration")).not.toBeVisible();
+  await audit.locator("summary").click();
+  await expect(audit.locator(".challenge-audit-declaration pre")).toHaveText(
+    "theorem Example.theorem : Eq Nat.zero Nat.zero",
+  );
+  await expect(audit.locator(".challenge-audit-intro")).toContainText(
+    "without imported delaborators or unexpanders",
+  );
+  await expect(audit.locator(".challenge-audit-limits")).toContainText(
+    "misleading instances, silently inserted coercions, or definitions",
+  );
   const rendered = page.frameLocator(".challenge-presentation iframe");
   await expect(rendered.locator(".docstring")).toHaveText("The theorem doc-string.");
   await expect(rendered.locator(".skip-link")).toHaveCount(0);


### PR DESCRIPTION
## Summary

- accept Challenge render-metadata schema v3 with one exact `audit_declarations` row for every compared declaration
- show the producer-supplied core-notation declarations in a deliberately low-emphasis, closed disclosure
- explain both the notation/macro protection and the instances, coercions, and definitions it does not audit
- keep historical schema v1/v2 render metadata readable without claiming an audit view
- validate every available immutable render-metadata document in the predeploy/public-health traversal

## Producer dependency and deployment order

PalomarSubmission must implement the producer half first: print each accepted compared declaration from its elaborated term using only Lean core notation, without imported delaborators or unexpanders, and emit the exact `audit_declarations` contract documented here. It must not begin emitting metadata schema v3 until this widened Web consumer is deployed; an older Web build rejects unknown metadata versions. Existing v1/v2 metadata keeps its current presentation throughout.

## Verification

- `PALOMAR_DATABASE_CHECKOUT=/tmp/tmp.adsDwkHvDu/PalomarDatabase npm test` (269 passed)
- `nix shell nixpkgs#chromium -c bash -lc 'export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=$(command -v chromium); npm run test:browser'` (88 passed, 2 expected local skips)
- `node scripts/check-published.mjs --data https://data.palomar-registry.org/` (24 active versions, 19 results, 80 classification codes)

Addresses #136.