### PR TITLE
Fix current arXiv classification limit

### DIFF
--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -382,7 +382,7 @@ export function validateRecent(value) {
       `${field}.classification.arxiv`,
       ARXIV_RE,
     );
-    if (arxiv.length > 2) fail(`${field}.classification.arxiv has more than 2 codes`);
+    if (arxiv.length > 8) fail(`${field}.classification.arxiv has more than 8 codes`);
     const msc2020 = distinctStringArray(
       classification.msc2020,
       `${field}.classification.msc2020`,
@@ -969,7 +969,7 @@ function validateSubjectRow(value, field, { kind, code, abstract }) {
     `${field}.classification`,
   );
   const arxiv = distinctStringArray(classification.arxiv, `${field}.classification.arxiv`, ARXIV_RE);
-  if (arxiv.length > 2) fail(`${field}.classification.arxiv has more than 2 codes`);
+  if (arxiv.length > 8) fail(`${field}.classification.arxiv has more than 8 codes`);
   const msc2020 = distinctStringArray(
     classification.msc2020,
     `${field}.classification.msc2020`,

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -318,14 +318,16 @@ test("recent applies the canonical producer's cheap presentation bounds", () => 
   }
 
   const classifications = recent();
-  classifications.entries[0].classification.arxiv = ["math.CO", "math.NT"];
+  classifications.entries[0].classification.arxiv = [
+    "math.CO", "math.NT", "cs.DM", "math.AG", "math.AT", "math.CA", "math.CT", "math.LO",
+  ];
   classifications.entries[0].classification.msc2020 = Array.from(
     { length: 8 },
     (_unused, position) => `10A${String(position + 1).padStart(2, "0")}`,
   );
   assert.equal(validateRecent(classifications), classifications);
-  classifications.entries[0].classification.arxiv.push("cs.DM");
-  assert.throws(() => validateRecent(classifications), /more than 2 codes/);
+  classifications.entries[0].classification.arxiv.push("math.MG");
+  assert.throws(() => validateRecent(classifications), /more than 8 codes/);
   classifications.entries[0].classification.arxiv.pop();
   classifications.entries[0].classification.msc2020.push("10A09");
   assert.throws(() => validateRecent(classifications), /more than 8 codes/);


### PR DESCRIPTION
The deployed schema permits up to eight arXiv classification codes, but the Web validators still reject more than two. This makes the live `recent.json` fail validation and takes down the landing page.

Align both recent and subject-row validation with the deployed limit and update the boundary regression.

Verified with the focused security suite and against all 47 rows in the live `recent.json`.