### PR TITLE
Improve responsive page formatting

### DIFF
--- a/404.html
+++ b/404.html
@@ -18,7 +18,7 @@
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/assets/style.css">
   </head>
-  <body>
+  <body data-page="not-found">
     <main class="about">
       <p class="entry-id">404</p>
       <h1>That record isn’t here</h1>

--- a/assets/about.js
+++ b/assets/about.js
@@ -38,11 +38,67 @@ function announce(message) {
   announceClipboard(status, message);
 }
 
-for (const heading of document.querySelectorAll("main.about h2, main.about h3")) {
-  const target = anchorTarget(heading);
-  if (!target) continue;
+const headings = [...document.querySelectorAll("main.about h2, main.about h3")]
+  .map((heading) => ({
+    heading,
+    target: anchorTarget(heading),
+    label: heading.textContent.replace(/\s+/g, " ").trim(),
+    level: Number(heading.tagName.slice(1)),
+  }))
+  .filter(({ target }) => target);
 
-  const label = heading.textContent.replace(/\s+/g, " ").trim();
+function contentsLink({ target, label }) {
+  const link = document.createElement("a");
+  link.href = `#${encodeURIComponent(target)}`;
+  link.textContent = label;
+  return link;
+}
+
+function tableOfContents(entries) {
+  const details = document.createElement("details");
+  details.className = "page-toc";
+  const desktop = window.matchMedia("(min-width: 701px)");
+  details.open = desktop.matches;
+
+  const summary = document.createElement("summary");
+  summary.textContent = "On this page";
+  const navigation = document.createElement("nav");
+  navigation.setAttribute("aria-label", "On this page");
+  const list = document.createElement("ol");
+  let currentSection;
+
+  for (const entry of entries) {
+    const item = document.createElement("li");
+    item.append(contentsLink(entry));
+    if (entry.level === 2 || !currentSection) {
+      list.append(item);
+      currentSection = item;
+      continue;
+    }
+    let children = currentSection.querySelector(":scope > ol");
+    if (!children) {
+      children = document.createElement("ol");
+      currentSection.append(children);
+    }
+    children.append(item);
+  }
+
+  navigation.append(list);
+  details.append(summary, navigation);
+  details.addEventListener("click", (event) => {
+    if (!desktop.matches && event.target.closest?.("a[href^='#']")) details.open = false;
+  });
+  return details;
+}
+
+const main = document.querySelector("main.about");
+const firstSection = main?.querySelector(":scope > section[id]");
+if (main && firstSection && headings.length) {
+  main.insertBefore(tableOfContents(headings), firstSection);
+}
+
+for (const { heading, target, label } of headings) {
+
   const anchor = document.createElement("a");
   anchor.className = "heading-anchor";
   anchor.href = `#${encodeURIComponent(target)}`;
@@ -74,5 +130,15 @@ for (const heading of document.querySelectorAll("main.about h2, main.about h3"))
       anchor.title = "Copy link to this section";
       status.textContent = "";
     }, CLIPBOARD_RESET_DELAY_MS);
+  });
+}
+
+// The generated contents sits above every fragment target. Re-apply an initial
+// fragment after that insertion so a deep link cannot stop at the target's old
+// pre-enhancement position.
+if (window.location.hash) {
+  window.requestAnimationFrame(() => {
+    const fragment = decodeURIComponent(window.location.hash.slice(1));
+    document.getElementById(fragment)?.scrollIntoView();
   });
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -129,8 +129,17 @@ a:focus-visible {
 
 nav {
   display: flex;
+  align-items: center;
   gap: 1.2rem;
   font: .9rem/1.3 var(--sans);
+}
+
+nav a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
 }
 
 nav a.active {
@@ -231,7 +240,7 @@ h3 {
   flex: 1;
   min-width: 14rem;
   max-width: 34rem;
-  min-height: 2.1rem;
+  min-height: 2.75rem;
   padding: .3rem .45rem;
   border: 1px solid var(--field);
   border-radius: 0;
@@ -312,6 +321,19 @@ body.registry-searching #entry-grid {
   display: none;
 }
 
+body.registry-searching .hero-copy,
+body.registry-searching .metric-row {
+  display: none;
+}
+
+body.registry-searching .hero {
+  padding-block: 1.25rem;
+}
+
+body.registry-searching .registry-section {
+  padding-top: 1rem;
+}
+
 .category-filters input:focus-visible,
 button:focus-visible {
   outline: 2px solid var(--link);
@@ -344,7 +366,7 @@ button:focus-visible {
 }
 
 .category-filters input {
-  min-height: 2rem;
+  min-height: 2.75rem;
   width: 9rem;
   padding: .25rem .4rem;
   border: 1px solid var(--field);
@@ -368,7 +390,7 @@ button:focus-visible {
 
 .date-filters select,
 .date-filters input {
-  min-height: 2rem;
+  min-height: 2.75rem;
   padding: .25rem .4rem;
   border: 1px solid var(--field);
   border-radius: 0;
@@ -429,7 +451,8 @@ button:focus-visible {
 }
 
 .filter {
-  min-height: 2rem;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
   padding: .25rem .5rem;
   border: 1px solid var(--field);
   border-radius: 0;
@@ -504,11 +527,21 @@ button:focus-visible {
 
 .entry-card h3 {
   margin: .35rem 0 .25rem;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.entry-card h3 a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.75rem;
+  overflow-wrap: anywhere;
 }
 
 .card-abstract {
   max-width: 76ch;
   margin-bottom: .75rem;
+  overflow-wrap: anywhere;
 }
 
 .card-meta {
@@ -543,6 +576,13 @@ button:focus-visible {
   font-size: .85rem;
 }
 
+.card-footer a {
+  display: inline-flex;
+  align-items: center;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+}
+
 .repo-link {
   overflow-wrap: anywhere;
 }
@@ -565,13 +605,71 @@ footer {
 
 .footer-links {
   display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 1rem;
+  min-width: 0;
+}
+
+.footer-links a {
+  display: inline-flex;
+  align-items: center;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
 }
 
 .about,
 .faq {
   max-width: 52rem;
   padding: 2.5rem 0 4rem;
+}
+
+.page-toc {
+  margin-top: 1.75rem;
+  border-block: 1px solid var(--line);
+  font: .9rem/1.35 var(--sans);
+}
+
+.page-toc > summary {
+  display: flex;
+  align-items: center;
+  min-height: 2.75rem;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.page-toc > summary:focus-visible {
+  outline: 2px solid var(--link);
+  outline-offset: 2px;
+}
+
+.page-toc nav {
+  display: block;
+  font: inherit;
+}
+
+.page-toc ol {
+  margin: 0;
+  padding: 0 0 .75rem 1.35rem;
+}
+
+.page-toc ol ol {
+  padding-bottom: 0;
+}
+
+.page-toc a {
+  min-height: 2.75rem;
+}
+
+@media (min-width: 701px) {
+  .page-toc > nav > ol {
+    columns: 2;
+    column-gap: 2rem;
+  }
+
+  .page-toc > nav > ol > li {
+    break-inside: avoid;
+  }
 }
 
 /* The founding statement follows the restrained, document-like typography of
@@ -627,12 +725,17 @@ footer {
 }
 
 .faq .anchored-heading {
+  max-width: 100%;
   width: fit-content;
 }
 
 .heading-anchor {
   display: inline-flex;
-  margin-left: .4rem;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  margin: -.5rem -.7rem -.5rem .1rem;
   color: var(--muted);
   opacity: 0;
   text-decoration: none;
@@ -727,6 +830,13 @@ footer {
   border-top: 1px solid var(--line);
 }
 
+.cta > a {
+  display: inline-flex;
+  align-items: center;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+}
+
 .meaning-grid article + article {
   margin-top: 1.5rem;
   padding-top: 1.5rem;
@@ -767,6 +877,7 @@ footer {
 .entry-heading h1 {
   margin-top: .5rem;
   font-size: 2rem;
+  overflow-wrap: anywhere;
 }
 
 .version-notice {
@@ -843,6 +954,8 @@ footer {
 }
 
 .citation-copy {
+  min-width: 2.75rem;
+  min-height: 2.75rem;
   padding: .4rem .65rem;
   border: 1px solid var(--line);
   background: var(--paper);
@@ -874,6 +987,10 @@ footer {
   border-top: 1px solid var(--line);
 }
 
+.entry-page summary {
+  min-height: 2.75rem;
+}
+
 /* Dense sections open on demand. The section heading is the summary, so the
    collapsed page reads as a list of section titles and the disclosure marker
    is the affordance; the verification table's toggle is the small text below
@@ -887,6 +1004,7 @@ footer {
      to a line of its own above the section title. Drawing it here keeps the
      affordance beside the words it opens. */
   list-style: none;
+  min-height: 2.75rem;
 }
 
 .section-collapse > summary::-webkit-details-marker {
@@ -928,6 +1046,16 @@ footer {
   font: .9rem/1.4 var(--sans);
 }
 
+.challenge-links a,
+.data-link,
+.standalone-action,
+body[data-page="not-found"] main a {
+  display: inline-flex;
+  align-items: center;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+}
+
 .challenge-metadata {
   margin-bottom: .75rem;
   padding: .75rem;
@@ -942,6 +1070,11 @@ footer {
   margin-top: .45rem;
 }
 
+.challenge-metadata-row .token-list {
+  flex: 1;
+  min-width: 0;
+}
+
 .challenge-module-doc {
   margin-top: .7rem;
   border-top: 1px dotted var(--line);
@@ -951,6 +1084,7 @@ footer {
 .challenge-module-doc summary {
   cursor: pointer;
   font-weight: bold;
+  min-height: 2.75rem;
 }
 
 .challenge-module-doc pre {
@@ -995,6 +1129,8 @@ footer {
   background: var(--paper);
   box-shadow: 0 1px 4px rgb(0 0 0 / 25%);
   color: var(--ink);
+  min-width: 2.75rem;
+  min-height: 2.75rem;
   font: bold .75rem/1.2 var(--sans);
   opacity: 0;
   pointer-events: none;
@@ -1117,6 +1253,7 @@ footer {
 .solution-dependencies summary {
   cursor: pointer;
   font-weight: bold;
+  min-height: 2.75rem;
 }
 
 .dependency-list {
@@ -1189,14 +1326,17 @@ pre {
   display: flex;
   flex-wrap: wrap;
   gap: .35rem;
+  min-width: 0;
 }
 
 .statement-import-line code,
 .token-list code {
+  max-width: 100%;
   padding: .15rem .3rem;
   border: 1px solid var(--token-line);
   background: var(--shade);
   font-size: .8rem;
+  overflow-wrap: anywhere;
 }
 
 .plain-list,
@@ -1278,6 +1418,10 @@ pre {
     flex-wrap: wrap;
   }
 
+  .footer-links {
+    justify-content: flex-start;
+  }
+
   .toolbar {
     width: 100%;
   }
@@ -1305,6 +1449,12 @@ pre {
   .detail-row {
     grid-template-columns: 1fr;
     gap: .15rem;
+  }
+
+  .challenge-metadata-row {
+    align-items: stretch;
+    flex-direction: column;
+    gap: .35rem;
   }
 
   .dependency-list {
@@ -1420,6 +1570,15 @@ pre {
 .subject-row h2 {
   margin: .35rem 0 .25rem;
   font-size: 1.15rem;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.subject-row h2 a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.75rem;
+  overflow-wrap: anywhere;
 }
 
 /* One line rather than the card's stacked label, because a subject row has
@@ -1444,7 +1603,8 @@ pre {
 }
 
 #subject-more {
-  min-height: 2rem;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
   padding: .35rem .7rem;
   border: 1px solid var(--field);
   border-radius: 0;
@@ -1467,6 +1627,13 @@ pre {
    a button and nothing else. */
 #subject-more-status:empty {
   display: none;
+}
+
+body[data-page="not-found"] {
+  display: grid;
+  grid-template-rows: 1fr auto;
+  min-height: 100vh;
+  min-height: 100dvh;
 }
 
 .exact-tombstone {

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -45,6 +45,29 @@ async function runSearch(page, query) {
   await expect(page.locator("#search-spinner")).toBeHidden();
 }
 
+async function expectNoHorizontalOverflow(page, label) {
+  await expect.poll(
+    () => page.evaluate(() =>
+      document.documentElement.scrollWidth - document.documentElement.clientWidth),
+    { message: `${label} should not widen the page` },
+  ).toBe(0);
+}
+
+async function expectMinimumTargets(locator, label) {
+  const undersized = await locator.evaluateAll((nodes) => nodes.flatMap((node) => {
+    const box = node.getBoundingClientRect();
+    if (!box.width || !box.height || getComputedStyle(node).visibility === "hidden") return [];
+    if (box.width >= 43.5 && box.height >= 43.5) return [];
+    return [{
+      element: `${node.tagName.toLowerCase()}${node.className ? `.${String(node.className).trim().replace(/\s+/g, ".")}` : ""}`,
+      text: (node.getAttribute("aria-label") || node.textContent || "").trim().slice(0, 80),
+      width: box.width,
+      height: box.height,
+    }];
+  }));
+  expect(undersized, label).toEqual([]);
+}
+
 /**
  * Which entry schema the previous deployment's validator would accept.
  *
@@ -140,6 +163,147 @@ test("submission-guide headings expose hoverable links that copy their section U
   );
 });
 
+test("long reference pages expose an adaptive table of contents", async ({ page }) => {
+  await page.setViewportSize({ width: 1000, height: 800 });
+  for (const path of ["/about", "/how-to-submit", "/privacy"]) {
+    await page.goto(path);
+    const toc = page.locator(".page-toc");
+    await expect(toc).toBeVisible();
+    await expect(toc).toHaveAttribute("open", "");
+    await expect(toc.locator("nav")).toHaveAttribute("aria-label", "On this page");
+    await expect(toc.locator("nav a")).toHaveCount(
+      await page.locator("main.about h2, main.about h3").count(),
+    );
+  }
+  await expect(page.locator(".page-toc ol ol a")).toHaveCount(0);
+
+  await page.goto("/how-to-submit");
+  expect(await page.locator(".page-toc ol ol a").count()).toBeGreaterThan(0);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/about");
+  const toc = page.locator(".page-toc");
+  await expect(toc).not.toHaveAttribute("open", "");
+  await toc.locator("summary").click();
+  await expect(toc).toHaveAttribute("open", "");
+  await toc.locator('a[href="#why-now"]').click();
+  await expect(toc).not.toHaveAttribute("open", "");
+  await expect(page).toHaveURL(/\/about#why-now$/);
+  await expect(page.locator("#why-now")).toBeInViewport();
+
+  await page.goto("/privacy#how-long");
+  await expect(page.locator("#how-long")).toBeInViewport();
+  await page.goto("/statement");
+  await expect(page.locator(".page-toc")).toHaveCount(0);
+});
+
+test("search mode removes unresolved hero furniture and restores it on clear", async ({ page }) => {
+  await page.goto(`/?database=${database}&q=synthetically`);
+  await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
+  await expect(page.locator("body")).toHaveClass(/registry-searching/);
+  await expect(page.locator(".hero-copy")).toBeHidden();
+  await expect(page.locator(".metric-row")).toBeHidden();
+  await expect(page.locator(".hero")).toHaveCSS("padding-top", "20px");
+  await expect(page.locator(".registry-section")).toHaveCSS("padding-top", "16px");
+
+  await runSearch(page, "");
+  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
+  await expect(page.locator("body")).not.toHaveClass(/registry-searching/);
+  await expect(page.locator(".hero-copy")).toBeVisible();
+  await expect(page.locator(".metric-row")).toBeVisible();
+  await expect(page.locator("#metric-results")).toHaveText("2");
+  await expect(page.locator("#metric-projects")).toHaveText("1");
+});
+
+test("user-facing pages do not overflow narrow mobile viewports", async ({ page }) => {
+  await page.route("**/database/recent.json", async (route) => {
+    const response = await route.fetch();
+    const recent = await response.json();
+    recent.entries[0].title =
+      "example/AnIntentionallyLongUnbrokenRepositoryNameThatMustWrapInsideTheRegistryCard";
+    recent.entries[0].abstract +=
+      " AnIntentionallyLongGeneratedDeclarationNameThatMirrorsProductionFormalizationTextWithoutChangingItsLength.";
+    await route.fulfill({ response, json: recent });
+  });
+
+  const surfaces = [
+    { name: "registry", path: `/?database=${database}`, ready: ".entry-card" },
+    { name: "search", path: `/?database=${database}&q=synthetically`, ready: "#search-results .entry-card" },
+    {
+      name: "entry",
+      path: `/entry?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`,
+      ready: ".entry-heading",
+    },
+    {
+      name: "render",
+      path: `/render?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`,
+      ready: "#render-content:not([hidden])",
+    },
+    {
+      name: "subject",
+      path: `/subject?kind=arxiv&code=math.AG&database=${database}`,
+      ready: ".subject-row",
+    },
+    { name: "statement", path: "/statement", ready: "main" },
+    { name: "about", path: "/about", ready: ".page-toc" },
+    { name: "how to submit", path: "/how-to-submit", ready: ".page-toc" },
+    { name: "privacy", path: "/privacy", ready: ".page-toc" },
+    { name: "404", path: "/404.html", ready: "main" },
+  ];
+
+  for (const width of [320, 390]) {
+    await page.setViewportSize({ width, height: 844 });
+    for (const surface of surfaces) {
+      await page.goto(surface.path);
+      await page.locator(surface.ready).first().waitFor({ state: "visible" });
+      await expectNoHorizontalOverflow(page, `${surface.name} at ${width}px`);
+    }
+  }
+});
+
+test("navigation and action controls expose mobile-sized targets", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto(`/?database=${database}`);
+  await expect(page.locator(".entry-card")).toHaveCount(2);
+  await expectMinimumTargets(
+    page.locator(
+      "header nav a, .registry-search input, .filter, .category-filters input, " +
+      ".date-filters select, .date-filters input, .card-footer a, footer .footer-links a",
+    ),
+    "registry controls should have 44px targets",
+  );
+
+  await page.goto("/about");
+  await page.locator(".page-toc > summary").click();
+  await expectMinimumTargets(
+    page.locator("header nav a, .page-toc > summary, .page-toc a, .heading-anchor, .cta > a, footer a"),
+    "reference-page navigation should have 44px targets",
+  );
+
+  await page.goto(`/entry?id=PALOMAR-2026-07-29-000123&version=1&database=${database}`);
+  await expect(page.locator(".entry-heading")).toBeVisible();
+  await expectMinimumTargets(
+    page.locator(
+      "header nav a, main summary, .challenge-links a, .challenge-playground-button, " +
+      ".citation-copy, footer a",
+    ),
+    "entry controls should have 44px targets",
+  );
+});
+
+test("the not-found footer stays at the viewport bottom", async ({ page }) => {
+  for (const viewport of [
+    { width: 1440, height: 1000 },
+    { width: 390, height: 844 },
+  ]) {
+    await page.setViewportSize(viewport);
+    await page.goto("/404.html");
+    await expect.poll(() => page.locator("footer").evaluate((footer) =>
+      Math.round(window.innerHeight - footer.getBoundingClientRect().bottom))).toBe(0);
+    await expectNoHorizontalOverflow(page, `404 at ${viewport.width}px`);
+  }
+});
+
 test("every formalization.yaml mention in the submission guide links to its standard", async ({ page }) => {
   await page.goto("/how-to-submit");
   const standard = "https://github.com/mathlib-initiative/formalization.yaml";
@@ -148,6 +312,7 @@ test("every formalization.yaml mention in the submission guide links to its stan
     const unlinked = [];
     let mentions = 0;
     for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+      if (node.parentElement.closest(".page-toc")) continue;
       const count = node.textContent.split("formalization.yaml").length - 1;
       mentions += count;
       if (count && node.parentElement.closest("a")?.href !== expected) {


### PR DESCRIPTION
## Summary

- prevent horizontal overflow from long titles, declarations, tokens, and production abstracts without truncating content
- enlarge navigation and action targets and improve narrow-screen stacking
- compact the registry hero while searching
- add adaptive tables of contents to long reference pages
- keep the 404 footer at the bottom of short viewports
- cover the changes with mobile and desktop Playwright tests

## Verification

- `npm test` (268 passed)
- `npx playwright test` with system Chromium (95 passed, 2 skipped)
- live production-data smoke check at 390px: registry and search both report zero horizontal overflow