### PR TITLE
Render maintainer-corrected entries from baseline artifacts

### DIFF
--- a/assets/entry-pages.mjs
+++ b/assets/entry-pages.mjs
@@ -70,9 +70,9 @@ export async function renderEntryPage({
       resolvedUrl.hash = requestedHash;
       history.replaceState(null, "", resolvedUrl);
     }
+    await renderEntry(loaded, content);
     status.hidden = true;
     content.hidden = false;
-    await renderEntry(loaded, content);
     const anchorTarget = requestedHash.startsWith("#")
       ? document.getElementById(decodeURIComponent(requestedHash.slice(1)))
       : null;
@@ -81,6 +81,9 @@ export async function renderEntryPage({
       anchorTarget.scrollIntoView();
     }
   } catch (error) {
+    content.replaceChildren();
+    content.hidden = true;
+    status.hidden = false;
     status.textContent = `The registry entry could not be loaded: ${error.message}`;
     status.classList.add("error");
   }

--- a/assets/rendering.js
+++ b/assets/rendering.js
@@ -79,9 +79,23 @@ export function renderArtifactUrl(id, version, treeHash, renderBase) {
 
 export function challengeArtifactUrl(entry, renderBase) {
   const id = entry?.id;
-  const version = entry?.version;
+  const entryVersion = entry?.version;
+  // A maintainer correction is a new immutable registry snapshot of the
+  // earlier mechanically checked result. Its render therefore remains under
+  // the baseline version's content address, just like its verification
+  // evidence. Do not silently accept an arbitrary alternate version: the
+  // correction must point backwards from a valid current version.
+  const correctionVersion = entry?.registry_correction?.based_on?.version;
+  const version = correctionVersion ?? entryVersion;
   const render = entry?.challenge_render;
-  if (!ID.test(id || "") || !Number.isInteger(version) || version < 1) {
+  if (
+    !ID.test(id || "") ||
+    !Number.isInteger(entryVersion) ||
+    entryVersion < 1 ||
+    !Number.isInteger(version) ||
+    version < 1 ||
+    (correctionVersion !== undefined && correctionVersion >= entryVersion)
+  ) {
     throw new Error("entry has an invalid Palomar identifier or version");
   }
   const treeHash = render?.artifact_tree_sha256;

--- a/tests/entry-pages.test.js
+++ b/tests/entry-pages.test.js
@@ -24,6 +24,9 @@ function node({ hidden = false } = {}) {
     append(...children) {
       this.children.push(...children);
     },
+    replaceChildren(...children) {
+      this.children = children;
+    },
   };
 }
 
@@ -96,7 +99,7 @@ test("entry routes reject noncanonical parameters before loading data", async ()
   assert.equal(view.content.hidden, true);
 });
 
-test("unversioned entry routes expose content progressively then preserve and scroll the fragment", async () => {
+test("unversioned entry routes reveal completed content then preserve and scroll the fragment", async () => {
   const entry = { id: "PALOMAR-2026-08-08-000001", version: 3 };
   const loaded = {
     entry,
@@ -146,8 +149,8 @@ test("unversioned entry routes expose content progressively then preserve and sc
 
   const route = renderEntryPage(settings);
   await started;
-  assert.equal(view.status.hidden, true);
-  assert.equal(view.content.hidden, false);
+  assert.equal(view.status.hidden, false);
+  assert.equal(view.content.hidden, true);
   assert.equal(scrolled, 0);
   releaseRender();
   await route;
@@ -188,6 +191,30 @@ test("entry routes preserve exact tombstones and load failures", async (t) => {
     assert.equal(view.status.textContent, "The registry entry could not be loaded: 503 Unavailable");
     assert.equal(view.status.classList.contains("error"), true);
     assert.equal(view.content.hidden, true);
+  });
+
+  await t.test("render failure remains visible and clears partial content", async () => {
+    const partial = node();
+    const { settings, view } = entryDependencies({
+      loadEntry: async () => ({
+        entry: { id: "PALOMAR-2026-08-08-000001", version: 2 },
+      }),
+      renderEntry: async (_loaded, content) => {
+        content.append(partial);
+        throw new Error("invalid Challenge render metadata");
+      },
+    });
+
+    await renderEntryPage(settings);
+
+    assert.equal(
+      view.status.textContent,
+      "The registry entry could not be loaded: invalid Challenge render metadata",
+    );
+    assert.equal(view.status.classList.contains("error"), true);
+    assert.equal(view.status.hidden, false);
+    assert.equal(view.content.hidden, true);
+    assert.deepEqual(view.content.children, []);
   });
 });
 

--- a/tests/rendering.test.js
+++ b/tests/rendering.test.js
@@ -65,6 +65,25 @@ test("artifact URL is derived only from the content-addressed registry fields", 
   assert.throws(() => challengeArtifactUrl(traversal, "https://example.test/"), /invalid/);
 });
 
+test("a maintainer correction reuses its baseline version's content-addressed render", () => {
+  const corrected = entry({
+    version: 2,
+    registry_correction: { based_on: { version: 1 } },
+  });
+  assert.equal(
+    challengeArtifactUrl(corrected, "https://data.palomar-registry.org/").href,
+    `https://data.palomar-registry.org/renders/PALOMAR-2026-07-29-000123-v1/${"a".repeat(64)}/Challenge/index.html`,
+  );
+
+  for (const version of [0, 2, 3, 1.5]) {
+    corrected.registry_correction.based_on.version = version;
+    assert.throws(
+      () => challengeArtifactUrl(corrected, "https://data.palomar-registry.org/"),
+      /invalid Palomar identifier or version/,
+    );
+  }
+});
+
 test("a content address alone resolves to the same rendering a record does", () => {
   const record = entry();
   assert.equal(


### PR DESCRIPTION
## Summary

- resolve corrected entries' Challenge renders from the immutable baseline version named by registry_correction.based_on
- retain strict canonical path and backwards-version checks
- keep route errors visible and clear partial content if presentation fails

## Regression coverage

- corrected v2 records reuse v1 content-addressed renders
- malformed correction versions remain rejected
- presentation failures leave a visible error instead of a blank page

## Verification

- PALOMAR_DATABASE_CHECKOUT=/home/kim/palomar/PalomarDatabase npm test (274 passed)
- npm run test:browser with Nixpkgs Chromium (96 passed, 2 expected skips)
- rendered live PALOMAR-2026-08-26-000003 v2 locally against the production data origin in Chromium; title, ORCID verification UI, and v1 Challenge artifact all appeared
- PALOMAR_ASSET_VERSION=local-test npm run build
