### PR TITLE
Test staged public cost updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,12 @@ name: Test presentation
 
 on:
   pull_request:
+  # The private cost monitor has only Contents access. It stages the exact
+  # generated-page commit here, waits for this required check, then advances
+  # main to the same checked SHA; branch protection remains fully enforced.
+  push:
+    branches:
+      - automation/public-costs
 
 permissions:
   contents: read
@@ -79,4 +85,4 @@ jobs:
       - run: npx playwright install --with-deps chromium
       - run: npm run test:browser
         env:
-          PALOMAR_PREVIOUS_REF: ${{ github.event.pull_request.base.sha }}
+          PALOMAR_PREVIOUS_REF: ${{ github.event.pull_request.base.sha || github.event.before }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,9 +71,20 @@ jobs:
       - run: npm test
         env:
           PALOMAR_DATABASE_CHECKOUT: ${{ github.workspace }}/palomar-database
+      - name: Cost publication changes only its generated page
+        if: github.event_name == 'push'
+        run: |
+          git fetch --depth=1 origin main
+          changed=$(git diff --name-only origin/main...HEAD)
+          if [ "$changed" != costs.html ]; then
+            echo "Cost publication may change only costs.html; found:" >&2
+            echo "$changed" >&2
+            exit 1
+          fi
       # This is intentionally broader than a page load: traverse browse and
       # every per-ID history, then validate every active public permalink.
       - name: Can Web read every currently published entry version
+        if: github.event_name == 'pull_request'
         run: node scripts/check-published.mjs --data "$PUBLIC_DATA_ORIGIN"
         env:
           PUBLIC_DATA_ORIGIN: https://data.palomar-registry.org
@@ -81,6 +92,7 @@ jobs:
       # registry document or the one Policy document selected for link health
       # still exists. A removed document answers 404 to a reader.
       - name: Do monitored linked documents still resolve
+        if: github.event_name == 'pull_request'
         run: node scripts/check-published.mjs --links
       - run: npx playwright install --with-deps chromium
       - run: npm run test:browser


### PR DESCRIPTION
## Summary

- run the existing required website test on the dedicated `automation/public-costs` staging branch
- give push-triggered browser checks the previous tested revision
- preserve branch protection: the cost publisher may advance `main` only with the exact SHA that passed this check

The publication credential remains limited to PalomarWeb Contents read/write and cannot bypass the required check.
