### PR TITLE
Display checked ORCID records

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -124,6 +124,37 @@ function authorNames(entry) {
   return entry.authors.map((author) => author.name).join(", ");
 }
 
+function personPresentation(person) {
+  const content = el("span", "person");
+  content.append(el("span", "person-name", person.name));
+  if (person.orcid) {
+    const link = externalLink(
+      `ORCID ${person.orcid}`,
+      `https://orcid.org/${person.orcid}`,
+      "orcid-id",
+    );
+    link.setAttribute("aria-label", `Open the ORCID record ${person.orcid} for ${person.name}`);
+    content.append(" · ", link);
+    if (person.orcid_record_checked_at) {
+      const checked = el("span", "orcid-record-checked", "✓ ORCID record checked");
+      checked.title =
+        `Palomar found this identifier in the ORCID Registry on ${displayTimestamp(
+          person.orcid_record_checked_at,
+        )}. This checks the record exists; it does not authenticate the person or prove authorship.`;
+      content.append(" ", checked);
+    }
+  }
+  return content;
+}
+
+function appendPeople(target, people) {
+  people.forEach((person, position) => {
+    if (position) target.append(", ");
+    target.append(personPresentation(person));
+  });
+  return target;
+}
+
 function theoremNames(entry) {
   return entry.formalization.theorem_names.join(", ");
 }
@@ -1012,6 +1043,12 @@ function detailRow(label, value) {
   return row;
 }
 
+function peopleDetailRow(label, people) {
+  const row = el("div", "detail-row");
+  row.append(el("dt", "", label), appendPeople(el("dd"), people));
+  return row;
+}
+
 /**
  * A note beside a value, for facts that matter but do not deserve a row.
  *
@@ -1296,9 +1333,9 @@ function provenanceSection(entry, sourceAvailability) {
   details.append(
     detailRow("Result origin", RESULT_ORIGIN_LABELS[provenance.result_origin]),
     detailRow("Repository role", REPOSITORY_ROLE_LABELS[provenance.repository_role]),
-    detailRow(
+    peopleDetailRow(
       "Responsible maintainers",
-      provenance.responsible_maintainers.map((person) => person.name).join(", "),
+      provenance.responsible_maintainers,
     ),
     detailRow(
       "Submission basis",
@@ -1321,7 +1358,14 @@ function provenanceSection(entry, sourceAvailability) {
       const label = source.authors.length
         ? `${source.authors.map((author) => author.name).join(", ")}: ${source.title}`
         : source.title;
-      item.append(el("span", "source-citation", label));
+      const citation = el("span", "source-citation");
+      if (source.authors.length) {
+        appendPeople(citation, source.authors);
+        citation.append(`: ${source.title}`);
+      } else {
+        citation.append(source.title);
+      }
+      item.append(citation);
       const identifier = mathematicalSourceIdentifier(source.identifier, label);
       if (identifier) item.append(" · ", identifier);
       if (source.contributors?.length) {
@@ -1379,7 +1423,8 @@ async function renderEntry(
   heading.append(top, el("h1", "", entry.title));
   const abstract = presentationAbstract(entry);
   if (abstract) heading.append(el("p", "lede", abstract));
-  const byline = el("p", "byline", `By ${authorNames(entry)}`);
+  const byline = el("p", "byline", "By ");
+  appendPeople(byline, entry.authors);
   heading.append(byline);
 
   const evidence = el("section", "entry-evidence");

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -63,7 +63,8 @@ const ARXIV_RE = /^[a-z]+(?:-[a-z]+)*(?:\.[A-Za-z-]+)?$/;
 const MSC2020_RE = /^[0-9]{2}(?:[A-Z][0-9]{2}|-[0-9]{2})$/;
 const LICENSE_PATH_RE = /^(?:licen[cs]e|copying|unlicense|ofl)(?:\.(?:md|markdown|txt))?$/i;
 const TIMESTAMP_RE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/;
-const ORCID_RE = /^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$/;
+const LEGACY_ORCID_RE = /^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9X]{4}$/;
+const CHECKED_ORCID_RE = /^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$/;
 export const AVAILABILITY_MAX_AGE_MS = 18 * 60 * 60 * 1000;
 export const AVAILABILITY_MAX_CLOCK_SKEW_MS = 5 * 60 * 1000;
 
@@ -185,7 +186,8 @@ function validatePerson(value, field) {
   }
   if (hasOrcid) {
     const identifier = string(person.orcid, `${field}.orcid`);
-    if (!ORCID_RE.test(identifier) || !validOrcidChecksum(identifier)) {
+    if (!LEGACY_ORCID_RE.test(identifier) ||
+        (hasCheck && (!CHECKED_ORCID_RE.test(identifier) || !validOrcidChecksum(identifier)))) {
       fail(`${field}.orcid is malformed`);
     }
   }

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -63,6 +63,7 @@ const ARXIV_RE = /^[a-z]+(?:-[a-z]+)*(?:\.[A-Za-z-]+)?$/;
 const MSC2020_RE = /^[0-9]{2}(?:[A-Z][0-9]{2}|-[0-9]{2})$/;
 const LICENSE_PATH_RE = /^(?:licen[cs]e|copying|unlicense|ofl)(?:\.(?:md|markdown|txt))?$/i;
 const TIMESTAMP_RE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/;
+const ORCID_RE = /^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$/;
 export const AVAILABILITY_MAX_AGE_MS = 18 * 60 * 60 * 1000;
 export const AVAILABILITY_MAX_CLOCK_SKEW_MS = 5 * 60 * 1000;
 
@@ -163,6 +164,35 @@ function instant(value, field) {
     fail(`${field} is malformed`);
   }
   return text;
+}
+
+function validOrcidChecksum(identifier) {
+  const compact = identifier.replaceAll("-", "");
+  if (compact.length !== 16 || !/^[0-9]{15}[0-9X]$/.test(compact)) return false;
+  let total = 0;
+  for (const character of compact.slice(0, 15)) total = (total + Number(character)) * 2;
+  const result = (12 - (total % 11)) % 11;
+  return compact.at(-1) === (result === 10 ? "X" : String(result));
+}
+
+function validatePerson(value, field) {
+  const person = object(value, field);
+  string(person.name, `${field}.name`);
+  const hasOrcid = Object.hasOwn(person, "orcid");
+  const hasCheck = Object.hasOwn(person, "orcid_record_checked_at");
+  if (hasCheck && !hasOrcid) {
+    fail(`${field} carries an ORCID record check without an ORCID iD`);
+  }
+  if (hasOrcid) {
+    const identifier = string(person.orcid, `${field}.orcid`);
+    if (!ORCID_RE.test(identifier) || !validOrcidChecksum(identifier)) {
+      fail(`${field}.orcid is malformed`);
+    }
+  }
+  if (hasCheck) {
+    instant(person.orcid_record_checked_at, `${field}.orcid_record_checked_at`);
+  }
+  return person;
 }
 
 function stringArray(value, field) {
@@ -1394,7 +1424,7 @@ export function validateEntry(entry, summary) {
   const entryAuthors = array(entry.authors, "entry.authors");
   if (!entryAuthors.length) fail("entry.authors must not be empty");
   for (const [position, value] of entryAuthors.entries()) {
-    string(object(value, `entry.authors[${position}]`).name, `entry.authors[${position}].name`);
+    validatePerson(value, `entry.authors[${position}]`);
   }
 
   validateClassification(entry.classification, "entry.classification");
@@ -1433,9 +1463,9 @@ export function validateEntry(entry, summary) {
       fail("entry.provenance.responsible_maintainers must not be empty");
     }
     for (const [position, maintainer] of maintainers.entries()) {
-      string(
-        object(maintainer, `entry.provenance.responsible_maintainers[${position}]`).name,
-        `entry.provenance.responsible_maintainers[${position}].name`,
+      validatePerson(
+        maintainer,
+        `entry.provenance.responsible_maintainers[${position}]`,
       );
     }
     const substantiveRelationships = new Set(["formalizes", "adapts", "independently-proves"]);
@@ -1443,7 +1473,15 @@ export function validateEntry(entry, summary) {
     for (const [position, sourceRecord] of sources.entries()) {
       const item = object(sourceRecord, `entry.provenance.mathematical_sources[${position}]`);
       string(item.title, `entry.provenance.mathematical_sources[${position}].title`);
-      array(item.authors, `entry.provenance.mathematical_sources[${position}].authors`);
+      for (const [authorPosition, author] of array(
+        item.authors,
+        `entry.provenance.mathematical_sources[${position}].authors`,
+      ).entries()) {
+        validatePerson(
+          author,
+          `entry.provenance.mathematical_sources[${position}].authors[${authorPosition}]`,
+        );
+      }
       if (item.identifier !== undefined) {
         boundedString(
           item.identifier,

--- a/assets/style.css
+++ b/assets/style.css
@@ -947,6 +947,24 @@ footer {
   font-style: italic;
 }
 
+.orcid-id,
+.orcid-record-checked {
+  font: .72rem/1.3 var(--sans);
+  font-style: normal;
+}
+
+.orcid-id {
+  white-space: nowrap;
+}
+
+.orcid-record-checked {
+  display: inline-block;
+  padding: .05rem .3rem;
+  border: 1px solid var(--success-line);
+  color: var(--success);
+  white-space: nowrap;
+}
+
 .citation-intro {
   margin: 0 0 .65rem;
   color: var(--muted);

--- a/how-to-submit.html
+++ b/how-to-submit.html
@@ -196,6 +196,16 @@
           source and displays them on the registry entry.
         </p>
         <p>
+          ORCID iDs are optional. Put them in the person's structured
+          <code>orcid</code> field, not in the name. If you include one for a
+          project author, responsible maintainer, or source author, mechanical
+          verification checks that the iD has a valid check digit and names a
+          current record in the ORCID Registry. A registered entry links the iD
+          and shows when Palomar made that check. This is a record-existence
+          check only: it does not authenticate the submitter, establish control
+          of the ORCID record, or prove authorship.
+        </p>
+        <p>
           Submit only if you are a responsible author or maintainer of the
           substantive formalization, or have approval from one. For a thin
           wrapper this means the people responsible for the underlying

--- a/privacy.html
+++ b/privacy.html
@@ -184,6 +184,15 @@
           honest, and the history comes with it.
         </p>
         <p>
+          <strong>How ORCID iDs are checked.</strong> If the repository metadata
+          declares an ORCID iD, mechanical verification sends that public iD to
+          the public ORCID Registry and checks that the same current record is
+          returned. Palomar discards the returned profile and records only the
+          declared iD and the time of the check. The public entry displays that
+          evidence as a record-existence check; it is not authentication of the
+          person, proof that anyone controls the record, or proof of authorship.
+        </p>
+        <p>
           <strong>How you are told.</strong> Not individually. Palomar does not
           write to the people a record names, and for the authors of a cited
           paper it usually has no way to. This page is the notice instead: it
@@ -364,8 +373,10 @@
           supported, handles and ORCIDs; the account that owns the repository;
           and the name and email address in every commit of the preserved fork. The
           declared part really is what a paper or a bibliography carries about
-          the same people, from a public repository, and Palomar does not
-          enrich, index, profile or contact anyone from it. The commit history
+          the same people, from a public repository. Apart from resolving each
+          declared ORCID iD to confirm that its current record exists, Palomar
+          does not enrich, index, profile or contact anyone from it. The ORCID
+          profile response is discarded. The commit history
           is not: nobody puts an email address in a commit in order to be
           catalogued by a registry. It is there because a preserved fork carries
           the history it has, and preserving the exact source is what makes the

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -47,7 +47,11 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
         "status": "registered",
         "title": f"Fixture {identifier} version {version}",
         "abstract": "A browser confinement fixture for the registry, about the quasicoherent behaviour of a synthetic result.",
-        "authors": [{"name": "Example"}],
+        "authors": [{
+            "name": "Example",
+            "orcid": "0000-0002-1825-0097",
+            "orcid_record_checked_at": "2026-08-31T12:00:00Z",
+        }],
         "classification": classification,
         "provenance": {
             "result_origin": "original",

--- a/tests/registry-fixture.mjs
+++ b/tests/registry-fixture.mjs
@@ -122,7 +122,11 @@ export function entry(overrides = {}) {
     status: "registered",
     title: "Fixture theorem",
     abstract: "A security fixture.",
-    authors: [{ name: "Example" }],
+    authors: [{
+      name: "Example",
+      orcid: "0000-0002-1825-0097",
+      orcid_record_checked_at: "2026-08-31T12:00:00Z",
+    }],
     classification: { arxiv: ["math.CO"], msc2020: ["05C10"] },
     submission: {
       submission_id: "a1b2c3d4e5f6",

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -528,6 +528,26 @@ test("registered records require authors and bounded source identifiers", () => 
   );
 });
 
+test("registered people validate ORCID identifiers and optional check evidence", () => {
+  const checked = entry();
+  assert.equal(validateEntry(checked, summary()), checked);
+
+  const legacy = entry();
+  delete legacy.authors[0].orcid_record_checked_at;
+  assert.equal(validateEntry(legacy, summary()), legacy);
+
+  const malformed = entry();
+  malformed.authors[0].orcid = "0000-0002-1825-0098";
+  assert.throws(() => validateEntry(malformed, summary()), /authors\[0\]\.orcid is malformed/);
+
+  const unpaired = entry();
+  delete unpaired.authors[0].orcid;
+  assert.throws(
+    () => validateEntry(unpaired, summary()),
+    /record check without an ORCID iD/,
+  );
+});
+
 test("preservation must cover every immutable source", () => {
   const missing = entry();
   missing.preservation.repositories.pop();

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -534,6 +534,7 @@ test("registered people validate ORCID identifiers and optional check evidence",
 
   const legacy = entry();
   delete legacy.authors[0].orcid_record_checked_at;
+  legacy.authors[0].orcid = "0000-0000-0000-000X";
   assert.equal(validateEntry(legacy, summary()), legacy);
 
   const malformed = entry();

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -824,6 +824,18 @@ test("a thin wrapper says where the mathematics is before anything else", async 
     .toHaveAttribute("href", `https://github.com/${repository}/tree/${commit}`);
 });
 
+test("a checked ORCID record is linked and labelled without claiming identity", async ({ page }) => {
+  await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}`);
+
+  const link = page.getByRole("link", {
+    name: "Open the ORCID record 0000-0002-1825-0097 for Example",
+  }).first();
+  await expect(link).toHaveAttribute("href", "https://orcid.org/0000-0002-1825-0097");
+  const checked = page.locator(".byline .orcid-record-checked");
+  await expect(checked).toHaveText("✓ ORCID record checked");
+  await expect(checked).toHaveAttribute("title", /does not authenticate the person or prove authorship/);
+});
+
 test("mathematical sources format known identifiers and preserve unknown ones", async ({ page }) => {
   await page.route(
     "**/database/entries/PALOMAR-2026-07-29-000123-v2.json",


### PR DESCRIPTION
## Summary

- link structured ORCID iDs for authors, maintainers, and source authors
- show a checked-record badge only when registry-check evidence exists
- explain explicitly that the check is not person authentication or proof of authorship
- document ORCID processing and validate identifiers at the browser trust boundary

Closes #135.

## Validation

- 269 unit tests passed
- 91 browser tests passed, 2 skipped