### PR TITLE
Use main as the staged cost baseline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,4 +97,4 @@ jobs:
       - run: npx playwright install --with-deps chromium
       - run: npm run test:browser
         env:
-          PALOMAR_PREVIOUS_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
+          PALOMAR_PREVIOUS_REF: ${{ github.event.pull_request.base.sha || 'origin/main' }}


### PR DESCRIPTION
## Summary

Use protected `main` as the previous deployment for cache-compatibility tests on the dedicated cost-publication staging branch.

The first live staging run proved why this is necessary: a newly created staging branch has an all-zero `before` revision, while every generated cost commit is deliberately based on current `main`.
