### PR TITLE
Isolate invalid landing registry rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,12 @@
   agrees with everything. Without a checkout you get hard failures and no hint
   why, so this is the first thing to check.
 
-- `recent.json` is an exact closed producer/consumer contract. Shape changes
-  require a coordinated producer-first deployment from PalomarDatabase before
-  the matching Web deployment. Do not add an old-shape or per-entry fallback;
-  invalid projections are supposed to fail closed.
+- `recent.json` has a strict document envelope and independently validated
+  landing rows. Browser validation is limited to fields needed to render and
+  link safely; PalomarDatabase owns policy such as classification cardinality,
+  uniqueness, and exact additive shape. An unusable row is omitted with private
+  diagnostics and a visible count, while deployment health still rejects any
+  omission so producer drift is caught without taking down valid siblings.
 
 - The subject surfaces—`subjects/<kind>/<code>.json`, its `<year>.json`, and its
   `<day>/<page>.json`—are the same closed contract, and are the same document

--- a/README.md
+++ b/README.md
@@ -95,18 +95,16 @@ to the newest matching version in the bounded candidate set, so a result is not
 repeated. A posting still says neither that a version is current nor how many
 active versions exist, so search cards make neither claim; landing cards get
 both facts from `recent.json`.
-Each `recent.json` row is the exact landing-card projection built from a
-validated canonical entry: identity, current/history count, registration time,
-title, abstract, authors, classifications, theorem names, trust, source commit
-and project path, and the source's preservation mapping. The browser validates
-that complete closed shape and renders it directly. A normal landing load is
-therefore exactly two dynamic data requests—`recent.json` and the optional
-source-availability manifest—with no per-card entry reads. Invalid or partial
-projections fail closed before any card is rendered.
-This is one exact closed producer/consumer contract, not an extensible summary:
-a shape change must be published by PalomarDatabase first and followed by the
-matching website deployment. The consumer deliberately has no old-row fallback
-or per-entry recovery path.
+Each `recent.json` row projects the fields a landing card needs from a canonical
+entry: identity, current/history count, registration time, title, abstract,
+authors, classifications, theorem names, trust, source commit and project path,
+and the source's preservation mapping. The browser checks the envelope and the
+fields needed to render and link safely, but leaves schema policy such as
+classification cardinality to PalomarDatabase. A normal landing load is still
+exactly two dynamic data requests—`recent.json` and the optional
+source-availability manifest—with no per-card entry reads. An unusable row is
+omitted with a visible count while valid siblings continue to render; transport
+and unsupported-schema failures still fail the page.
 The `browse/index.json`, `browse/<year>.json`, and
 `browse/<day>/<page>.json` hierarchy is another exact, closed contract owned by
 PalomarDatabase and consumed by Web. Its head declares years and aggregate

--- a/assets/app.js
+++ b/assets/app.js
@@ -3,6 +3,7 @@ import {
   REPOSITORY_ROLE_LABELS,
   isLoopbackHostname,
   pinnedRepositoryDirectoryUrl,
+  recentValidationIssues,
   safeDataUrl,
   safeExternalUrl,
   safeInternalUrl,
@@ -128,9 +129,10 @@ function theoremNames(entry) {
 }
 
 function classification(entry) {
+  const distinct = (value) => Array.isArray(value) ? [...new Set(value)] : [];
   return {
-    arxiv: Array.isArray(entry.classification?.arxiv) ? entry.classification.arxiv : [],
-    msc2020: Array.isArray(entry.classification?.msc2020) ? entry.classification.msc2020 : [],
+    arxiv: distinct(entry.classification?.arxiv),
+    msc2020: distinct(entry.classification?.msc2020),
   };
 }
 
@@ -394,6 +396,32 @@ function entryCard(
 let landingSuppressed = false;
 let landingStatusHidden = document.querySelector("#status")?.hidden ?? true;
 
+function registryWarningNode() {
+  let warning = document.querySelector("#registry-warning");
+  if (warning) return warning;
+  const status = document.querySelector("#status");
+  if (!status) return null;
+  warning = el("div", "status warning");
+  warning.id = "registry-warning";
+  warning.hidden = true;
+  warning.setAttribute("role", "status");
+  status.before(warning);
+  return warning;
+}
+
+function showRecentIssues(issues) {
+  const warning = registryWarningNode();
+  if (!warning) return;
+  warning.hidden = issues.omitted === 0;
+  warning.textContent = issues.omitted === 1
+    ? "1 registry entry could not be displayed."
+    : `${issues.omitted} registry entries could not be displayed.`;
+  for (const issue of issues.details) {
+    const identity = issue.id ? ` (${issue.id})` : "";
+    console.warn(`Recent registry row ${issue.position}${identity}: ${issue.reason}`);
+  }
+}
+
 function setLandingStatusHidden(hidden) {
   landingStatusHidden = hidden;
   const status = document.querySelector("#status");
@@ -428,7 +456,9 @@ function setLandingSuppressed(suppressed) {
 async function renderIndex() {
   const status = document.querySelector("#status");
   const grid = document.querySelector("#entry-grid");
+  const warning = registryWarningNode();
   try {
+    if (warning) warning.hidden = true;
     status.className = "status";
     status.textContent = "Reading the Palomar database…";
     setLandingStatusHidden(false);
@@ -439,6 +469,7 @@ async function renderIndex() {
     // entries into this bounded newest-first document. Rendering the selection
     // therefore costs one summary read, not one record read per card.
     const recent = await loadRecent(databaseBase);
+    const issues = recentValidationIssues(recent);
     const entries = recent.entries;
     landingMatches = entries.map((entry) => ({ entry, blob: searchBlob(entry) }));
     // GitHub Pages may briefly pair HTML and JavaScript from adjacent deployments.
@@ -450,11 +481,21 @@ async function renderIndex() {
     );
     if (!entries.length) {
       setLandingStatusHidden(false);
-      status.textContent =
-        "The telescope is ready. No entries have been registered yet; the first registered result will appear here automatically.";
-      status.classList.add("empty");
+      if (issues.omitted) {
+        status.textContent = issues.omitted === 1
+          ? "1 registry entry could not be displayed."
+          : `${issues.omitted} registry entries could not be displayed.`;
+        status.classList.add("warning");
+      } else {
+        status.textContent =
+          "The telescope is ready. No entries have been registered yet; the first registered result will appear here automatically.";
+        status.classList.add("empty");
+      }
+      showRecentIssues(issues);
+      if (warning) warning.hidden = true;
       return true;
     }
+    showRecentIssues(issues);
     setLandingStatusHidden(true);
     status.textContent = "";
     status.className = "status";
@@ -647,6 +688,7 @@ async function renderIndex() {
     update();
     return true;
   } catch (error) {
+    if (warning) warning.hidden = true;
     setLandingStatusHidden(false);
     status.textContent = `The registry could not be loaded: ${error.message}`;
     status.className = "status error";

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -72,9 +72,12 @@ export const AVAILABILITY_MAX_CLOCK_SKEW_MS = 5 * 60 * 1000;
 const availabilityIndexes = new WeakMap();
 const validatedSourceRecords = new WeakMap();
 const recentRenderIndexes = new WeakMap();
+const recentIssueIndexes = new WeakMap();
+
+class RegistryDataError extends Error {}
 
 function fail(message) {
-  throw new Error(`invalid registry data: ${message}`);
+  throw new RegistryDataError(`invalid registry data: ${message}`);
 }
 
 export function validatedSourceMapping(record, repository, revision) {
@@ -177,6 +180,25 @@ function distinctStringArray(value, field, pattern = null) {
     fail(`${field} contains a malformed value`);
   }
   return items;
+}
+
+/**
+ * Classification fields needed by presentation.
+ *
+ * Cardinality, uniqueness, and exact schema shape are producer policy. The
+ * browser only requires arrays of codes it can turn into usable subject links.
+ */
+function validateClassification(value, field) {
+  const classification = object(value, field);
+  const arxiv = stringArray(classification.arxiv, `${field}.arxiv`);
+  const msc2020 = stringArray(classification.msc2020, `${field}.msc2020`);
+  if (arxiv.some((code) => !ARXIV_RE.test(code))) {
+    fail(`${field}.arxiv contains a malformed code`);
+  }
+  if (msc2020.some((code) => !MSC2020_RE.test(code))) {
+    fail(`${field}.msc2020 contains a malformed code`);
+  }
+  return classification;
 }
 
 function commit(value, field) {
@@ -295,152 +317,131 @@ export function recentRendersUrl(databaseBase) {
 /**
  * What is new, from `recent.json`.
  *
- * Each row is the publisher's exact, self-contained landing-card projection of
- * one validated canonical entry. The deliberately small nested objects carry
- * every field a card renders and no record-only fields. Besides that complete
- * shape, this document claims to be the newest current versions and no more
- * than the publisher's bound of them, so coverage and ordering are checked too.
+ * Each accepted row has every field a card needs to render and link safely.
+ * Producer policy is checked before publication; one unusable row here is
+ * omitted rather than turning every independent sibling into an error page.
  */
-export function validateRecent(value) {
-  const document = exactObject(value, ["schema_version", "entries"], "recent");
-  if (document.schema_version !== RECENT_SCHEMA_VERSION) {
-    fail(`unsupported recent schema_version ${String(document.schema_version)}`);
+function validateRecentRow(value, position) {
+  const field = `recent.entries[${position}]`;
+  const summary = object(value, field);
+  const id = string(summary.id, `${field}.id`);
+  if (!ID_RE.test(id)) fail(`${field}.id is malformed`);
+  const version = integer(summary.version, `${field}.version`);
+  boundedString(summary.title, `${field}.title`, 300);
+  if (summary.abstract !== undefined) boundedString(summary.abstract, `${field}.abstract`, 10_000);
+  if (summary.status !== "registered") fail(`${field}.status is not registered`);
+  const expectedPath = `entries/${id}-v${version}.json`;
+  if (summary.path !== expectedPath) fail(`${field}.path must be ${expectedPath}`);
+  integer(summary.versions, `${field}.versions`);
+  instant(summary.published_at, `${field}.published_at`);
+
+  for (const [authorPosition, authorValue] of array(summary.authors, `${field}.authors`).entries()) {
+    const authorField = `${field}.authors[${authorPosition}]`;
+    string(object(authorValue, authorField).name, `${authorField}.name`);
   }
-  const entries = array(document.entries, "recent.entries");
-  if (entries.length > RECENT_ITEMS) fail("recent carries more rows than it may");
-  const seen = new Set();
-  const sourceReceipts = [];
-  let previous = null;
-  for (const [position, value] of entries.entries()) {
-    const field = `recent.entries[${position}]`;
-    const summary = exactObject(value, [
-      "abstract",
-      "authors",
-      "classification",
-      "formalization",
-      "id",
-      "path",
-      "preservation",
-      "published_at",
-      "source",
-      "status",
-      "title",
-      "trust",
-      "version",
-      "versions",
-    ], field);
-    const id = string(summary.id, `${field}.id`);
-    if (!ID_RE.test(id)) fail(`recent.entries[${position}].id is malformed`);
-    const version = integer(summary.version, `${field}.version`);
-    boundedString(summary.title, `${field}.title`, 300);
-    boundedString(summary.abstract, `${field}.abstract`, 10_000);
-    if (summary.status !== "registered") fail(`recent.entries[${position}].status is not registered`);
-    const expectedPath = `entries/${id}-v${version}.json`;
-    if (summary.path !== expectedPath) {
-      fail(`recent.entries[${position}].path must be ${expectedPath}`);
-    }
-    integer(summary.versions, `${field}.versions`);
-    const publishedAt = string(summary.published_at, `${field}.published_at`);
-    // An instant, and only an instant. This is the record's `registered_at`,
-    // which the schema requires of every version. A date was tolerated while a
-    // row could fall back to `first_registered_on`, and a date read as an instant is
-    // midnight, so such a row would sort ahead of everything registered that
-    // day with nothing to say why.
-    if (!TIMESTAMP_RE.test(publishedAt)) {
-      fail(`recent.entries[${position}].published_at is malformed`);
-    }
-    const moment = Date.parse(publishedAt);
-    if (Number.isNaN(moment) ||
-        new Date(moment).toISOString().replace(".000Z", "Z") !== publishedAt) {
-      fail(`recent.entries[${position}].published_at is malformed`);
-    }
-    if (previous !== null &&
-        (moment > previous.moment || (moment === previous.moment && id > previous.id))) {
-      fail("recent is not in newest-first order");
-    }
-    previous = { moment, id };
-    // One row per result, because these are the current versions: the same
-    // identifier twice means this is not the selection it says it is.
-    if (seen.has(id)) fail(`recent names ${id} more than once`);
-    seen.add(id);
 
-    const authors = array(summary.authors, `${field}.authors`);
-    if (!authors.length) fail(`${field}.authors must be a non-empty array`);
-    for (const [authorPosition, authorValue] of authors.entries()) {
-      const authorField = `${field}.authors[${authorPosition}]`;
-      const author = exactObject(authorValue, ["name"], authorField);
-      string(author.name, `${authorField}.name`);
-    }
+  validateClassification(summary.classification, `${field}.classification`);
+  const formalization = object(summary.formalization, `${field}.formalization`);
+  stringArray(formalization.theorem_names, `${field}.formalization.theorem_names`);
+  const trust = object(summary.trust, `${field}.trust`);
+  if (!["high", "qualified"].includes(trust.level)) fail(`${field}.trust.level is invalid`);
 
-    const classification = exactObject(
-      summary.classification,
-      ["arxiv", "msc2020"],
-      `${field}.classification`,
-    );
-    const arxiv = distinctStringArray(
-      classification.arxiv,
-      `${field}.classification.arxiv`,
-      ARXIV_RE,
-    );
-    if (arxiv.length > 8) fail(`${field}.classification.arxiv has more than 8 codes`);
-    const msc2020 = distinctStringArray(
-      classification.msc2020,
-      `${field}.classification.msc2020`,
-      MSC2020_RE,
-    );
-    if (msc2020.length > 8) fail(`${field}.classification.msc2020 has more than 8 codes`);
-    const formalization = exactObject(
-      summary.formalization,
-      ["theorem_names"],
-      `${field}.formalization`,
-    );
-    distinctStringArray(formalization.theorem_names, `${field}.formalization.theorem_names`);
-    const trust = exactObject(summary.trust, ["level"], `${field}.trust`);
-    if (!["high", "qualified"].includes(trust.level)) fail(`${field}.trust.level is invalid`);
+  const source = object(summary.source, `${field}.source`);
+  const repository = string(source.repository, `${field}.source.repository`);
+  if (!REPOSITORY_RE.test(repository)) fail(`${field}.source.repository is malformed`);
+  commit(string(source.commit, `${field}.source.commit`), `${field}.source.commit`);
+  if (source.project_path !== null && source.project_path !== undefined) {
+    safeRepositoryPath(source.project_path, `${field}.source.project_path`);
+  }
 
-    const source = exactObject(
-      summary.source,
-      ["repository", "commit", "project_path"],
-      `${field}.source`,
-    );
-    const repository = string(source.repository, `${field}.source.repository`);
-    if (!REPOSITORY_RE.test(repository)) fail(`${field}.source.repository is malformed`);
-    commit(string(source.commit, `${field}.source.commit`), `${field}.source.commit`);
-    if (source.project_path !== null) safeRepositoryPath(source.project_path, `${field}.source.project_path`);
-
-    const preservation = exactObject(
-      summary.preservation,
-      ["repositories"],
-      `${field}.preservation`,
-    );
-    const repositories = array(preservation.repositories, `${field}.preservation.repositories`);
-    if (repositories.length !== 1) fail(`${field}.preservation must contain one source mapping`);
-    const mapping = exactObject(repositories[0], [
-      "source_repository",
-      "commit",
-      "fork_repository",
-    ], `${field}.preservation.repositories[0]`);
-    if (typeof mapping.source_repository !== "string" ||
-        mapping.source_repository.toLowerCase() !== repository.toLowerCase() ||
-        mapping.commit !== source.commit ||
-        typeof mapping.fork_repository !== "string" ||
-        !REPOSITORY_RE.test(mapping.fork_repository) ||
-        !mapping.fork_repository.startsWith("PalomarArchive/")) {
-      fail(`${field}.preservation does not match source`);
-    }
-    const key = `${mapping.source_repository.toLowerCase()}\0${mapping.commit}`;
-    sourceReceipts.push({
+  const preservation = object(summary.preservation, `${field}.preservation`);
+  const repositories = array(preservation.repositories, `${field}.preservation.repositories`);
+  const matching = repositories.filter((mapping) =>
+    mapping && typeof mapping === "object" && !Array.isArray(mapping) &&
+    typeof mapping.source_repository === "string" &&
+    mapping.source_repository.toLowerCase() === repository.toLowerCase() &&
+    mapping.commit === source.commit);
+  if (matching.length !== 1) fail(`${field}.preservation does not match source`);
+  const [mapping] = matching;
+  if (typeof mapping.fork_repository !== "string" ||
+      !REPOSITORY_RE.test(mapping.fork_repository) ||
+      !mapping.fork_repository.startsWith("PalomarArchive/")) {
+    fail(`${field}.preservation does not match source`);
+  }
+  const key = `${mapping.source_repository.toLowerCase()}\0${mapping.commit}`;
+  return {
+    id,
+    summary,
+    receipt: {
       record: summary,
       repositories,
       index: new Map([[key, sourceMappingSnapshot(mapping)]]),
-    });
+    },
+  };
+}
+
+export function validateRecent(value) {
+  const source = object(value, "recent");
+  if (source.schema_version !== RECENT_SCHEMA_VERSION) {
+    fail(`unsupported recent schema_version ${String(source.schema_version)}`);
   }
-  // Mark rows only after the complete projection succeeds. A reference to an
-  // early row from a later-rejected document must not become presentation data.
-  for (const receipt of sourceReceipts) {
-    validatedSourceRecords.set(receipt.record, receipt);
+  const rawEntries = array(source.entries, "recent.entries");
+  const details = [];
+  let omitted = Math.max(0, rawEntries.length - RECENT_ITEMS);
+  if (omitted) {
+    details.push(Object.freeze({
+      id: null,
+      position: RECENT_ITEMS,
+      reason: `${omitted} rows exceed the ${RECENT_ITEMS}-card presentation limit`,
+    }));
   }
+
+  const candidates = [];
+  for (const [position, raw] of rawEntries.slice(0, RECENT_ITEMS).entries()) {
+    try {
+      candidates.push({ ...validateRecentRow(raw, position), position });
+    } catch (error) {
+      if (!(error instanceof RegistryDataError)) throw error;
+      omitted += 1;
+      details.push(Object.freeze({
+        id: typeof raw?.id === "string" && ID_RE.test(raw.id) ? raw.id : null,
+        position,
+        reason: error.message,
+      }));
+    }
+  }
+
+  const counts = new Map();
+  for (const { id } of candidates) counts.set(id, (counts.get(id) ?? 0) + 1);
+  const accepted = [];
+  for (const candidate of candidates) {
+    if (counts.get(candidate.id) !== 1) {
+      omitted += 1;
+      details.push(Object.freeze({
+        id: candidate.id,
+        position: candidate.position,
+        reason: `invalid registry data: recent names ${candidate.id} more than once`,
+      }));
+      continue;
+    }
+    accepted.push(candidate.summary);
+    validatedSourceRecords.set(candidate.receipt.record, candidate.receipt);
+  }
+
+  const document = { schema_version: source.schema_version, entries: accepted };
+  recentIssueIndexes.set(document, Object.freeze({
+    received: rawEntries.length,
+    omitted,
+    details: Object.freeze(details),
+  }));
   return document;
+}
+
+/** Diagnostics for a validated landing projection, kept outside public JSON. */
+export function recentValidationIssues(document) {
+  const issues = recentIssueIndexes.get(document);
+  if (!issues) fail("recent document was not validated");
+  return issues;
 }
 
 /**
@@ -963,19 +964,7 @@ function validateSubjectRow(value, field, { kind, code, abstract }) {
   );
   instant(row.published_at, `${field}.published_at`);
   if (abstract) boundedString(row.abstract, `${field}.abstract`, 10_000);
-  const classification = exactObject(
-    row.classification,
-    ["arxiv", "msc2020"],
-    `${field}.classification`,
-  );
-  const arxiv = distinctStringArray(classification.arxiv, `${field}.classification.arxiv`, ARXIV_RE);
-  if (arxiv.length > 8) fail(`${field}.classification.arxiv has more than 8 codes`);
-  const msc2020 = distinctStringArray(
-    classification.msc2020,
-    `${field}.classification.msc2020`,
-    MSC2020_RE,
-  );
-  if (msc2020.length > 8) fail(`${field}.classification.msc2020 has more than 8 codes`);
+  const classification = validateClassification(row.classification, `${field}.classification`);
   if (!classification[SUBJECT_CLASSIFICATION_FIELDS[kind]].includes(code)) {
     fail(`${field} is not classified ${code}`);
   }
@@ -1408,23 +1397,7 @@ export function validateEntry(entry, summary) {
     string(object(value, `entry.authors[${position}]`).name, `entry.authors[${position}].name`);
   }
 
-  {
-    const classification = object(entry.classification, "entry.classification");
-    const arxiv = stringArray(classification.arxiv, "entry.classification.arxiv");
-    const msc2020 = stringArray(classification.msc2020, "entry.classification.msc2020");
-    if (arxiv.length < 1 || arxiv.length > 8 || new Set(arxiv).size !== arxiv.length) {
-      fail("entry.classification.arxiv must contain one to eight unique codes");
-    }
-    if (msc2020.length > 8 || new Set(msc2020).size !== msc2020.length) {
-      fail("entry.classification.msc2020 must contain at most eight unique codes");
-    }
-    if (arxiv.some((code) => !ARXIV_RE.test(code))) {
-      fail("entry.classification.arxiv contains a malformed code");
-    }
-    if (msc2020.some((code) => !MSC2020_RE.test(code))) {
-      fail("entry.classification.msc2020 contains a malformed code");
-    }
-  }
+  validateClassification(entry.classification, "entry.classification");
 
   // A published record names the submission, and nothing about the person who
   // sent it. There is no submitter field to display, by construction.

--- a/assets/style.css
+++ b/assets/style.css
@@ -307,6 +307,7 @@ h3 {
 
 body.registry-searching .toolbar,
 body.registry-searching #status,
+body.registry-searching #registry-warning,
 body.registry-searching #entry-grid {
   display: none;
 }

--- a/index.html
+++ b/index.html
@@ -79,6 +79,7 @@
           </div>
         </div>
 
+        <div id="registry-warning" class="status warning" role="status" hidden></div>
         <div id="status" class="status" role="status">
           Reading the Palomar database…
           <noscript>

--- a/scripts/check-published.mjs
+++ b/scripts/check-published.mjs
@@ -16,6 +16,7 @@ import { readFile } from "node:fs/promises";
 import { shippedFiles } from "./build-site.mjs";
 import {
   entryRecordUrl,
+  recentValidationIssues,
   subjectHeadUrl,
   validateBrowseHead,
   validateBrowsePage,
@@ -134,6 +135,7 @@ async function fetchJson(url, fetcher, policy) {
 }
 
 const PUBLIC_VALIDATORS = {
+  recentValidationIssues,
   validateBrowseHead,
   validateBrowsePage,
   validateBrowseYear,
@@ -156,6 +158,12 @@ export async function publicDataState(
     const recent = validators.validateRecent(
       await fetchJson(new URL("recent.json", base), fetcher, policy),
     );
+    if (validators.recentValidationIssues) {
+      const issues = validators.recentValidationIssues(recent);
+      if (issues.omitted) {
+        throw new Error(`recent.json contains ${issues.omitted} unusable rows`);
+      }
+    }
     const recentRenders = validators.validateRecentRenders(
       await fetchJson(new URL("recent-renders.json", base), fetcher, policy),
     );

--- a/tests/check-published.test.js
+++ b/tests/check-published.test.js
@@ -381,6 +381,17 @@ test("live-data health fails on the same contract error a visitor would see", as
   assert.match(state.reason, /entry\.review\.scores must be an object/);
 });
 
+test("live-data health refuses a landing projection that omitted unusable rows", async () => {
+  const fetcher = async () => ({ ok: true, async json() { return { entries: [{}] }; } });
+  const state = await publicDataState("https://data.example", fetcher, {
+    validateRecent: (value) => value,
+    recentValidationIssues: () => ({ omitted: 1, details: [] }),
+  });
+
+  assert.equal(state.healthy, false);
+  assert.match(state.reason, /recent\.json contains 1 unusable rows/);
+});
+
 test("live-data health retries a transient request and recovers", async () => {
   const fixture = oneEntryRegistry();
   let recentAttempts = 0;

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -45,6 +45,7 @@ import {
   recentRenderRow,
   recentRendersUrl,
   recentUrl,
+  recentValidationIssues,
   tombstoneUrl,
   validateEntry,
   validateAvailability,
@@ -189,25 +190,21 @@ test("what is new is read from the database prefix and nowhere else", () => {
   );
 });
 
-test("recent validation rejects unsupported, rejected, and malformed rows", () => {
+test("recent validation rejects unsupported envelopes and isolates malformed rows", () => {
   assert.throws(() => validateRecent(recent([], { schema_version: 3 })), /unsupported recent/);
-  assert.throws(
-    () => validateRecent(recent([recentRow({ status: "draft" })])),
-    /status is not registered/,
-  );
-  assert.throws(
-    () => validateRecent(recent([recentRow({ published_at: "yesterday" })])),
-    /published_at is malformed/,
-  );
-  // A date, not an instant. Every row carries the record's `registered_at`,
-  // which the schema requires of every version, and a date read as an instant
-  // is midnight: such a row would sort ahead of everything registered that day
-  // and no reader could tell why.
-  assert.throws(
-    () => validateRecent(recent([recentRow({ published_at: "2026-07-29" })])),
-    /published_at is malformed/,
-  );
+  // A date, not an instant, would sort at an invented midnight with no way for
+  // a reader to tell why.
+  for (const row of [
+    recentRow({ status: "draft" }),
+    recentRow({ published_at: "yesterday" }),
+    recentRow({ published_at: "2026-07-29" }),
+  ]) {
+    const document = validateRecent(recent([row]));
+    assert.deepEqual(document.entries, []);
+    assert.equal(recentValidationIssues(document).omitted, 1);
+  }
   assert.equal(validateRecent(recent()).entries.length, 1);
+  assert.throws(() => recentValidationIssues(recent()), /was not validated/);
 });
 
 test("recent validation accepts the Database-owned landing-card fixture", async () => {
@@ -219,7 +216,7 @@ test("recent validation accepts the Database-owned landing-card fixture", async 
     await readFile(join(checkout, "tests", "fixtures", "recent.json"), "utf8"),
   );
   assert.ok(fixture.entries.length > 0, "the external contract fixture must exercise a row");
-  assert.equal(validateRecent(fixture), fixture);
+  assert.deepEqual(validateRecent(fixture), fixture);
 });
 
 test("an empty recent registry is valid", () => {
@@ -268,69 +265,75 @@ test("a rejected render companion leaves no row usable", () => {
   assert.throws(() => recentRenderRow(document, renderRow().id), /was not validated/);
 });
 
-test("recent is one exact complete projection, not a legacy summary shape", () => {
-  assert.throws(
-    () => validateRecent({ schema_version: 2, entries: [summary()] }),
-    /invalid shape/,
-  );
+test("recent requires renderable fields but ignores additive producer fields", () => {
+  const legacy = validateRecent({ schema_version: 2, entries: [summary()] });
+  assert.deepEqual(legacy.entries, []);
+  assert.equal(recentValidationIssues(legacy).omitted, 1);
+
+  const additive = recent();
+  additive.legacy_entries = [];
+  additive.entries[0].registered_at = additive.entries[0].published_at;
+  additive.entries[0].authors[0].github = "somebody";
+  assert.equal(validateRecent(additive).entries.length, 1);
 
   for (const mutate of [
-    (page) => { page.legacy_entries = []; },
-    (page) => { delete page.entries[0].abstract; },
-    (page) => { page.entries[0].registered_at = page.entries[0].published_at; },
-    (page) => { delete page.entries[0].source.project_path; },
-    (page) => { page.entries[0].authors[0].github = "somebody"; },
     (page) => { page.entries[0].preservation = null; },
     (page) => { page.entries[0].preservation.repositories = []; },
   ]) {
     const page = recent();
     mutate(page);
-    assert.throws(
-      () => validateRecent(page),
-      /invalid shape|preservation must be an object|must contain one source mapping/,
-    );
+    const validated = validateRecent(page);
+    assert.deepEqual(validated.entries, []);
+    assert.equal(recentValidationIssues(validated).omitted, 1);
+  }
+
+  for (const mutate of [
+    (page) => { delete page.entries[0].abstract; },
+    (page) => { delete page.entries[0].source.project_path; },
+  ]) {
+    const page = recent();
+    mutate(page);
+    assert.equal(validateRecent(page).entries.length, 1);
   }
 });
 
-test("recent validates every projected card field and source mapping", () => {
+test("recent treats classification cardinality as producer policy", () => {
   const duplicateClassifications = recent();
   duplicateClassifications.entries[0].classification.arxiv.push("math.CO");
-  assert.throws(() => validateRecent(duplicateClassifications), /distinct values/);
+  assert.equal(validateRecent(duplicateClassifications).entries.length, 1);
 
   const missingTheorems = recent();
   missingTheorems.entries[0].formalization.theorem_names = [];
-  assert.throws(() => validateRecent(missingTheorems), /non-empty array/);
+  assert.equal(validateRecent(missingTheorems).entries.length, 1);
+
+  const manyClassifications = recent();
+  manyClassifications.entries[0].classification.arxiv = Array.from(
+    { length: 12 },
+    (_unused, position) => `math.${String.fromCharCode(65 + position)}A`,
+  );
+  manyClassifications.entries[0].classification.msc2020 = [];
+  assert.equal(validateRecent(manyClassifications).entries.length, 1);
 
   const mismatchedPreservation = recent();
   mismatchedPreservation.entries[0].preservation.repositories[0].commit = "2".repeat(40);
-  assert.throws(() => validateRecent(mismatchedPreservation), /does not match source/);
+  const validated = validateRecent(mismatchedPreservation);
+  assert.deepEqual(validated.entries, []);
+  assert.match(recentValidationIssues(validated).details[0].reason, /does not match source/);
 });
 
-test("recent applies the canonical producer's cheap presentation bounds", () => {
+test("recent applies cheap presentation text bounds", () => {
   for (const [field, maximum] of [["title", 300], ["abstract", 10_000]]) {
     const atBound = recent();
     atBound.entries[0][field] = "x".repeat(maximum);
-    assert.equal(validateRecent(atBound), atBound);
+    assert.deepEqual(validateRecent(atBound), atBound);
 
     const overBound = recent();
     overBound.entries[0][field] = "x".repeat(maximum + 1);
-    assert.throws(() => validateRecent(overBound), new RegExp(`longer than ${maximum}`));
+    const validated = validateRecent(overBound);
+    assert.equal(recentValidationIssues(validated).omitted, 1);
+    assert.match(recentValidationIssues(validated).details[0].reason, new RegExp(`longer than ${maximum}`));
   }
 
-  const classifications = recent();
-  classifications.entries[0].classification.arxiv = [
-    "math.CO", "math.NT", "cs.DM", "math.AG", "math.AT", "math.CA", "math.CT", "math.LO",
-  ];
-  classifications.entries[0].classification.msc2020 = Array.from(
-    { length: 8 },
-    (_unused, position) => `10A${String(position + 1).padStart(2, "0")}`,
-  );
-  assert.equal(validateRecent(classifications), classifications);
-  classifications.entries[0].classification.arxiv.push("math.MG");
-  assert.throws(() => validateRecent(classifications), /more than 8 codes/);
-  classifications.entries[0].classification.arxiv.pop();
-  classifications.entries[0].classification.msc2020.push("10A09");
-  assert.throws(() => validateRecent(classifications), /more than 8 codes/);
 });
 
 test("a record must say when the version was registered, and agree with its result date", () => {
@@ -387,35 +390,34 @@ test("a recent summary's publication instant matches the entry it orders", () =>
   assert.equal(validateEntry(record, summary()), record);
 });
 
-test("what recent claims is coverage and ordering, so both are checked", () => {
-  // The rows would render perfectly well in any order, and a result listed
-  // twice under two versions is two well-formed rows. Nothing else on this
-  // side would notice either, which is exactly why this does.
+test("recent leaves producer ordering to the Database and isolates duplicate identities", () => {
   const older = recentRow({
     id: "PALOMAR-2026-07-29-000124",
     path: "entries/PALOMAR-2026-07-29-000124-v1.json",
     published_at: "2026-07-01T00:00:00Z",
   });
   const newer = recentRow({ published_at: "2026-08-01T00:00:00Z" });
-  assert.throws(() => validateRecent(recent([older, newer])), /newest-first/);
+  assert.deepEqual(validateRecent(recent([older, newer])).entries, [older, newer]);
   assert.equal(validateRecent(recent([newer, older])).entries.length, 2);
-  assert.throws(
-    () => validateRecent(recent([recentRow(), recentRow({ version: 2, path: "entries/PALOMAR-2026-07-29-000123-v2.json" })])),
-    /more than once/,
-  );
+  const duplicates = validateRecent(recent([
+    recentRow(),
+    recentRow({ version: 2, path: "entries/PALOMAR-2026-07-29-000123-v2.json" }),
+  ]));
+  assert.deepEqual(duplicates.entries, []);
+  assert.equal(recentValidationIssues(duplicates).omitted, 2);
 });
 
-test("recent breaks equal publication timestamps by descending identifier", () => {
+test("recent accepts either producer order for equal publication timestamps", () => {
   const lower = recentRow();
   const higher = recentRow({
     id: "PALOMAR-2026-07-29-000124",
     path: "entries/PALOMAR-2026-07-29-000124-v1.json",
   });
   assert.deepEqual(validateRecent(recent([higher, lower])).entries, [higher, lower]);
-  assert.throws(() => validateRecent(recent([lower, higher])), /newest-first/);
+  assert.deepEqual(validateRecent(recent([lower, higher])).entries, [lower, higher]);
 });
 
-test("recent is bounded, because the document it replaced was the registry", () => {
+test("recent bounds presentation without rejecting its usable prefix", () => {
   // A reader that accepted an unbounded page would let the whole-registry
   // document come back under another name with nothing failing to say so.
   const page = recent(
@@ -427,7 +429,10 @@ test("recent is bounded, because the document it replaced was the registry", () 
       });
     }),
   );
-  assert.throws(() => validateRecent(page), /more rows than it may/);
+  const validated = validateRecent(page);
+  assert.equal(validated.entries.length, 200);
+  assert.equal(recentValidationIssues(validated).omitted, 1);
+  assert.match(recentValidationIssues(validated).details[0].reason, /presentation limit/);
 });
 
 test("exact tombstones are closed, date-only, and bound to their URL", () => {
@@ -478,6 +483,19 @@ test("active-content and insecure data-derived links are never allowed", () => {
 
 test("a canonical registered record validates", () => {
   assert.equal(validateEntry(entry(), summary()).id, "PALOMAR-2026-07-29-000123");
+});
+
+test("entry classification policy is not duplicated in the browser", () => {
+  const record = entry();
+  record.classification.arxiv = [
+    "math.CO", "math.NT", "cs.DM", "math.AG", "math.AT",
+    "math.CA", "math.CT", "math.LO", "math.MG", "math.CO",
+  ];
+  record.classification.msc2020 = [];
+  assert.equal(validateEntry(record, summary()), record);
+
+  record.classification.arxiv.push("not a subject code");
+  assert.throws(() => validateEntry(record, summary()), /malformed code/);
 });
 
 test("registered records require authors and bounded source identifiers", () => {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -257,42 +257,38 @@ test("landing cards preserve the publisher's newest-first order", async ({ page 
   ]);
 });
 
-test("old, partial, and malformed recent summaries fail closed before rendering", async ({ page }) => {
-  let variant = "old";
-  const entryRequests = [];
-  page.on("request", (request) => {
-    const path = new URL(request.url()).pathname;
-    if (path.startsWith("/database/entries/")) entryRequests.push(path);
-  });
+test("an unusable recent row is omitted without hiding its valid siblings", async ({ page }) => {
   await page.route("**/database/recent.json", async (route) => {
     const response = await route.fetch();
     const document = await response.json();
-    if (variant === "old") {
-      document.entries = document.entries.map((row) => ({
-        id: row.id,
-        version: row.version,
-        title: row.title,
-        status: row.status,
-        path: row.path,
-        published_at: row.published_at,
-        versions: row.versions,
-      }));
-    } else if (variant === "partial") {
-      delete document.entries[0].abstract;
-    } else {
-      document.entries[0].preservation.repositories[0].commit = "2".repeat(40);
-    }
+    document.entries[0].preservation.repositories[0].commit = "2".repeat(40);
     await route.fulfill({ response, json: document });
   });
 
-  for (const selected of ["old", "partial", "malformed"]) {
-    variant = selected;
-    await page.goto(`/?database=${database}&contract-case=${selected}`);
-    await expect(page.locator("#entry-grid .entry-card")).toHaveCount(0);
-    await expect(page.locator("#status")).toHaveClass(/error/);
-    await expect(page.locator("#status")).toContainText("The registry could not be loaded");
-  }
-  expect(entryRequests).toEqual([]);
+  await page.goto(`/?database=${database}`);
+  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(1);
+  await expect(page.locator("#registry-warning")).toBeVisible();
+  await expect(page.locator("#registry-warning")).toHaveText(
+    "1 registry entry could not be displayed.",
+  );
+  await expect(page.locator("#status")).not.toHaveClass(/error/);
+  await page.locator("#arxiv-query").fill("math.NT");
+  await expect(page.locator("#registry-warning")).toBeVisible();
+});
+
+test("an entirely unusable recent projection is not reported as an empty registry", async ({ page }) => {
+  await page.route("**/database/recent.json", async (route) => {
+    const response = await route.fetch();
+    const document = await response.json();
+    for (const row of document.entries) row.status = "draft";
+    await route.fulfill({ response, json: document });
+  });
+
+  await page.goto(`/?database=${database}`);
+  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(0);
+  await expect(page.locator("#status")).toHaveClass(/warning/);
+  await expect(page.locator("#status")).toContainText("registry entries could not be displayed");
+  await expect(page.locator("#status")).not.toContainText("No entries have been registered");
 });
 
 test("an unavailable recent summary reports failure instead of emptiness", async ({ page }) => {
@@ -953,7 +949,7 @@ test("entry schema v1 fails closed before rendering", async ({ page }) => {
   await expect(page.locator("#status")).toContainText("unsupported entry schema_version 1");
 });
 
-test("a recent row without the required preservation mapping fails closed", async ({ page }) => {
+test("a recent row without the required preservation mapping is omitted", async ({ page }) => {
   await page.route("**/database/recent.json", async (route) => {
     const response = await route.fetch();
     const recent = await response.json();
@@ -962,9 +958,11 @@ test("a recent row without the required preservation mapping fails closed", asyn
   });
   await page.goto(`/?database=${database}`);
 
-  await expect(page.locator(".entry-card")).toHaveCount(0);
-  await expect(page.locator("#status")).toHaveClass(/error/);
-  await expect(page.locator("#status")).toContainText("preservation must be an object");
+  await expect(page.locator(".entry-card")).toHaveCount(1);
+  await expect(page.locator("#registry-warning")).toHaveText(
+    "1 registry entry could not be displayed.",
+  );
+  await expect(page.locator("#status")).not.toHaveClass(/error/);
 });
 
 test("a card says the original is unavailable exactly when the manifest says so", async ({ page }) => {

--- a/tests/source-preservation.test.mjs
+++ b/tests/source-preservation.test.mjs
@@ -9,7 +9,12 @@ import {
   sourceLocation,
   topSourceLocation,
 } from "../assets/source-preservation.mjs";
-import { validateAvailability, validateEntry, validateRecent } from "../assets/security.mjs";
+import {
+  recentValidationIssues,
+  validateAvailability,
+  validateEntry,
+  validateRecent,
+} from "../assets/security.mjs";
 import {
   COMMIT,
   availabilityEndpoint,
@@ -289,12 +294,11 @@ test("recent presentation also uses the mapping captured by validation", () => {
   assert.equal(topSourceLocation(record, null).archiveRepository, acceptedFork);
 });
 
-test("a rejected recent document leaves its earlier rows unusable", () => {
+test("duplicate recent identities leave every ambiguous row unusable", () => {
   const first = recentRow();
-  assert.throws(
-    () => validateRecent(recent([first, recentRow()])),
-    /more than once/,
-  );
+  const projection = validateRecent(recent([first, recentRow()]));
+  assert.deepEqual(projection.entries, []);
+  assert.equal(recentValidationIssues(projection).omitted, 2);
   assert.throws(
     () => topSourceLocation(first, null),
     /was not validated/,


### PR DESCRIPTION
## Summary
- keep browser classification validation limited to render/link safety while PalomarDatabase owns cardinality and uniqueness policy
- omit malformed `recent.json` rows independently and show a non-blocking omitted-entry count
- keep deployment health strict by rejecting any snapshot whose recent projection needs omissions

## Verification
- `npm test` (263 passed)
- `npm run test:browser` with the documented Nix Chromium environment (90 passed, 2 skipped)
- `node scripts/check-published.mjs --data https://data.palomar-registry.org` (52 active entry versions, 47 results, 149 classification codes)