### PR TITLE
feat: add Cite this BibTeX control to entry pages

### DIFF
--- a/assets/about.js
+++ b/assets/about.js
@@ -1,5 +1,9 @@
+import {
+  CLIPBOARD_RESET_DELAY_MS,
+  createClipboard,
+} from "./clipboard.mjs";
+
 const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
-const RESET_DELAY_MS = 1600;
 
 function linkIcon() {
   const svg = document.createElementNS(SVG_NAMESPACE, "svg");
@@ -17,35 +21,11 @@ function linkIcon() {
   return svg;
 }
 
-function fallbackCopy(text) {
-  const previousFocus = document.activeElement;
-  const input = document.createElement("textarea");
-  input.value = text;
-  input.className = "clipboard-fallback";
-  document.body.append(input);
-  input.select();
-  input.setSelectionRange(0, text.length);
-  try {
-    return document.execCommand("copy");
-  } catch {
-    return false;
-  } finally {
-    input.remove();
-    previousFocus?.focus();
-  }
-}
-
-async function copyText(text) {
-  if (navigator.clipboard?.writeText) {
-    try {
-      await navigator.clipboard.writeText(text);
-      return true;
-    } catch {
-      // The fallback supports browsers that expose but deny the Clipboard API.
-    }
-  }
-  return fallbackCopy(text);
-}
+const { announce: announceClipboard, copyText } = createClipboard({
+  document,
+  navigator,
+  window,
+});
 
 function anchorTarget(heading) {
   if (heading.id) return heading.id;
@@ -55,10 +35,7 @@ function anchorTarget(heading) {
 const status = document.querySelector("#anchor-status");
 
 function announce(message) {
-  status.textContent = "";
-  window.requestAnimationFrame(() => {
-    status.textContent = message;
-  });
+  announceClipboard(status, message);
 }
 
 for (const heading of document.querySelectorAll("main.about h2, main.about h3")) {
@@ -85,7 +62,8 @@ for (const heading of document.querySelectorAll("main.about h2, main.about h3"))
       announce(`Could not copy link to ${label}`);
       resetTimer = window.setTimeout(() => {
         anchor.title = "Copy link to this section";
-      }, RESET_DELAY_MS);
+        status.textContent = "";
+      }, CLIPBOARD_RESET_DELAY_MS);
       return;
     }
     anchor.classList.add("copied");
@@ -94,6 +72,7 @@ for (const heading of document.querySelectorAll("main.about h2, main.about h3"))
     resetTimer = window.setTimeout(() => {
       anchor.classList.remove("copied");
       anchor.title = "Copy link to this section";
-    }, RESET_DELAY_MS);
+      status.textContent = "";
+    }, CLIPBOARD_RESET_DELAY_MS);
   });
 }

--- a/assets/app.js
+++ b/assets/app.js
@@ -21,6 +21,7 @@ import {
   renderEntryPage,
 } from "./entry-pages.mjs";
 import { createChallengePresentation } from "./challenge-presentation.mjs";
+import { mathematicalSourceUrl } from "./bibliography.mjs";
 import { createCitationPresentation } from "./citation-presentation.mjs";
 import { createEntryHistoryPresentation } from "./entry-history-presentation.mjs";
 import { createFormalizationPresentation } from "./formalization-presentation.mjs";
@@ -1197,25 +1198,13 @@ function classificationSection(entry) {
   return section;
 }
 
-function mathematicalSourceIdentifier(identifier) {
+function mathematicalSourceIdentifier(identifier, sourceLabel) {
   if (!identifier) return null;
-  const arxiv = /^arXiv:([0-9]{4}\.[0-9]{4,5}(?:v[0-9]+)?)$/i.exec(identifier);
-  if (arxiv) {
-    return externalLink(identifier, `https://arxiv.org/abs/${arxiv[1]}`);
-  }
-  const doi = /^doi:(10\.[0-9]{4,9}\/\S+)$/i.exec(identifier);
-  if (doi) {
-    const encoded = doi[1].split("/").map(encodeURIComponent).join("/");
-    return externalLink(identifier, `https://doi.org/${encoded}`);
-  }
-  if (identifier.startsWith("https://")) {
-    try {
-      return externalLink(identifier, identifier);
-    } catch {
-      // An unparseable source is still bibliography text; it is never a link.
-    }
-  }
-  return el("code", "", identifier);
+  const resolved = mathematicalSourceUrl(identifier);
+  if (!resolved) return el("code", "", identifier);
+  const link = externalLink(resolved.kind === "url" ? "Source link" : identifier, resolved.href);
+  if (resolved.kind === "url") link.setAttribute("aria-label", `Open source for ${sourceLabel}`);
+  return link;
 }
 
 function provenanceSection(entry, sourceAvailability) {
@@ -1291,7 +1280,7 @@ function provenanceSection(entry, sourceAvailability) {
         ? `${source.authors.map((author) => author.name).join(", ")}: ${source.title}`
         : source.title;
       item.append(el("span", "source-citation", label));
-      const identifier = mathematicalSourceIdentifier(source.identifier);
+      const identifier = mathematicalSourceIdentifier(source.identifier, label);
       if (identifier) item.append(" · ", identifier);
       if (source.contributors?.length) {
         item.append(el(

--- a/assets/app.js
+++ b/assets/app.js
@@ -21,6 +21,7 @@ import {
   renderEntryPage,
 } from "./entry-pages.mjs";
 import { createChallengePresentation } from "./challenge-presentation.mjs";
+import { createCitationPresentation } from "./citation-presentation.mjs";
 import { createEntryHistoryPresentation } from "./entry-history-presentation.mjs";
 import { createFormalizationPresentation } from "./formalization-presentation.mjs";
 import { createRegistryLoader } from "./registry-loading.mjs";
@@ -1076,6 +1077,7 @@ const {
   versionHistory,
   versionNotice,
 } = createEntryHistoryPresentation({ document, localPageUrl, window });
+const { citationSection } = createCitationPresentation({ document, navigator, window });
 
 /** One kind of assurance, named so the two can be told apart at a glance. */
 function assurance(kind, ...content) {
@@ -1195,6 +1197,27 @@ function classificationSection(entry) {
   return section;
 }
 
+function mathematicalSourceIdentifier(identifier) {
+  if (!identifier) return null;
+  const arxiv = /^arXiv:([0-9]{4}\.[0-9]{4,5}(?:v[0-9]+)?)$/i.exec(identifier);
+  if (arxiv) {
+    return externalLink(identifier, `https://arxiv.org/abs/${arxiv[1]}`);
+  }
+  const doi = /^doi:(10\.[0-9]{4,9}\/\S+)$/i.exec(identifier);
+  if (doi) {
+    const encoded = doi[1].split("/").map(encodeURIComponent).join("/");
+    return externalLink(identifier, `https://doi.org/${encoded}`);
+  }
+  if (identifier.startsWith("https://")) {
+    try {
+      return externalLink(identifier, identifier);
+    } catch {
+      // An unparseable source is still bibliography text; it is never a link.
+    }
+  }
+  return el("code", "", identifier);
+}
+
 function provenanceSection(entry, sourceAvailability) {
   const provenance = entry.provenance;
   const section = el("section", "entry-provenance");
@@ -1267,11 +1290,9 @@ function provenanceSection(entry, sourceAvailability) {
       const label = source.authors.length
         ? `${source.authors.map((author) => author.name).join(", ")}: ${source.title}`
         : source.title;
-      if (source.identifier?.startsWith("https://")) {
-        item.append(externalLink(label, source.identifier));
-      } else {
-        item.append(el("span", "", label));
-      }
+      item.append(el("span", "source-citation", label));
+      const identifier = mathematicalSourceIdentifier(source.identifier);
+      if (identifier) item.append(" · ", identifier);
       if (source.contributors?.length) {
         item.append(el(
           "span",
@@ -1282,9 +1303,6 @@ function provenanceSection(entry, sourceAvailability) {
         ));
       }
       item.append(el("span", "source-relationship", ` — ${source.relationship}`));
-      if (source.identifier && !source.identifier.startsWith("https://")) {
-        item.append(el("code", "", source.identifier));
-      }
       sources.append(item);
     }
     disclosure.append(sources);
@@ -1524,6 +1542,7 @@ async function renderEntry(
     externalLink,
   });
   const versionNoticeNode = versionNotice(entry, currentVersion);
+  const citation = citationSection(entry);
   const history = versionHistory(entry, versions, currentVersion);
   content.append(heading);
   // A broken or degraded source affects every link on the page and remains a
@@ -1543,6 +1562,7 @@ async function renderEntry(
     solutionMetadata(entry, challenge.metadata, sourceAvailability),
     provenanceSection(entry, sourceAvailability),
     classificationSection(entry),
+    citation,
     editorial,
     history,
   );

--- a/assets/bibliography.mjs
+++ b/assets/bibliography.mjs
@@ -1,0 +1,40 @@
+import { safeExternalUrl } from "./security.mjs";
+
+const ARXIV_IDENTIFIER_RE = /^arXiv:((?:[0-9]{4}\.[0-9]{4,5}|[a-z-]+(?:\.[a-z]{2})?\/[0-9]{7})(?:v[0-9]+)?)$/i;
+const DOI_IDENTIFIER_RE = /^doi:(10\.[0-9]{4,9}\/\S+)$/i;
+
+function encodePathSegment(segment) {
+  return encodeURIComponent(segment).replace(
+    /[!'()*]/g,
+    (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+/** Resolve recognized bibliography identifiers without ever hiding raw text. */
+export function mathematicalSourceUrl(identifier) {
+  if (typeof identifier !== "string") return null;
+
+  const arxiv = ARXIV_IDENTIFIER_RE.exec(identifier);
+  if (arxiv) {
+    return { href: safeExternalUrl(`https://arxiv.org/abs/${arxiv[1]}`), kind: "arxiv" };
+  }
+
+  const doi = DOI_IDENTIFIER_RE.exec(identifier);
+  if (doi) {
+    const segments = doi[1].split("/");
+    if (segments.some((segment) => segment === "." || segment === "..")) return null;
+    const encoded = segments.map(encodePathSegment).join("/");
+    const target = new URL(encoded, "https://doi.org/");
+    if (target.origin !== "https://doi.org" || target.pathname !== `/${encoded}`) return null;
+    return { href: safeExternalUrl(target), kind: "doi" };
+  }
+
+  if (identifier.startsWith("https://")) {
+    try {
+      return { href: safeExternalUrl(identifier), kind: "url" };
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}

--- a/assets/citation-presentation.mjs
+++ b/assets/citation-presentation.mjs
@@ -1,6 +1,9 @@
+import {
+  CLIPBOARD_RESET_DELAY_MS,
+  createClipboard,
+} from "./clipboard.mjs";
 import { canonicalEntryPageUrl } from "./entry-history-presentation.mjs";
 
-const RESET_DELAY_MS = 1600;
 const BIBTEX_ESCAPES = Object.freeze({
   "\\": "\\textbackslash{}",
   "{": "\\{",
@@ -10,8 +13,8 @@ const BIBTEX_ESCAPES = Object.freeze({
   "%": "\\%",
   "&": "\\&",
   "_": "\\_",
-  "^": "\\^{}",
-  "~": "\\~{}",
+  "^": "\\textasciicircum{}",
+  "~": "\\textasciitilde{}",
 });
 
 function bibtexText(value) {
@@ -22,6 +25,9 @@ function bibtexText(value) {
 /** A ready-to-paste citation of exactly the immutable snapshot being viewed. */
 export function bibtexCitation(entry) {
   const key = `${entry.id.toLowerCase()}-v${entry.version}`;
+  // Records carry one exact display name rather than structured given/family
+  // parts. Bracing each complete name preserves it and prevents a literal
+  // "and" in one name from becoming a false author boundary.
   const authors = entry.authors
     .map((author) => `{${bibtexText(author.name)}}`)
     .join(" and ");
@@ -36,43 +42,15 @@ export function bibtexCitation(entry) {
   ].join("\n");
 }
 
-function fallbackCopy(document, text) {
-  const previousFocus = document.activeElement;
-  const input = document.createElement("textarea");
-  input.value = text;
-  input.className = "clipboard-fallback";
-  document.body.append(input);
-  input.select();
-  input.setSelectionRange(0, text.length);
-  try {
-    return document.execCommand("copy");
-  } catch {
-    return false;
-  } finally {
-    input.remove();
-    previousFocus?.focus();
-  }
-}
-
 /** Bind the citation and its clipboard control to an entry page. */
 export function createCitationPresentation({ document, navigator, window }) {
+  const { announce, copyText } = createClipboard({ document, navigator, window });
+
   function el(tag, className, text) {
     const node = document.createElement(tag);
     if (className) node.className = className;
     if (text !== undefined) node.textContent = text;
     return node;
-  }
-
-  async function copyText(text) {
-    if (navigator.clipboard?.writeText) {
-      try {
-        await navigator.clipboard.writeText(text);
-        return true;
-      } catch {
-        // The fallback supports browsers that expose but deny the Clipboard API.
-      }
-    }
-    return fallbackCopy(document, text);
   }
 
   function citationSection(entry) {
@@ -95,6 +73,9 @@ export function createCitationPresentation({ document, navigator, window }) {
 
     const code = el("code", "", citation);
     const block = el("pre", "citation-bibtex");
+    block.tabIndex = 0;
+    block.setAttribute("role", "group");
+    block.setAttribute("aria-labelledby", titleHeading.id);
     block.append(code);
     section.append(
       heading,
@@ -113,13 +94,14 @@ export function createCitationPresentation({ document, navigator, window }) {
       window.clearTimeout(resetTimer);
       copy.classList.toggle("copied", copied);
       copy.textContent = copied ? "Copied!" : "Copy failed";
-      status.textContent = copied
+      announce(status, copied
         ? "Copied BibTeX citation."
-        : "Could not copy BibTeX citation.";
+        : "Could not copy BibTeX citation.");
       resetTimer = window.setTimeout(() => {
         copy.classList.remove("copied");
         copy.textContent = "Copy BibTeX";
-      }, RESET_DELAY_MS);
+        status.textContent = "";
+      }, CLIPBOARD_RESET_DELAY_MS);
     });
 
     return section;

--- a/assets/citation-presentation.mjs
+++ b/assets/citation-presentation.mjs
@@ -1,0 +1,129 @@
+import { canonicalEntryPageUrl } from "./entry-history-presentation.mjs";
+
+const RESET_DELAY_MS = 1600;
+const BIBTEX_ESCAPES = Object.freeze({
+  "\\": "\\textbackslash{}",
+  "{": "\\{",
+  "}": "\\}",
+  "#": "\\#",
+  "$": "\\$",
+  "%": "\\%",
+  "&": "\\&",
+  "_": "\\_",
+  "^": "\\^{}",
+  "~": "\\~{}",
+});
+
+function bibtexText(value) {
+  const oneLine = value.replace(/\s+/gu, " ").trim();
+  return [...oneLine].map((character) => BIBTEX_ESCAPES[character] ?? character).join("");
+}
+
+/** A ready-to-paste citation of exactly the immutable snapshot being viewed. */
+export function bibtexCitation(entry) {
+  const key = `${entry.id.toLowerCase()}-v${entry.version}`;
+  const authors = entry.authors
+    .map((author) => `{${bibtexText(author.name)}}`)
+    .join(" and ");
+  return [
+    `@misc{${key},`,
+    `  author = {${authors}},`,
+    `  title = {{${bibtexText(entry.title)}}},`,
+    `  year = {${entry.registered_at.slice(0, 4)}},`,
+    `  howpublished = {Palomar, ${entry.id} v${entry.version}},`,
+    `  url = {${canonicalEntryPageUrl(entry).href}},`,
+    "}",
+  ].join("\n");
+}
+
+function fallbackCopy(document, text) {
+  const previousFocus = document.activeElement;
+  const input = document.createElement("textarea");
+  input.value = text;
+  input.className = "clipboard-fallback";
+  document.body.append(input);
+  input.select();
+  input.setSelectionRange(0, text.length);
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    input.remove();
+    previousFocus?.focus();
+  }
+}
+
+/** Bind the citation and its clipboard control to an entry page. */
+export function createCitationPresentation({ document, navigator, window }) {
+  function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined) node.textContent = text;
+    return node;
+  }
+
+  async function copyText(text) {
+    if (navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        return true;
+      } catch {
+        // The fallback supports browsers that expose but deny the Clipboard API.
+      }
+    }
+    return fallbackCopy(document, text);
+  }
+
+  function citationSection(entry) {
+    const citation = bibtexCitation(entry);
+    const section = el("section", "entry-citation");
+    section.setAttribute("aria-labelledby", "citation-heading");
+
+    const heading = el("div", "section-heading");
+    const title = el("div");
+    const titleHeading = el("h2", "", "Cite this");
+    titleHeading.id = "citation-heading";
+    title.append(el("div", "eyebrow", "Citation"), titleHeading);
+
+    const copy = el("button", "citation-copy", "Copy BibTeX");
+    copy.type = "button";
+    const status = el("span", "visually-hidden citation-status");
+    status.setAttribute("role", "status");
+    status.setAttribute("aria-live", "polite");
+    heading.append(title, copy);
+
+    const code = el("code", "", citation);
+    const block = el("pre", "citation-bibtex");
+    block.append(code);
+    section.append(
+      heading,
+      el(
+        "p",
+        "citation-intro",
+        `This citation names immutable version ${entry.version} of the registered record.`,
+      ),
+      block,
+      status,
+    );
+
+    let resetTimer;
+    copy.addEventListener("click", async () => {
+      const copied = await copyText(citation);
+      window.clearTimeout(resetTimer);
+      copy.classList.toggle("copied", copied);
+      copy.textContent = copied ? "Copied!" : "Copy failed";
+      status.textContent = copied
+        ? "Copied BibTeX citation."
+        : "Could not copy BibTeX citation.";
+      resetTimer = window.setTimeout(() => {
+        copy.classList.remove("copied");
+        copy.textContent = "Copy BibTeX";
+      }, RESET_DELAY_MS);
+    });
+
+    return section;
+  }
+
+  return { citationSection };
+}

--- a/assets/clipboard.mjs
+++ b/assets/clipboard.mjs
@@ -1,0 +1,46 @@
+export const CLIPBOARD_RESET_DELAY_MS = 1600;
+
+/** Clipboard access with a selection-based fallback for older or denied APIs. */
+export function createClipboard({ document, navigator, window }) {
+  function fallbackCopy(text) {
+    const previousFocus = document.activeElement;
+    const input = document.createElement("textarea");
+    input.value = text;
+    input.readOnly = true;
+    input.className = "clipboard-fallback";
+    document.body.append(input);
+    input.select();
+    input.setSelectionRange(0, text.length);
+    try {
+      return document.execCommand("copy");
+    } catch {
+      return false;
+    } finally {
+      input.remove();
+      previousFocus?.focus();
+    }
+  }
+
+  async function copyText(text) {
+    if (navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        return true;
+      } catch {
+        // The fallback supports browsers that expose but deny the Clipboard API.
+      }
+    }
+    return fallbackCopy(text);
+  }
+
+  // Replacing an unchanged live-region value does not make assistive
+  // technology announce it again. Clear it for one frame before every update.
+  function announce(status, message) {
+    status.textContent = "";
+    window.requestAnimationFrame(() => {
+      status.textContent = message;
+    });
+  }
+
+  return { announce, copyText };
+}

--- a/assets/entry-history-presentation.mjs
+++ b/assets/entry-history-presentation.mjs
@@ -2,6 +2,14 @@ import { safeExternalUrl, safeInternalUrl } from "./security.mjs";
 
 const CANONICAL_WEB_BASE = "https://palomar-registry.org/";
 
+/** The public URL of one immutable registered snapshot. */
+export function canonicalEntryPageUrl(entry) {
+  const target = new URL("entry", CANONICAL_WEB_BASE);
+  target.searchParams.set("id", entry.id);
+  target.searchParams.set("version", String(entry.version));
+  return safeExternalUrl(target);
+}
+
 /**
  * Bind immutable-version history presentation to the page's DOM and local URL
  * builder. Entry/version validation, route orchestration, and page composition
@@ -23,13 +31,6 @@ export function createEntryHistoryPresentation({ document, localPageUrl, window 
       window.location.href,
     ).href;
     return node;
-  }
-
-  function canonicalEntryPageUrl(entry) {
-    const target = new URL("entry", CANONICAL_WEB_BASE);
-    target.searchParams.set("id", entry.id);
-    target.searchParams.set("version", String(entry.version));
-    return safeExternalUrl(target);
   }
 
   function setCanonicalEntryPage(entry) {

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -1402,7 +1402,9 @@ export function validateEntry(entry, summary) {
     fail("entry.registered_at does not match summary.published_at");
   }
 
-  for (const [position, value] of array(entry.authors, "entry.authors").entries()) {
+  const entryAuthors = array(entry.authors, "entry.authors");
+  if (!entryAuthors.length) fail("entry.authors must not be empty");
+  for (const [position, value] of entryAuthors.entries()) {
     string(object(value, `entry.authors[${position}]`).name, `entry.authors[${position}].name`);
   }
 
@@ -1469,6 +1471,13 @@ export function validateEntry(entry, summary) {
       const item = object(sourceRecord, `entry.provenance.mathematical_sources[${position}]`);
       string(item.title, `entry.provenance.mathematical_sources[${position}].title`);
       array(item.authors, `entry.provenance.mathematical_sources[${position}].authors`);
+      if (item.identifier !== undefined) {
+        boundedString(
+          item.identifier,
+          `entry.provenance.mathematical_sources[${position}].identifier`,
+          2048,
+        );
+      }
       if (item.contributors !== undefined) {
         const contributors = array(
           item.contributors,

--- a/assets/style.css
+++ b/assets/style.css
@@ -835,6 +835,39 @@ footer {
   font-style: italic;
 }
 
+.citation-intro {
+  margin: 0 0 .65rem;
+  color: var(--muted);
+  font-size: .9rem;
+}
+
+.citation-copy {
+  padding: .4rem .65rem;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  color: var(--ink);
+  cursor: pointer;
+  font: bold .78rem/1.2 var(--sans);
+}
+
+.citation-copy:hover,
+.citation-copy:focus-visible,
+.citation-copy.copied {
+  border-color: var(--success-line);
+  color: var(--success);
+}
+
+.citation-bibtex {
+  max-width: 100%;
+  margin: 0;
+  overflow: auto;
+  padding: .8rem;
+  border: 1px solid var(--line);
+  background: var(--shade);
+  font-size: .8rem;
+  white-space: pre;
+}
+
 .entry-page section {
   padding: 1.5rem 0;
   border-top: 1px solid var(--line);

--- a/assets/style.css
+++ b/assets/style.css
@@ -854,7 +854,7 @@ footer {
 .citation-copy:focus-visible,
 .citation-copy.copied {
   border-color: var(--success-line);
-  color: var(--success);
+  color: var(--copied);
 }
 
 .citation-bibtex {

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -19,6 +19,7 @@ const browserModuleFiles = [
   "about.js",
   "app.js",
   "challenge-presentation.mjs",
+  "citation-presentation.mjs",
   "entry-history-presentation.mjs",
   "entry-pages.mjs",
   "formalization-presentation.mjs",

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -18,8 +18,10 @@ const publicFiles = [...htmlFiles, "site.webmanifest", "favicon.svg"];
 const browserModuleFiles = [
   "about.js",
   "app.js",
+  "bibliography.mjs",
   "challenge-presentation.mjs",
   "citation-presentation.mjs",
+  "clipboard.mjs",
   "entry-history-presentation.mjs",
   "entry-pages.mjs",
   "formalization-presentation.mjs",

--- a/tests/bibliography.test.mjs
+++ b/tests/bibliography.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mathematicalSourceUrl } from "../assets/bibliography.mjs";
+
+test("current and legacy arXiv identifiers resolve to their matching abstracts", () => {
+  assert.equal(
+    mathematicalSourceUrl("arXiv:2605.20695v2").href.href,
+    "https://arxiv.org/abs/2605.20695v2",
+  );
+  assert.equal(
+    mathematicalSourceUrl("arXiv:math.AG/0211159").href.href,
+    "https://arxiv.org/abs/math.AG/0211159",
+  );
+});
+
+test("DOI links encode data and refuse path normalization", () => {
+  assert.equal(
+    mathematicalSourceUrl("doi:10.1000/a?#b").href.href,
+    "https://doi.org/10.1000/a%3F%23b",
+  );
+  assert.equal(mathematicalSourceUrl("doi:10.1000/../10.9999/other"), null);
+});
+
+test("unsafe and unknown source identifiers remain unresolved", () => {
+  assert.equal(mathematicalSourceUrl("https://reader:secret@example.invalid/source"), null);
+  assert.equal(mathematicalSourceUrl("bibliographic:custom-reference"), null);
+  assert.equal(mathematicalSourceUrl(null), null);
+});

--- a/tests/build-site.test.js
+++ b/tests/build-site.test.js
@@ -26,6 +26,10 @@ test("deployment build versions coupled browser assets", async () => {
       path.join(destination, "assets", "challenge-presentation.mjs"),
       "utf8",
     );
+    const citationPresentation = await readFile(
+      path.join(destination, "assets", "citation-presentation.mjs"),
+      "utf8",
+    );
     const entryHistoryPresentation = await readFile(
       path.join(destination, "assets", "entry-history-presentation.mjs"),
       "utf8",
@@ -62,6 +66,7 @@ test("deployment build versions coupled browser assets", async () => {
     assert.match(about, /assets\/about\.js\?v=0123456789abcdef/);
     await readFile(path.join(destination, "assets", "about.js"), "utf8");
     assert.match(app, /\.\/challenge-presentation\.mjs\?v=0123456789abcdef/);
+    assert.match(app, /\.\/citation-presentation\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/entry-history-presentation\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/entry-pages\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/formalization-presentation\.mjs\?v=0123456789abcdef/);
@@ -74,6 +79,10 @@ test("deployment build versions coupled browser assets", async () => {
     assert.match(registryLoading, /\.\/loading\.mjs\?v=0123456789abcdef/);
     assert.match(registryLoading, /\.\/security\.mjs\?v=0123456789abcdef/);
     assert.match(challengePresentation, /\.\/rendering\.js\?v=0123456789abcdef/);
+    assert.match(
+      citationPresentation,
+      /\.\/entry-history-presentation\.mjs\?v=0123456789abcdef/,
+    );
     assert.match(challengePresentation, /\.\/security\.mjs\?v=0123456789abcdef/);
     assert.match(entryHistoryPresentation, /\.\/security\.mjs\?v=0123456789abcdef/);
     assert.match(

--- a/tests/build-site.test.js
+++ b/tests/build-site.test.js
@@ -30,6 +30,7 @@ test("deployment build versions coupled browser assets", async () => {
       path.join(destination, "assets", "citation-presentation.mjs"),
       "utf8",
     );
+    await readFile(path.join(destination, "assets", "clipboard.mjs"), "utf8");
     const entryHistoryPresentation = await readFile(
       path.join(destination, "assets", "entry-history-presentation.mjs"),
       "utf8",
@@ -64,7 +65,9 @@ test("deployment build versions coupled browser assets", async () => {
     assert.match(index, /assets\/app\.js\?v=0123456789abcdef/);
     assert.match(about, /assets\/style\.css\?v=0123456789abcdef/);
     assert.match(about, /assets\/about\.js\?v=0123456789abcdef/);
-    await readFile(path.join(destination, "assets", "about.js"), "utf8");
+    const aboutScript = await readFile(path.join(destination, "assets", "about.js"), "utf8");
+    assert.match(aboutScript, /\.\/clipboard\.mjs\?v=0123456789abcdef/);
+    assert.match(app, /\.\/bibliography\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/challenge-presentation\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/citation-presentation\.mjs\?v=0123456789abcdef/);
     assert.match(app, /\.\/entry-history-presentation\.mjs\?v=0123456789abcdef/);
@@ -83,6 +86,8 @@ test("deployment build versions coupled browser assets", async () => {
       citationPresentation,
       /\.\/entry-history-presentation\.mjs\?v=0123456789abcdef/,
     );
+    assert.match(citationPresentation, /\.\/clipboard\.mjs\?v=0123456789abcdef/);
+    assert.match(about, /assets\/about\.js\?v=0123456789abcdef/);
     assert.match(challengePresentation, /\.\/security\.mjs\?v=0123456789abcdef/);
     assert.match(entryHistoryPresentation, /\.\/security\.mjs\?v=0123456789abcdef/);
     assert.match(

--- a/tests/citation-presentation.test.mjs
+++ b/tests/citation-presentation.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { bibtexCitation } from "../assets/citation-presentation.mjs";
+
+test("BibTeX citations pin the selected immutable Palomar version", () => {
+  const entry = {
+    id: "PALOMAR-2026-08-08-000001",
+    version: 3,
+    registered_at: "2027-01-02T03:04:05Z",
+    title: "A result",
+    authors: [{ name: "Ada Lovelace" }, { name: "Emmy Noether" }],
+  };
+
+  assert.equal(
+    bibtexCitation(entry),
+    `@misc{palomar-2026-08-08-000001-v3,
+  author = {{Ada Lovelace} and {Emmy Noether}},
+  title = {{A result}},
+  year = {2027},
+  howpublished = {Palomar, PALOMAR-2026-08-08-000001 v3},
+  url = {https://palomar-registry.org/entry?id=PALOMAR-2026-08-08-000001&version=3},
+}`,
+  );
+});
+
+test("BibTeX citations preserve Unicode and escape TeX-significant record text", () => {
+  const citation = bibtexCitation({
+    id: "PALOMAR-2026-08-08-000001",
+    version: 1,
+    registered_at: "2026-08-08T12:00:00Z",
+    title: "Erdős & 100% of {cases}_x ~ ^ \\ path\ncontinued",
+    authors: [{ name: "Research & Development" }],
+  });
+
+  assert.match(citation, /author = \{\{Research \\& Development\}\}/);
+  assert.match(
+    citation,
+    /title = \{\{Erdős \\& 100\\% of \\\{cases\\\}\\_x \\~\{\} \\\^\{\} \\textbackslash\{\} path continued\}\}/,
+  );
+});

--- a/tests/citation-presentation.test.mjs
+++ b/tests/citation-presentation.test.mjs
@@ -1,7 +1,67 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { bibtexCitation } from "../assets/citation-presentation.mjs";
+import {
+  bibtexCitation,
+  createCitationPresentation,
+} from "../assets/citation-presentation.mjs";
+
+function fakeDocument(copyResult) {
+  const createElement = (tag) => {
+    const node = {
+      attributes: new Map(),
+      children: [],
+      className: "",
+      listeners: new Map(),
+      tagName: tag.toUpperCase(),
+      textContent: "",
+      append(...children) {
+        for (const child of children) {
+          if (child && typeof child === "object") child.parent = this;
+          this.children.push(child);
+        }
+      },
+      addEventListener(name, listener) {
+        this.listeners.set(name, listener);
+      },
+      remove() {
+        if (this.parent) this.parent.children = this.parent.children.filter((child) => child !== this);
+      },
+      select() {},
+      setAttribute(name, value) {
+        this.attributes.set(name, value);
+      },
+      setSelectionRange() {},
+    };
+    node.classList = {
+      remove(name) {
+        node.className = node.className.split(" ").filter((item) => item !== name).join(" ");
+      },
+      toggle(name, force) {
+        this.remove(name);
+        if (force) node.className = `${node.className} ${name}`.trim();
+      },
+    };
+    return node;
+  };
+  const body = createElement("body");
+  return {
+    activeElement: { focus() {} },
+    body,
+    createElement,
+    execCommand: () => copyResult,
+  };
+}
+
+function byClass(root, className) {
+  if (!root || typeof root !== "object") return null;
+  if (root.className?.split(" ").includes(className)) return root;
+  for (const child of root.children ?? []) {
+    const found = byClass(child, className);
+    if (found) return found;
+  }
+  return null;
+}
 
 test("BibTeX citations pin the selected immutable Palomar version", () => {
   const entry = {
@@ -36,6 +96,40 @@ test("BibTeX citations preserve Unicode and escape TeX-significant record text",
   assert.match(citation, /author = \{\{Research \\& Development\}\}/);
   assert.match(
     citation,
-    /title = \{\{Erdős \\& 100\\% of \\\{cases\\\}\\_x \\~\{\} \\\^\{\} \\textbackslash\{\} path continued\}\}/,
+    /title = \{\{Erdős \\& 100\\% of \\\{cases\\\}\\_x \\textasciitilde\{\} \\textasciicircum\{\} \\textbackslash\{\} path continued\}\}/,
   );
+});
+
+test("citation controls report and reset a failed clipboard fallback", async () => {
+  const document = fakeDocument(false);
+  let reset;
+  const window = {
+    clearTimeout() {},
+    requestAnimationFrame: (callback) => callback(),
+    setTimeout(callback) {
+      reset = callback;
+      return 1;
+    },
+  };
+  const navigator = { clipboard: { writeText: async () => { throw new Error("denied"); } } };
+  const { citationSection } = createCitationPresentation({ document, navigator, window });
+  const section = citationSection({
+    id: "PALOMAR-2026-08-08-000001",
+    version: 1,
+    registered_at: "2026-08-08T12:00:00Z",
+    title: "A result",
+    authors: [{ name: "Example" }],
+  });
+  const button = byClass(section, "citation-copy");
+  const status = byClass(section, "citation-status");
+  const block = byClass(section, "citation-bibtex");
+
+  assert.equal(block.tabIndex, 0);
+  assert.equal(block.attributes.get("role"), "group");
+  await button.listeners.get("click")();
+  assert.equal(button.textContent, "Copy failed");
+  assert.equal(status.textContent, "Could not copy BibTeX citation.");
+  reset();
+  assert.equal(button.textContent, "Copy BibTeX");
+  assert.equal(status.textContent, "");
 });

--- a/tests/clipboard.test.mjs
+++ b/tests/clipboard.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createClipboard } from "../assets/clipboard.mjs";
+
+test("clipboard announcements clear before repeating the same message", () => {
+  const frames = [];
+  const status = { textContent: "Copied" };
+  const { announce } = createClipboard({
+    document: {},
+    navigator: {},
+    window: { requestAnimationFrame: (callback) => frames.push(callback) },
+  });
+
+  announce(status, "Copied");
+  assert.equal(status.textContent, "");
+  frames.shift()();
+  assert.equal(status.textContent, "Copied");
+  announce(status, "Copied");
+  assert.equal(status.textContent, "");
+  frames.shift()();
+  assert.equal(status.textContent, "Copied");
+});
+
+test("denied Clipboard API access falls back without taking focus", async () => {
+  let fallback;
+  let restored = false;
+  const body = {
+    append(node) {
+      fallback = node;
+    },
+  };
+  const document = {
+    activeElement: { focus: () => { restored = true; } },
+    body,
+    createElement() {
+      return {
+        remove() {},
+        select() {},
+        setSelectionRange() {},
+      };
+    },
+    execCommand(command) {
+      assert.equal(command, "copy");
+      return true;
+    },
+  };
+  const navigator = { clipboard: { writeText: async () => { throw new Error("denied"); } } };
+  const { copyText } = createClipboard({ document, navigator, window: {} });
+
+  assert.equal(await copyText("citation"), true);
+  assert.equal(fallback.value, "citation");
+  assert.equal(fallback.readOnly, true);
+  assert.equal(restored, true);
+});

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -478,6 +478,36 @@ test("a canonical registered record validates", () => {
   assert.equal(validateEntry(entry(), summary()).id, "PALOMAR-2026-07-29-000123");
 });
 
+test("registered records require authors and bounded source identifiers", () => {
+  const authorless = entry();
+  authorless.authors = [];
+  assert.throws(() => validateEntry(authorless, summary()), /authors must not be empty/);
+
+  const nonStringIdentifier = entry();
+  nonStringIdentifier.provenance.mathematical_sources = [{
+    title: "Source",
+    authors: [],
+    relationship: "background",
+    identifier: 123,
+  }];
+  assert.throws(
+    () => validateEntry(nonStringIdentifier, summary()),
+    /mathematical_sources\[0\]\.identifier must be a non-empty string/,
+  );
+
+  const oversizedIdentifier = entry();
+  oversizedIdentifier.provenance.mathematical_sources = [{
+    title: "Source",
+    authors: [],
+    relationship: "background",
+    identifier: "x".repeat(2049),
+  }];
+  assert.throws(
+    () => validateEntry(oversizedIdentifier, summary()),
+    /mathematical_sources\[0\]\.identifier is longer than 2048 characters/,
+  );
+});
+
 test("preservation must cover every immutable source", () => {
   const missing = entry();
   missing.preservation.repositories.pop();

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -684,7 +684,19 @@ test("mathematical sources format known identifiers and preserve unknown ones", 
         {
           title: "A journal source",
           authors: [],
-          identifier: "doi:10.1000/example",
+          identifier: "doi:10.1000/a?#b",
+          relationship: "background",
+        },
+        {
+          title: "An older arXiv source",
+          authors: [],
+          identifier: "arXiv:math.AG/0211159",
+          relationship: "background",
+        },
+        {
+          title: "A DOI preserved without normalization",
+          authors: [],
+          identifier: "doi:10.1000/../10.9999/other",
           relationship: "background",
         },
         {
@@ -697,6 +709,17 @@ test("mathematical sources format known identifiers and preserve unknown ones", 
           title: "An unsafe link preserved as text",
           authors: [],
           identifier: "https://reader:secret@example.invalid/source",
+          relationship: "background",
+        },
+        {
+          title: "A linked web source",
+          authors: [],
+          identifier: "https://example.invalid/a/very/long/source/url",
+          relationship: "background",
+        },
+        {
+          title: "A source without an identifier",
+          authors: [],
           relationship: "background",
         },
       ];
@@ -713,9 +736,16 @@ test("mathematical sources format known identifiers and preserve unknown ones", 
   );
   await expect(page.getByRole("link", { name: "arXiv:2605.20695", includeHidden: true }))
     .toHaveAttribute("href", "https://arxiv.org/abs/2605.20695");
-  await expect(page.getByRole("link", { name: "doi:10.1000/example", includeHidden: true }))
-    .toHaveAttribute("href", "https://doi.org/10.1000/example");
+  await expect(page.getByRole("link", { name: "doi:10.1000/a?#b", includeHidden: true }))
+    .toHaveAttribute("href", "https://doi.org/10.1000/a%3F%23b");
+  await expect(page.getByRole("link", { name: "arXiv:math.AG/0211159", includeHidden: true }))
+    .toHaveAttribute("href", "https://arxiv.org/abs/math.AG/0211159");
+  await expect(page.getByRole("link", {
+    name: "Open source for A linked web source",
+    includeHidden: true,
+  })).toHaveAttribute("href", "https://example.invalid/a/very/long/source/url");
   await expect(page.locator(".provenance-sources code")).toHaveText([
+    "doi:10.1000/../10.9999/other",
     "bibliographic:custom-reference",
     "https://reader:secret@example.invalid/source",
   ]);
@@ -1050,6 +1080,9 @@ test("entry pages offer a version-pinned BibTeX citation that can be copied", as
 
   const citation = page.locator(".entry-citation");
   await expect(citation.getByRole("heading", { name: "Cite this" })).toBeVisible();
+  await expect(citation.locator("pre")).toHaveAttribute("tabindex", "0");
+  await expect(citation.locator("pre")).toHaveAttribute("role", "group");
+  await expect(citation.locator("pre")).toHaveAttribute("aria-labelledby", "citation-heading");
   await expect(citation.locator("code")).toHaveText(
     `@misc{palomar-2026-07-29-000123-v1,
   author = {{Example}},

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -663,33 +663,62 @@ test("a thin wrapper says where the mathematics is before anything else", async 
     .toHaveAttribute("href", `https://github.com/${repository}/tree/${commit}`);
 });
 
-test("mathematical sources show non-author contributor roles", async ({ page }) => {
+test("mathematical sources format known identifiers and preserve unknown ones", async ({ page }) => {
   await page.route(
     "**/database/entries/PALOMAR-2026-07-29-000123-v2.json",
     async (route) => {
       const response = await route.fetch();
       const entry = await response.json();
       entry.provenance.result_origin = "source-based";
-      entry.provenance.mathematical_sources = [{
-        title: "Kourovka Notebook",
-        authors: [{ name: "Solution Author" }],
-        contributors: [
-          { name: "Wilhelm Magnus", role: "problem-proposer" },
-          { name: "Evgenii Khukhro", role: "editor" },
-        ],
-        relationship: "formalizes",
-      }];
+      entry.provenance.mathematical_sources = [
+        {
+          title: "Kourovka Notebook",
+          authors: [{ name: "Solution Author" }],
+          contributors: [
+            { name: "Wilhelm Magnus", role: "problem-proposer" },
+            { name: "Evgenii Khukhro", role: "editor" },
+          ],
+          identifier: "arXiv:2605.20695",
+          relationship: "formalizes",
+        },
+        {
+          title: "A journal source",
+          authors: [],
+          identifier: "doi:10.1000/example",
+          relationship: "background",
+        },
+        {
+          title: "A preserved custom source",
+          authors: [],
+          identifier: "bibliographic:custom-reference",
+          relationship: "background",
+        },
+        {
+          title: "An unsafe link preserved as text",
+          authors: [],
+          identifier: "https://reader:secret@example.invalid/source",
+          relationship: "background",
+        },
+      ];
       await route.fulfill({ response, json: entry });
     },
   );
 
   await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}`);
-  await expect(page.locator(".provenance-sources li")).toContainText(
+  await expect(page.locator(".provenance-sources li").first()).toContainText(
     "Solution Author: Kourovka Notebook",
   );
   await expect(page.locator(".source-contributors")).toHaveText(
     " — Wilhelm Magnus (problem-proposer); Evgenii Khukhro (editor)",
   );
+  await expect(page.getByRole("link", { name: "arXiv:2605.20695", includeHidden: true }))
+    .toHaveAttribute("href", "https://arxiv.org/abs/2605.20695");
+  await expect(page.getByRole("link", { name: "doi:10.1000/example", includeHidden: true }))
+    .toHaveAttribute("href", "https://doi.org/10.1000/example");
+  await expect(page.locator(".provenance-sources code")).toHaveText([
+    "bibliographic:custom-reference",
+    "https://reader:secret@example.invalid/source",
+  ]);
 });
 
 test("entry and render content do not wait for a never-settling availability read", async ({ page }) => {
@@ -1011,6 +1040,32 @@ test("entry pages list immutable versions and flag superseded snapshots", async 
     "href",
     "https://palomar-registry.org/entry?id=PALOMAR-2026-07-29-000123&version=1",
   );
+});
+
+test("entry pages offer a version-pinned BibTeX citation that can be copied", async ({ context, page }) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await page.goto(
+    `/entry.html?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`,
+  );
+
+  const citation = page.locator(".entry-citation");
+  await expect(citation.getByRole("heading", { name: "Cite this" })).toBeVisible();
+  await expect(citation.locator("code")).toHaveText(
+    `@misc{palomar-2026-07-29-000123-v1,
+  author = {{Example}},
+  title = {{Fixture PALOMAR-2026-07-29-000123 version 1}},
+  year = {2026},
+  howpublished = {Palomar, PALOMAR-2026-07-29-000123 v1},
+  url = {https://palomar-registry.org/entry?id=PALOMAR-2026-07-29-000123&version=1},
+}`,
+  );
+
+  await citation.getByRole("button", { name: "Copy BibTeX" }).click();
+  await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toContain(
+    "@misc{palomar-2026-07-29-000123-v1,",
+  );
+  await expect(citation.getByRole("status")).toHaveText("Copied BibTeX citation.");
+  await expect(citation.getByRole("button", { name: "Copied!" })).toHaveClass(/copied/);
 });
 
 test("a single current version has no supersession treatment", async ({ page }) => {


### PR DESCRIPTION
Closes #134.

Summary:
- add a styled Cite this section with ready-to-paste BibTeX and an accessible copy control
- pin the BibTeX key and canonical URL to the immutable version being viewed, and use that version registration year
- escape TeX-significant title and author text while preserving Unicode
- share resilient clipboard fallback and repeatable live-region announcements with the submission guide
- format current and legacy arXiv and DOI mathematical-source identifiers as links, with unknown, unsafe, or normalization-changing identifiers preserved verbatim
- validate entry authors and source-identifier bounds at the record boundary
- ship and asset-version the new presentation, clipboard, and bibliography modules

Design decisions:
- use @misc, the broadly supported BibTeX type for registry records
- omit the source commit because the immutable Palomar version URL already resolves to the exact validated record and its commit
- keep each free-form author display name braced so attribution is preserved without inventing given/family structure
- do not add runtime Highwire or Dublin Core tags in this change; entry data is loaded dynamically, so JavaScript-inserted head tags would not provide reliable crawler discovery

Verification:
- PALOMAR_DATABASE_CHECKOUT=/home/kim/palomar/PalomarDatabase npm test (261 passed)
- Nixpkgs Chromium browser suite (89 passed, 2 expected PALOMAR_PREVIOUS_REF skips)