### PR TITLE
Add public operating cost page

### DIFF
--- a/costs.html
+++ b/costs.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Palomar's automatically refreshed annual operating cost run rate.">
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#101216" media="(prefers-color-scheme: dark)">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://data.palomar-registry.org; frame-src 'self' https://data.palomar-registry.org; manifest-src 'self'; base-uri 'none'; form-action 'none'; object-src 'none'">
+    <title>Operating costs — Palomar</title>
+    <link rel="canonical" href="https://palomar-registry.org/costs">
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <link rel="stylesheet" href="assets/style.css">
+  </head>
+  <body data-page="costs">
+    <a class="skip-link" href="#content">Skip to content</a>
+    <header class="site-header">
+      <a class="brand" href="./">Palomar</a>
+      <nav aria-label="Main navigation">
+        <a href="./">Registry</a>
+        <a href="/statement">Statement</a>
+        <a href="/about">About</a>
+        <a href="/how-to-submit">How to submit</a>
+      </nav>
+    </header>
+
+    <main id="content" class="about faq">
+      <h1>Operating cost run rate</h1>
+      <p class="subtitle">Automatically refreshed from live workload and provider billing</p>
+
+      <section id="annual-estimate">
+        <h2>$8,352.07 per year</h2>
+        <p>
+          The current incurred-cost forecast is
+          <strong>$696.01 per month</strong>.
+          It is a forward run rate at current submission volumes, not a statement
+          of cash paid or prepaid credits purchased.
+        </p>
+        <ul>
+          <li><strong>OpenAI:</strong> $7,248.19 per year</li>
+          <li><strong>GitHub Actions:</strong> $1,019.87 per year</li>
+          <li><strong>Cloudflare:</strong> $61.00 per year in projected usage charges</li>
+          <li><strong>Domains:</strong> $23.00 per year</li>
+        </ul>
+          <p>If an unconfirmed $5/month Workers plan is active, the total would be <strong>$8,412.07 per year</strong>.</p>
+      </section>
+
+      <section id="live-volume">
+        <h2>Live workload</h2>
+        <p>
+          The forecast annualizes the observed rate to
+          <strong>7,680 submissions</strong>,
+          3,957 completed reviews, and
+          1,986 registrations per year.
+        </p>
+      </section>
+
+      <section id="reconciliation">
+        <h2>Independent billing check</h2>
+        <p>
+          Retained conversation logs reprice to
+          <strong>$500.06</strong>, compared with
+          <strong>$538.49</strong> of OpenAI billed
+          model cost over the same complete-day window. The resulting
+          reconciliation coverage is <strong>92.9%</strong>.
+          Palomar refuses to publish a refreshed estimate if this falls below 90%.
+        </p>
+      </section>
+
+      <section id="freshness">
+        <h2>Freshness and method</h2>
+        <p>
+          This passing report was generated at
+          <time datetime="2026-08-31T05:58:33.298960Z">2026-08-31T05:58:33.298960Z</time> from the window
+          <time datetime="2026-08-06T00:00:00Z">2026-08-06T00:00:00Z</time> through, but excluding,
+          <time datetime="2026-08-31T00:00:00Z">2026-08-31T00:00:00Z</time>
+          (25.0 complete days).
+        </p>
+        <p>
+          Submission and conversation-token rates come from Palomar's retained
+          operational records. OpenAI, GitHub, and Cloudflare amounts come from
+          their live billing or analytics APIs. This public page contains only
+          the aggregate result; it contains no submissions, identities, API keys,
+          project identifiers, or private provider responses.
+        </p>
+      </section>
+    </main>
+
+    <footer>
+      <div><span class="footer-brand">Palomar</span><span> — a registry of Lean-verified results</span></div>
+      <div class="footer-links"><a href="https://github.com/PalomarRegistry/PalomarPolicy">Policy</a><a href="/privacy">Privacy</a><a href="/llms.txt">llms.txt</a><a href="https://data.palomar-registry.org/recent.json">Data</a><a href="https://github.com/PalomarRegistry/PalomarWeb">Source</a></div>
+    </footer>
+  </body>
+</html>

--- a/llms.txt
+++ b/llms.txt
@@ -15,6 +15,7 @@ Use https://data.palomar-registry.org (CORS `*`, CC0, no query strings).
 - Browse head: https://data.palomar-registry.org/browse/index.json
 - Licence: https://data.palomar-registry.org/LICENSE
 - Policy: https://github.com/PalomarRegistry/PalomarPolicy/blob/main/CONTRIBUTING.md
+- Current aggregate operating-cost run rate: https://palomar-registry.org/costs
 
 Path grammar on that origin, substituting the braces. These are not documents
 to fetch as written:

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -6,6 +6,7 @@ const root = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 export const htmlFiles = [
   "404.html",
   "about.html",
+  "costs.html",
   "entry.html",
   "how-to-submit.html",
   "index.html",

--- a/tests/appearance.test.js
+++ b/tests/appearance.test.js
@@ -153,6 +153,7 @@ test("fixed public pages declare extensionless canonical URLs", async () => {
   const routes = new Map([
     ["index.html", "/"],
     ["about.html", "/about"],
+    ["costs.html", "/costs"],
     ["how-to-submit.html", "/how-to-submit"],
     ["privacy.html", "/privacy"],
     ["statement.html", "/statement"],
@@ -164,6 +165,18 @@ test("fixed public pages declare extensionless canonical URLs", async () => {
       new RegExp(`<link rel="canonical" href="https://palomar-registry\\.org${route}">`),
     );
   }
+});
+
+test("the public cost page is aggregate, fresh, and free of private identifiers", async () => {
+  const html = await readFile(new URL("../costs.html", import.meta.url), "utf8");
+  assert.match(html, /Operating cost run rate/);
+  assert.match(html, /Independent billing check/);
+  assert.match(html, /<time datetime="[^"]+">/);
+  assert.match(html, /contains no submissions, identities, API keys/);
+  assert.doesNotMatch(
+    html,
+    /OPENAI_ADMIN_KEY|CLOUDFLARE_API_TOKEN|PALOMAR_BILLING_TOKEN|proj_|sk-/,
+  );
 });
 
 // This page claimed for a while that GitHub processed for Palomar under the


### PR DESCRIPTION
## Summary

- add a static, identity-free operating cost page at the permanent `/costs` route
- expose only aggregate annual/monthly costs, workload, OpenAI reconciliation, and freshness
- include the page in the reviewed Pages build and machine-readable site map
- test canonical routing, CSP, required chrome, freshness, and absence of credential/project identifiers

## Verification

- `PALOMAR_DATABASE_CHECKOUT=/home/kim/palomar/PalomarDatabase npm test` — 271 tests pass
- production-style site build contains `costs.html`
- page is byte-for-byte equal to the private cost monitor's reviewed public projection
