### PR TITLE
Keep the audit disclosure on the render page

### DIFF
--- a/assets/challenge-presentation.mjs
+++ b/assets/challenge-presentation.mjs
@@ -276,6 +276,7 @@ export function createChallengePresentation({ fetchJson, document, window, local
     {
       forceFrame = false,
       dependenciesOnThisPage = false,
+      showAudit = false,
       sourceAvailability = null,
       availabilityPromise = null,
     } = {},
@@ -395,8 +396,10 @@ export function createChallengePresentation({ fetchJson, document, window, local
         ),
       );
     }
-    const audit = auditPanel(metadata);
-    if (audit) section.append(audit);
+    if (showAudit) {
+      const audit = auditPanel(metadata);
+      if (audit) section.append(audit);
+    }
     return { section, metadata };
   };
 }

--- a/assets/entry-pages.mjs
+++ b/assets/entry-pages.mjs
@@ -125,7 +125,7 @@ export async function renderChallengePage({
     const challenge = await challengePresentation(
       entry,
       renderBase,
-      { forceFrame: true, availabilityPromise },
+      { forceFrame: true, showAudit: true, availabilityPromise },
     );
     content.append(heading, challenge.section);
     status.hidden = true;

--- a/tests/challenge-presentation.test.mjs
+++ b/tests/challenge-presentation.test.mjs
@@ -206,20 +206,7 @@ test("an inline presentation keeps links confined and accepts height only from i
   assert.equal(byClass(result.section, "challenge-metadata").length, 1);
   assert.equal(byClass(result.section, "challenge-no-module-doc").length, 1);
   assert.equal(byClass(result.section, "challenge-fallback").length, 0);
-  const [audit] = byClass(result.section, "challenge-audit");
-  assert.ok(audit);
-  assert.equal(audit.children[0].textContent, "View core-notation audit");
-  assert.match(byClass(audit, "challenge-audit-intro")[0].textContent, /same content-addressed render bundle/);
-  const auditDeclaration = byClass(audit, "challenge-audit-declaration")[0];
-  const auditSource = auditDeclaration.children[1];
-  assert.equal(auditSource.textContent, "theorem Example.theorem : Eq Nat.zero Nat.zero");
-  assert.equal(auditSource.getAttribute("tabindex"), "0");
-  assert.equal(
-    auditDeclaration.getAttribute("aria-labelledby"),
-    "challenge-audit-declaration-0",
-  );
-  assert.match(byClass(audit, "challenge-audit-limits")[0].textContent, /misleading instances/);
-  assert.match(byClass(audit, "challenge-audit-limits")[0].textContent, /printer resource limit/);
+  assert.equal(byClass(result.section, "challenge-audit").length, 0);
   const [frame] = byClass(result.section, "challenge-frame");
   const [shell] = byClass(result.section, "challenge-frame-shell");
   assert.ok(frame);
@@ -262,6 +249,38 @@ test("an inline presentation keeps links confined and accepts height only from i
   assert.equal(frame.dataset.heightAdjusted, "true");
   onMessage({ source: frame.contentWindow, data: { type: "palomar-render-height", height: 1_000 } });
   assert.equal(frame.style.height, "672px");
+});
+
+test("the dedicated render presentation includes the core-notation audit", async () => {
+  const browser = fakeBrowser("http://127.0.0.1:4173/render.html");
+  const record = acceptedEntry();
+  const metadata = renderMetadata();
+  const present = createChallengePresentation({
+    ...browser,
+    fetchJson: async () => metadata,
+    localPageUrl: () => new URL("http://127.0.0.1:4173/entry.html"),
+  });
+
+  const result = await present(
+    record,
+    new URL("http://127.0.0.1:4173/database/"),
+    { forceFrame: true, showAudit: true },
+  );
+
+  const [audit] = byClass(result.section, "challenge-audit");
+  assert.ok(audit);
+  assert.equal(audit.children[0].textContent, "View core-notation audit");
+  assert.match(byClass(audit, "challenge-audit-intro")[0].textContent, /same content-addressed render bundle/);
+  const auditDeclaration = byClass(audit, "challenge-audit-declaration")[0];
+  const auditSource = auditDeclaration.children[1];
+  assert.equal(auditSource.textContent, "theorem Example.theorem : Eq Nat.zero Nat.zero");
+  assert.equal(auditSource.getAttribute("tabindex"), "0");
+  assert.equal(
+    auditDeclaration.getAttribute("aria-labelledby"),
+    "challenge-audit-declaration-0",
+  );
+  assert.match(byClass(audit, "challenge-audit-limits")[0].textContent, /misleading instances/);
+  assert.match(byClass(audit, "challenge-audit-limits")[0].textContent, /printer resource limit/);
 });
 
 test("historical render metadata does not invent an audit view", async () => {

--- a/tests/entry-pages.test.js
+++ b/tests/entry-pages.test.js
@@ -281,6 +281,7 @@ test("named-declaration routes validate before loading and reveal only completed
       assert.equal(selected, entry);
       assert.equal(renderBase.href, "https://render.example/");
       assert.equal(options.forceFrame, true);
+      assert.equal(options.showAudit, true);
       assert.deepEqual(await options.availabilityPromise, { repositories: [] });
       challengeStarted();
       await challenging;

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -1447,31 +1447,7 @@ test("eligible Challenge renders inline without origin privilege", async ({ page
   await expect(page.locator(".challenge-module-doc summary")).toHaveText("Notes from the statement file");
   await page.locator(".challenge-module-doc summary").click();
   await expect(page.locator(".challenge-module-doc pre")).toContainText("Parsed outside the Verso renderer");
-  const audit = page.locator(".challenge-audit");
-  await expect(audit.locator("summary")).toHaveText("View core-notation audit");
-  await expect(audit.locator(".challenge-audit-declaration")).not.toBeVisible();
-  await audit.locator("summary").click();
-  const auditSource = audit.locator(".challenge-audit-declaration pre");
-  await expect(auditSource).toHaveText(
-    "theorem Example.theorem : Eq Nat.zero Nat.zero",
-  );
-  await expect(auditSource).toHaveAttribute("tabindex", "0");
-  await expect(audit.locator(".challenge-audit-declaration")).toHaveAttribute(
-    "aria-labelledby",
-    "challenge-audit-declaration-0",
-  );
-  await expect(audit.locator(".challenge-audit-declaration")).toHaveAccessibleName(
-    "Example.theorem",
-  );
-  await expect(audit.locator(".challenge-audit-intro")).toContainText(
-    "without imported delaborators or unexpanders",
-  );
-  await expect(audit.locator(".challenge-audit-limits")).toContainText(
-    "misleading instances, silently inserted coercions, or definitions",
-  );
-  await expect(audit.locator(".challenge-audit-limits")).toContainText(
-    "omitted subterm with ⋯",
-  );
+  await expect(page.locator(".challenge-audit")).toHaveCount(0);
   const rendered = page.frameLocator(".challenge-presentation iframe");
   await expect(rendered.locator(".docstring")).toHaveText("The theorem doc-string.");
   await expect(rendered.locator(".skip-link")).toHaveCount(0);
@@ -1601,17 +1577,52 @@ test("larger Challenge falls back to the dedicated wrapper", async ({ page }) =>
   await expect(page.locator(".challenge-fallback")).toContainText(
     "This statement is too large to display here",
   );
+  await expect(page.locator(".challenge-audit")).toHaveCount(0);
   await page.getByRole("link", { name: "Open formatted statement" }).click();
   await expect(page).toHaveURL(/\/render\?id=PALOMAR-2026-07-29-000124/);
   await expect(page.locator(".challenge-presentation iframe")).toHaveAttribute(
     "sandbox",
     "allow-scripts",
   );
+  await expect(page.locator(".challenge-presentation iframe")).toHaveAttribute(
+    "data-height-adjusted",
+    "true",
+  );
   await expect(page.locator(".challenge-source")).toHaveAttribute(
     "href",
     `https://github.com/example/challenge/blob/${"1".repeat(40)}/Challenge.lean`,
   );
-  await page.getByRole("link", { name: "Inspect statement dependencies" }).click();
+  const audit = page.locator(".challenge-audit");
+  await expect(audit.locator("summary")).toHaveText("View core-notation audit");
+  await expect(audit.locator(".challenge-audit-declaration")).not.toBeVisible();
+  await audit.locator("summary").click();
+  const auditSource = audit.locator(".challenge-audit-declaration pre");
+  await expect(auditSource).toHaveText(
+    "theorem Example.theorem : Eq Nat.zero Nat.zero",
+  );
+  await expect(auditSource).toHaveAttribute("tabindex", "0");
+  await expect(audit.locator(".challenge-audit-declaration")).toHaveAttribute(
+    "aria-labelledby",
+    "challenge-audit-declaration-0",
+  );
+  await expect(audit.locator(".challenge-audit-declaration")).toHaveAccessibleName(
+    "Example.theorem",
+  );
+  await expect(audit.locator(".challenge-audit-intro")).toContainText(
+    "without imported delaborators or unexpanders",
+  );
+  await expect(audit.locator(".challenge-audit-limits")).toContainText(
+    "misleading instances, silently inserted coercions, or definitions",
+  );
+  await expect(audit.locator(".challenge-audit-limits")).toContainText(
+    "omitted subterm with ⋯",
+  );
+  await audit.locator("summary").click();
+  await expect(audit.locator(".challenge-audit-declaration")).not.toBeVisible();
+  const dependencies = page.getByRole("link", { name: "Inspect statement dependencies" });
+  await dependencies.scrollIntoViewIfNeeded();
+  await expect(dependencies).toBeInViewport();
+  await dependencies.click();
   await expect(page).toHaveURL(/\/entry\?.*#statement-dependencies$/);
   await expect(page.locator("#statement-dependencies")).toBeInViewport();
 });


### PR DESCRIPTION
Follow-up to #136.

The core-notation audit is useful on the dedicated statement surface, but it is confusing on an entry whose formatted statement was intentionally omitted as too large. This change makes the audit an explicit /render-page concern:

- /entry never constructs the audit disclosure, for either inline or large statements
- /render opts in and continues to show the schema-v3 audit
- unit and browser coverage prove both sides of that route boundary

Verification:

- PALOMAR_DATABASE_CHECKOUT=/home/kim/palomar/PalomarDatabase npm test (292 passed)
- Nixpkgs Chromium browser suite (96 passed, 2 CI-only previous-ref tests skipped)