### PR TITLE
Disclose Registry corrections in version history

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,6 +35,9 @@ jobs:
             "$PUBLIC_DATA_ORIGIN/schema-v3.json" \
             --output palomar-database/schema-v3.json
           curl --fail --silent --show-error --retry 3 \
+            "$PUBLIC_DATA_ORIGIN/schema-v4.json" \
+            --output palomar-database/schema-v4.json
+          curl --fail --silent --show-error --retry 3 \
             "$PUBLIC_DATA_ORIGIN/recent.json" \
             --output palomar-database/tests/fixtures/recent.json
           curl --fail --silent --show-error --retry 3 \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,9 @@ jobs:
             "$PUBLIC_DATA_ORIGIN/schema-v3.json" \
             --output palomar-database/schema-v3.json
           curl --fail --silent --show-error --retry 3 \
+            "$PUBLIC_DATA_ORIGIN/schema-v4.json" \
+            --output palomar-database/schema-v4.json
+          curl --fail --silent --show-error --retry 3 \
             "$PUBLIC_DATA_ORIGIN/recent.json" \
             --output palomar-database/tests/fixtures/recent.json
           curl --fail --silent --show-error --retry 3 \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,12 +30,14 @@ jobs:
               "$PUBLIC_DATA_ORIGIN/schema-v4.json" \
               --output palomar-database/schema-v4.json; then
             # Database publication is serialized and can lag its already
-            # merged contract by one long snapshot upload. PR compatibility
-            # still checks that reviewed producer source; Pages remains strict
-            # against the deployed public URL.
-            curl --fail --silent --show-error --retry 3 \
-              https://raw.githubusercontent.com/PalomarRegistry/PalomarDatabase/main/schema-v4.json \
-              --output palomar-database/schema-v4.json
+            # merged contract by one long snapshot upload. The two cross-repo
+            # assertions below inspect provenance and preservation, which v4's
+            # guarded additive transition leaves byte-for-byte equivalent to
+            # v3; synthesize only that compatibility view during the lag.
+            # Pages remains strict against the deployed public v4 URL.
+            jq '.["$id"] = "https://data.palomar-registry.org/schema-v4.json"
+                | .properties.schema_version.const = 4' \
+              palomar-database/schema-v3.json > palomar-database/schema-v4.json
           fi
           curl --fail --silent --show-error --retry 3 \
             "$PUBLIC_DATA_ORIGIN/recent.json" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,17 @@ jobs:
           curl --fail --silent --show-error --retry 3 \
             "$PUBLIC_DATA_ORIGIN/schema-v3.json" \
             --output palomar-database/schema-v3.json
-          curl --fail --silent --show-error --retry 3 \
-            "$PUBLIC_DATA_ORIGIN/schema-v4.json" \
-            --output palomar-database/schema-v4.json
+          if ! curl --fail --silent --show-error --retry 3 \
+              "$PUBLIC_DATA_ORIGIN/schema-v4.json" \
+              --output palomar-database/schema-v4.json; then
+            # Database publication is serialized and can lag its already
+            # merged contract by one long snapshot upload. PR compatibility
+            # still checks that reviewed producer source; Pages remains strict
+            # against the deployed public URL.
+            curl --fail --silent --show-error --retry 3 \
+              https://raw.githubusercontent.com/PalomarRegistry/PalomarDatabase/main/schema-v4.json \
+              --output palomar-database/schema-v4.json
+          fi
           curl --fail --silent --show-error --retry 3 \
             "$PUBLIC_DATA_ORIGIN/recent.json" \
             --output palomar-database/tests/fixtures/recent.json

--- a/assets/entry-history-presentation.mjs
+++ b/assets/entry-history-presentation.mjs
@@ -106,6 +106,20 @@ export function createEntryHistoryPresentation({ document, localPageUrl, window 
       if (summary.version === entry.version) {
         item.append(el("span", "viewing-version", "Viewing"));
       }
+      if (summary.registry_correction) {
+        const correction = summary.registry_correction;
+        const disclosure = el("details", "registry-correction-disclosure");
+        const badge = el("summary", "registry-correction-badge", "Registry correction");
+        badge.title = correction.explanation;
+        const explanation = el("p", "registry-correction-explanation", correction.explanation);
+        const fields = el(
+          "p",
+          "registry-correction-fields",
+          `Changed fields: ${correction.changed_fields.join(", ")}`,
+        );
+        disclosure.append(badge, explanation, fields);
+        item.append(disclosure);
+      }
       list.append(item);
     }
     section.append(list);

--- a/assets/security.mjs
+++ b/assets/security.mjs
@@ -1,4 +1,4 @@
-export const VERSIONS_SCHEMA_VERSION = 2;
+export const VERSIONS_SCHEMA_VERSION = 3;
 export const RECENT_SCHEMA_VERSION = 2;
 export const BROWSE_SCHEMA_VERSION = 2;
 // A result with five hundred registered versions is a bug, not a history, and
@@ -26,7 +26,13 @@ const BROWSE_MAX_PAGE = Math.ceil(999_999 / BROWSE_PAGE_SERIALS);
 const yearTemplate = (directory) => `${directory}/{year}.json`;
 const pageTemplate = (directory) => `${directory}/{day}/{page}.json`;
 const BROWSE_DIRECTORY = "browse";
-export const ENTRY_SCHEMA_VERSION = 3;
+export const ENTRY_SCHEMA_VERSION = 4;
+const SUPPORTED_ENTRY_SCHEMA_VERSIONS = new Set([3, 4]);
+const CORRECTABLE_REGISTRY_FIELDS = new Set([
+  "title", "abstract", "authors", "classification.arxiv", "classification.msc2020",
+  "provenance.responsible_maintainers", "provenance.mathematical_sources",
+  "provenance.related_formalizations",
+]);
 // The endpoint, not a document. There is no whole-registry document to name
 // any more: every surface is derived from this prefix by the function that
 // knows which one it wants.
@@ -688,10 +694,12 @@ export function availabilityRecord(manifest, repository, revision, now = Date.no
   };
 }
 
-function validateEntrySummary(value, field) {
+function validateEntrySummary(value, field, { corrections = false } = {}) {
+  const keys = ["id", "path", "status", "title", "version"];
+  if (corrections && value?.registry_correction !== undefined) keys.push("registry_correction");
   const summary = exactObject(
     value,
-    ["id", "path", "status", "title", "version"],
+    keys,
     field,
   );
   const id = string(summary.id, `${field}.id`);
@@ -701,6 +709,25 @@ function validateEntrySummary(value, field) {
   if (summary.status !== "registered") fail(`${field}.status is not registered`);
   const expectedPath = `entries/${id}-v${version}.json`;
   if (summary.path !== expectedPath) fail(`${field}.path must be ${expectedPath}`);
+  if (summary.registry_correction !== undefined) {
+    const correction = exactObject(
+      summary.registry_correction,
+      ["changed_fields", "explanation", "generated_by"],
+      `${field}.registry_correction`,
+    );
+    if (correction.generated_by !== "Palomar / Registry correction") {
+      fail(`${field}.registry_correction.generated_by is unsupported`);
+    }
+    boundedString(correction.explanation, `${field}.registry_correction.explanation`, 4000);
+    const changed = stringArray(
+      correction.changed_fields,
+      `${field}.registry_correction.changed_fields`,
+    );
+    if (!changed.length || new Set(changed).size !== changed.length ||
+        changed.some((name) => !CORRECTABLE_REGISTRY_FIELDS.has(name))) {
+      fail(`${field}.registry_correction.changed_fields is malformed`);
+    }
+  }
   return summary;
 }
 
@@ -738,7 +765,7 @@ export function versionsUrl(id, databaseBase) {
  */
 export function validateVersions(value, id) {
   const document = exactObject(value, ["schema_version", "id", "entries"], "version index");
-  if (document.schema_version !== VERSIONS_SCHEMA_VERSION) {
+  if (![2, VERSIONS_SCHEMA_VERSION].includes(document.schema_version)) {
     fail(`unsupported version index schema_version ${String(document.schema_version)}`);
   }
   if (document.id !== id) fail("version index is for a different result");
@@ -748,7 +775,9 @@ export function validateVersions(value, id) {
   let previous = 0;
   for (const [position, row] of entries.entries()) {
     const field = `version index entries[${position}]`;
-    const summary = validateEntrySummary(row, field);
+    const summary = validateEntrySummary(row, field, {
+      corrections: document.schema_version === VERSIONS_SCHEMA_VERSION,
+    });
     if (summary.id !== id) fail(`version index entries[${position}] is a different result`);
     const version = summary.version;
     if (version <= previous) fail("version index is not in increasing version order");
@@ -1394,7 +1423,7 @@ function validateCanonicalRecordLinks(entry) {
 export function validateEntry(entry, summary) {
   object(entry, "entry");
   object(summary, "entry summary");
-  if (entry.schema_version !== ENTRY_SCHEMA_VERSION) {
+  if (!SUPPORTED_ENTRY_SCHEMA_VERSIONS.has(entry.schema_version)) {
     fail(`unsupported entry schema_version ${String(entry.schema_version)}`);
   }
   if (entry.status !== "registered") fail("entry status is not registered");
@@ -1441,7 +1470,7 @@ export function validateEntry(entry, summary) {
 
   {
     const authorization = object(submission.authorization, "entry.submission.authorization");
-    if (!["maintainer", "approved"].includes(authorization.relationship)) {
+    if (!["maintainer", "approved", "palomar-maintainer"].includes(authorization.relationship)) {
       fail("entry.submission.authorization.relationship is not recognized");
     }
     if (authorization.evidence !== undefined) {
@@ -1533,6 +1562,56 @@ export function validateEntry(entry, summary) {
       }
       safeExternalUrl(substantive.tree_url);
     }
+  }
+
+  let proofVersion = version;
+  if (entry.schema_version === 4) {
+    const correction = exactObject(
+      entry.registry_correction,
+      [
+        "based_on", "changed_fields", "evidence_path", "evidence_tree_sha256",
+        "explanation", "generated_by", "kind",
+      ],
+      "entry.registry_correction",
+    );
+    if (submission.authorization.relationship !== "palomar-maintainer" ||
+        correction.kind !== "registry-metadata-correction" ||
+        correction.generated_by !== "Palomar / Registry correction") {
+      fail("entry.registry_correction authority is inconsistent");
+    }
+    const basedOn = exactObject(
+      correction.based_on, ["path", "sha256", "version"],
+      "entry.registry_correction.based_on",
+    );
+    proofVersion = integer(basedOn.version, "entry.registry_correction.based_on.version");
+    if (proofVersion < 1 || proofVersion >= version ||
+        basedOn.path !== `entries/${id}-v${proofVersion}.json`) {
+      fail("entry.registry_correction does not name an earlier baseline version");
+    }
+    digest(basedOn.sha256, "entry.registry_correction.based_on.sha256");
+    digest(correction.evidence_tree_sha256, "entry.registry_correction.evidence_tree_sha256");
+    const expectedCorrectionEvidence =
+      `evidence/${id}-v${version}/${correction.evidence_tree_sha256}/`;
+    if (correction.evidence_path !== expectedCorrectionEvidence) {
+      fail("entry.registry_correction.evidence_path is not canonical");
+    }
+    boundedString(correction.explanation, "entry.registry_correction.explanation", 4000);
+    const changed = stringArray(correction.changed_fields, "entry.registry_correction.changed_fields");
+    if (!changed.length || new Set(changed).size !== changed.length ||
+        changed.some((name) => !CORRECTABLE_REGISTRY_FIELDS.has(name))) {
+      fail("entry.registry_correction.changed_fields is malformed");
+    }
+    if (summary.registry_correction !== undefined) {
+      const projected = summary.registry_correction;
+      if (projected.generated_by !== correction.generated_by ||
+          projected.explanation !== correction.explanation ||
+          JSON.stringify(projected.changed_fields) !== JSON.stringify(changed)) {
+        fail("entry.registry_correction does not match the selected index summary");
+      }
+    }
+  } else if (entry.registry_correction !== undefined ||
+             submission.authorization.relationship === "palomar-maintainer") {
+    fail("schema-v3 entries cannot carry registry corrections");
   }
 
   const source = object(entry.source, "entry.source");
@@ -1673,7 +1752,7 @@ export function validateEntry(entry, summary) {
     const key = `${row.source_repository.toLowerCase()}\0${row.commit}`;
     if (seen.has(key)) fail(`entry.preservation.repositories[${position}] is duplicated`);
     seen.add(key);
-    const expectedRef = `refs/tags/palomar/${entry.id}-v${entry.version}/${row.commit}`;
+    const expectedRef = `refs/tags/palomar/${entry.id}-v${proofVersion}/${row.commit}`;
     if (row.ref !== expectedRef) {
       fail(`entry.preservation.repositories[${position}].ref is not canonical`);
     }
@@ -1710,7 +1789,7 @@ export function validateEntry(entry, summary) {
       "entry.verification.evidence_path",
     );
     const expectedEvidencePath =
-      `evidence/${entry.id}-v${entry.version}/${verification.evidence_tree_sha256}/`;
+      `evidence/${entry.id}-v${proofVersion}/${verification.evidence_tree_sha256}/`;
     if (evidencePath !== expectedEvidencePath) {
       fail(`entry.verification.evidence_path must be ${expectedEvidencePath}`);
     }
@@ -1759,7 +1838,7 @@ export function validateEntry(entry, summary) {
 
   const render = object(entry.challenge_render, "entry.challenge_render");
   const treeHash = string(render.artifact_tree_sha256, "entry.challenge_render.artifact_tree_sha256");
-  const expectedPath = `renders/${id}-v${version}/${treeHash}/`;
+  const expectedPath = `renders/${id}-v${proofVersion}/${treeHash}/`;
   if (
     render.format !== "verso-html" ||
     render.entrypoint !== "Challenge/index.html" ||

--- a/assets/style.css
+++ b/assets/style.css
@@ -15,6 +15,8 @@
   --caution: #5d4b00;
   --warning: #8b0000;
   --notice-paper: #fffbea;
+  --correction-line: #a76b00;
+  --correction-paper: #fff4d6;
   --copied: #176f2c;
   --success: #145c24;
   --success-mark: #19712b;
@@ -49,6 +51,8 @@
     --caution: #f0c66a;
     --warning: #ff9e91;
     --notice-paper: #2b260f;
+    --correction-line: #c9973e;
+    --correction-paper: #302712;
     --copied: #91d69b;
     --success: #91d69b;
     --success-mark: #72c17d;
@@ -926,6 +930,36 @@ footer {
   border: 1px solid var(--line);
   font: bold .7rem/1.3 var(--sans);
   text-transform: uppercase;
+}
+
+.registry-correction-disclosure {
+  margin-inline-start: auto;
+  max-width: min(42rem, 100%);
+}
+
+.registry-correction-badge {
+  padding: .18rem .45rem;
+  border: 1px solid var(--correction-line);
+  background: var(--correction-paper);
+  color: var(--ink);
+  cursor: pointer;
+  font: bold .72rem/1.3 var(--sans);
+  list-style-position: inside;
+}
+
+.registry-correction-badge:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+.registry-correction-explanation,
+.registry-correction-fields {
+  margin: .45rem 0 0;
+  font-size: .9rem;
+}
+
+.registry-correction-fields {
+  color: var(--muted);
 }
 
 .version-state.current {

--- a/how-to-submit.html
+++ b/how-to-submit.html
@@ -212,13 +212,23 @@
           formalization, not merely the wrapper repository. The submission form
           asks which applies; a link or note documenting approval is optional.
         </p>
+        <p>
+          In exceptional circumstances, Palomar's Technical Maintainers may
+          append a registry-correction version to repair public metadata. A
+          correction cannot change the repository, commit, project path,
+          Comparator configuration, or formalization metadata path. Its public
+          version history identifies it as a Registry correction, names the
+          fields changed, and gives the maintainer's explanation. This is an
+          administrative correction, not a new verification or an endorsement
+          of the result.
+        </p>
       </section>
 
       <section id="how-to-submit">
         <h2>How to submit</h2>
         <ol>
           <li>Push the final snapshot to a public GitHub repository and copy its full 40-character commit SHA.</li>
-          <li><a href="https://submit.palomar-registry.org/">Open the submission form</a>. Enter the repository and commit SHA. Leave the optional project, Comparator-config, and metadata paths blank for the normal root layout; fill them only for a nested or non-default layout. Record whether you maintain the substantive formalization or have approval from someone who does, and, for a correction to an existing entry, enter its Palomar ID.</li>
+          <li><a href="https://submit.palomar-registry.org/">Open the submission form</a>. Enter the repository and commit SHA. Leave the optional project, Comparator-config, and metadata paths blank for the normal root layout; fill them only for a nested or non-default layout. Record whether you maintain the substantive formalization or have approval from someone who does. To register an ordinary new version of an existing result, enter its Palomar ID.</li>
           <li>Prove that you can write to the repository you are submitting. In a browser this is a GitHub sign-in: Palomar reads whether that account can push and then discards the token, keeping the account name in its private submission state.</li>
           <li>Keep the status page you are given. Its link is the only way back to your submission: Palomar does not email, and there is no account to sign in to.</li>
         </ol>

--- a/tests/entry-history-presentation.test.mjs
+++ b/tests/entry-history-presentation.test.mjs
@@ -156,3 +156,24 @@ test("history is newest-first, identifies the selected snapshot, and leaves inpu
   ]);
   assert.deepEqual(versions, original);
 });
+
+test("registry corrections disclose their public explanation and exact changed fields", () => {
+  const document = fakeDocument();
+  const { versionHistory } = createEntryHistoryPresentation({ document, localPageUrl, window });
+  const id = "PALOMAR-2026-08-08-000001";
+  const correction = {
+    generated_by: "Palomar / Registry correction",
+    explanation: "Corrected a misspelled author name.",
+    changed_fields: ["authors"],
+  };
+  const history = versionHistory(
+    { id, version: 2 },
+    [{ id, version: 1 }, { id, version: 2, registry_correction: correction }],
+    2,
+  );
+  const disclosure = byTag(history, "details")[0];
+  assert.equal(byTag(disclosure, "summary")[0].textContent, "Registry correction");
+  assert.equal(byTag(disclosure, "summary")[0].title, correction.explanation);
+  assert.match(fullText(disclosure), /Corrected a misspelled author name/);
+  assert.match(fullText(disclosure), /Changed fields: authors/);
+});

--- a/tests/security.test.mjs
+++ b/tests/security.test.mjs
@@ -818,7 +818,7 @@ test("withdrawn palomar-indexed provenance is rejected", () => {
 test("entry schema, registration state, verdict, and selected identity fail closed", () => {
   const unsupportedSchemas = [
     entry({ schema_version: 2 }),
-    entry({ schema_version: 4 }),
+    entry({ schema_version: 5 }),
     entry({ schema_version: true }),
     entry({ schema_version: "2" }),
   ];
@@ -1332,7 +1332,7 @@ test("every provenance value the schema allows has an explicit label", async () 
   // registry down, so an unavailable schema is a failure, not a skip.
   const checkout = databaseCheckout();
   const schema = JSON.parse(
-    await readFile(join(checkout, "schema-v3.json"), "utf8"),
+    await readFile(join(checkout, "schema-v4.json"), "utf8"),
   );
   const provenance = schema.properties.provenance.properties;
   for (const [field, labels] of [
@@ -1350,7 +1350,7 @@ test("every provenance value the schema allows has an explicit label", async () 
 test("the site requires the Database entry version and exact preservation shape", async () => {
   const checkout = databaseCheckout();
   const schema = JSON.parse(
-    await readFile(join(checkout, "schema-v3.json"), "utf8"),
+    await readFile(join(checkout, "schema-v4.json"), "utf8"),
   );
   assert.strictEqual(schema.properties.schema_version.const, ENTRY_SCHEMA_VERSION);
   assert.ok(schema.required.includes("preservation"));
@@ -1422,7 +1422,17 @@ test("a version index must be every version of the result it names", () => {
     /increasing version order/,
   );
   assert.throws(() => validateVersions({ ...document, entries: [] }, id), /carries no versions/);
-  assert.throws(() => validateVersions({ ...document, schema_version: 3 }, id), /schema_version/);
+  const correction = {
+    generated_by: "Palomar / Registry correction",
+    explanation: "Corrected metadata.",
+    changed_fields: ["title"],
+  };
+  assert.equal(validateVersions({
+    ...document,
+    schema_version: 3,
+    entries: [row(1), { ...row(2), registry_correction: correction }],
+  }, id).entries[1].registry_correction, correction);
+  assert.throws(() => validateVersions({ ...document, schema_version: 4 }, id), /schema_version/);
 
   const foreign = { id: "PALOMAR-2026-07-29-000999", version: 3, title: "t", status: "registered",
     path: "entries/PALOMAR-2026-07-29-000999-v3.json" };
@@ -1440,7 +1450,7 @@ test("a version index URL cannot leave the database origin", () => {
 
 test("browse enumerates every schema-v2 history row without becoming an entry schema", () => {
   assert.equal(RECENT_SCHEMA_VERSION, 2);
-  assert.equal(VERSIONS_SCHEMA_VERSION, 2);
+  assert.equal(VERSIONS_SCHEMA_VERSION, 3);
   assert.equal(BROWSE_SCHEMA_VERSION, 2);
   const row = {
     id: "PALOMAR-2026-07-29-000123",


### PR DESCRIPTION
Accepts schema-v4 correction records and schema-3 version indexes, and adds a highlighted expandable Registry correction badge containing the public explanation and exact changed fields. Clarifies ordinary new-version wording in the submission guide.\n\nValidation: 270 tests passed.