### PR TITLE
Make Lean notation and math notations readable, and table view for homepage with list option

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -29,7 +29,7 @@ import { createFormalizationPresentation } from "./formalization-presentation.mj
 import { createRegistryLoader } from "./registry-loading.mjs";
 import { createStatementPreview } from "./statement-preview.mjs";
 import { renderSubjectPage } from "./subject-pages.mjs";
-import { presentationAbstract } from "./presentation-text.mjs";
+import { abstractSegments, presentationAbstract } from "./presentation-text.mjs";
 import {
   DEFAULT_ORDER,
   FIRST_REGISTRATION_ORDER,
@@ -69,6 +69,23 @@ function el(tag, className, text) {
   if (className) node.className = className;
   if (text !== undefined) node.textContent = text;
   return node;
+}
+
+/**
+ * One abstract as a paragraph, with the submitter's own code spans kept apart
+ * from their prose.
+ *
+ * Both surfaces that show an abstract build it here, so a card and an entry
+ * page mark the same runs. Each run is appended as text or as a `code`
+ * element, never as markup, which is what keeps a submitter's abstract unable
+ * to introduce any.
+ */
+function abstractParagraph(className, text) {
+  const paragraph = el("p", className);
+  for (const segment of abstractSegments(text)) {
+    paragraph.append(segment.code ? el("code", "", segment.text) : segment.text);
+  }
+  return paragraph;
 }
 
 function anchor(text, href, className) {
@@ -419,7 +436,7 @@ function entryCard(
     footer.append(historyLink);
   }
   card.append(top, title);
-  if (abstract) card.append(el("p", "card-abstract", abstract));
+  if (abstract) card.append(abstractParagraph("card-abstract", abstract));
   card.append(meta, footer);
   return card;
 }
@@ -1422,7 +1439,7 @@ async function renderEntry(
   top.append(el("span", "entry-id", `${entry.id} v${entry.version}`), trustBadge(entry));
   heading.append(top, el("h1", "", entry.title));
   const abstract = presentationAbstract(entry);
-  if (abstract) heading.append(el("p", "lede", abstract));
+  if (abstract) heading.append(abstractParagraph("lede", abstract));
   const byline = el("p", "byline", "By ");
   appendPeople(byline, entry.authors);
   heading.append(byline);
@@ -1709,7 +1726,7 @@ function renderSubjectRows(rows, content) {
     title.append(internalLink(row.title, localPageUrl("/entry", row)));
     article.append(identity, title);
     const abstract = presentationAbstract(row);
-    if (abstract) article.append(el("p", "card-abstract", abstract));
+    if (abstract) article.append(abstractParagraph("card-abstract", abstract));
     const subjects = el("div", "card-subjects");
     subjects.append(el("small", "", "Subjects"), categoryTokens(row));
     article.append(subjects);

--- a/assets/app.js
+++ b/assets/app.js
@@ -349,18 +349,95 @@ function dateSpans({ id, registeredAt }, order) {
 }
 
 /**
- * Date a card again after the grid is rearranged.
+ * Date a listed result again after the grid is rearranged.
  *
- * The dates are rewritten rather than the card rebuilt: a card carries a hover
+ * The dates are rewritten rather than the node rebuilt: a card carries a hover
  * preview registration and whatever the availability answer decorated it with,
- * and neither survives being replaced by an equal one.
+ * and neither survives being replaced by an equal one. A table row carries the
+ * registration too, and is dated the same way in its own cell.
  */
-function setCardDates(card, row, order) {
-  const identity = card.querySelector(".card-identity");
-  identity.replaceChildren(
-    identity.querySelector(".entry-id"),
-    ...dateSpans(row, order),
+function setListedDates(node, row, order) {
+  const identity = node.querySelector(".card-identity");
+  if (identity) {
+    identity.replaceChildren(
+      identity.querySelector(".entry-id"),
+      ...dateSpans(row, order),
+    );
+    return;
+  }
+  node.querySelector(".row-registered")?.replaceChildren(...dateSpans(row, order));
+}
+
+// The landing grid shows the same selection either as cards, which lead with
+// the abstract, or as a table, which does not. The table is the default: two
+// hundred results are a list to be scanned before any one of them is read, and
+// the cards put four hundred thousand characters of abstract on the page to
+// scroll past first. Both read the one recent.json, so neither is faster to
+// load -- this is what reaches the reader once it has arrived, not how much
+// arrives.
+const LANDING_VIEWS = new Set(["table", "cards"]);
+const DEFAULT_LANDING_VIEW = "table";
+
+/**
+ * Which view the address asks for.
+ *
+ * Carried in the URL rather than stored on the reader's device: the registry
+ * deep-links its order, its dates and its subject filters the same way, a
+ * chosen view is then a link someone can send, and this page goes on keeping
+ * nothing about whoever is reading it.
+ */
+export function requestedLandingView(search) {
+  const value = new URLSearchParams(search).get("view");
+  return LANDING_VIEWS.has(value) ? value : DEFAULT_LANDING_VIEW;
+}
+
+const TABLE_COLUMNS = [
+  ["Result", "row-result"],
+  ["Authors", "row-authors"],
+  ["Subjects", "row-subjects"],
+  ["Dependencies", "row-dependencies"],
+  ["Registered", "row-registered"],
+];
+
+/**
+ * One registered result as a table row.
+ *
+ * Carries the same identity and classification data attributes the card does,
+ * because the toolbar narrows the selection by reading them off whichever node
+ * is showing rather than by asking the record again.
+ */
+function entryRow(entry, { registeredAt = entry.registered_at, order = DEFAULT_ORDER } = {}) {
+  const categories = classification(entry);
+  const row = el("tr", "entry-row");
+  row.dataset.id = entry.id;
+  row.dataset.trust = entry.trust.level;
+  row.dataset.arxiv = categories.arxiv.join(" ");
+  row.dataset.msc = categories.msc2020.join(" ");
+  row.dataset.search = searchBlob(entry);
+
+  const result = el("td", "row-result");
+  const titleLink = internalLink(entry.title, localPageUrl("/entry", entry));
+  // The same hover preview the cards carry: a row says less than a card, so
+  // the rendering behind it is worth more here, not less.
+  statementPreview.register(titleLink, entry);
+  result.append(titleLink);
+
+  const subjects = el("td", "row-subjects");
+  subjects.append(categoryTokens(entry));
+  const registered = el("td", "row-registered");
+  registered.append(...dateSpans({ id: entry.id, registeredAt }, order));
+  row.append(
+    result,
+    el("td", "row-authors", authorNames(entry)),
+    subjects,
+    el(
+      "td",
+      "row-dependencies",
+      entry.trust.level === "high" ? "Mathlib only" : "Additional libraries",
+    ),
+    registered,
   );
+  return row;
 }
 
 function entryCard(
@@ -564,19 +641,46 @@ async function renderIndex() {
     // Pages, so the order is read from the control when the page has one and
     // from the link when it does not.
     let order = normalizeOrder(orderControl ? orderControl.value : params.get("order"));
-    const cards = entries.map((entry) =>
-      entryCard(entry, {
-        versionCount: entry.versions,
-        current: true,
-        registeredAt: entry.published_at,
-        order,
-      }));
-    // The rows the grid is arranged and filtered by, paired with the cards
-    // showing them, so that neither question has to read a card back.
+    let view = requestedLandingView(window.location.search);
+    const buildNodes = () => entries.map((entry) =>
+      view === "table"
+        ? entryRow(entry, { registeredAt: entry.published_at, order })
+        : entryCard(entry, {
+          versionCount: entry.versions,
+          current: true,
+          registeredAt: entry.published_at,
+          order,
+        }));
+    let nodes = buildNodes();
+    // The rows the grid is arranged and filtered by, paired with the node
+    // showing them, so that neither question has to read a node back.
     const listed = entries.map((entry, index) => ({
-      card: cards[index],
+      node: nodes[index],
       row: { id: entry.id, registeredAt: entry.published_at },
     }));
+    // A table needs a body to append into; cards go straight into the grid.
+    // Rebuilt whenever the view changes, which is also what clears the old one.
+    let mount = grid;
+    const remount = () => {
+      grid.replaceChildren();
+      grid.classList.toggle("entry-table-view", view === "table");
+      if (view !== "table") {
+        mount = grid;
+        return;
+      }
+      const table = el("table", "entry-table");
+      const headRow = el("tr");
+      for (const [label, className] of TABLE_COLUMNS) {
+        const heading = el("th", className, label);
+        heading.scope = "col";
+        headRow.append(heading);
+      }
+      const head = el("thead");
+      head.append(headRow);
+      mount = el("tbody");
+      table.append(head, mount);
+      grid.append(table);
+    };
     /**
      * The cards, in the order asked for, dated by the day that order keys on.
      *
@@ -589,12 +693,22 @@ async function renderIndex() {
       statementPreview.close();
       const ordered = [...listed].sort((left, right) =>
         compareRows(left.row, right.row, order));
-      for (const item of ordered) setCardDates(item.card, item.row, order);
-      grid.append(...ordered.map((item) => item.card));
+      for (const item of ordered) setListedDates(item.node, item.row, order);
+      mount.append(...ordered.map((item) => item.node));
     };
+    remount();
     arrange();
+    // Held because a reader who switches to the cards after this resolves gets
+    // cards built too late to have been decorated by it.
+    let sourceAvailability = null;
+    const decorateListed = () => {
+      // A row carries no source control to decorate; the cards do.
+      if (view !== "cards" || !sourceAvailability) return;
+      decorateCardSet(nodes, entries, sourceAvailability, "Landing card");
+    };
     void availabilityPromise.then((availability) => {
-      decorateCardSet(cards, entries, availability, "Landing card");
+      sourceAvailability = availability;
+      decorateListed();
     }).catch((error) => {
       console.warn(`Landing card source availability could not be applied: ${error.message}`);
     });
@@ -657,17 +771,17 @@ async function renderIndex() {
       const dates = dayWindow({ from: fromControl?.value, to: toControl?.value });
       let shown = 0;
       let oldest = null;
-      for (const { card, row } of listed) {
+      for (const { node, row } of listed) {
         const day = orderedDay(row, order);
         if (oldest === null || day < oldest) oldest = day;
         const visible =
-          (trust === "all" || card.dataset.trust === trust) &&
-          (!arxivValue || (!arxivInvalid && card.dataset.arxiv.split(" ").includes(arxivValue))) &&
+          (trust === "all" || node.dataset.trust === trust) &&
+          (!arxivValue || (!arxivInvalid && node.dataset.arxiv.split(" ").includes(arxivValue))) &&
           (!mscValue ||
             (!mscInvalid &&
-              card.dataset.msc.split(" ").some((code) => code.startsWith(mscValue)))) &&
+              node.dataset.msc.split(" ").some((code) => code.startsWith(mscValue)))) &&
           withinWindow(day, dates);
-        card.hidden = !visible;
+        node.hidden = !visible;
         if (visible) shown += 1;
       }
       const classificationQuery = [
@@ -726,6 +840,39 @@ async function renderIndex() {
       arrange();
       update();
     });
+    // Deliberately not the .filter class the dependency buttons use: those are
+    // collected by it, and a view is not one of the things they narrow.
+    const viewButtons = [...document.querySelectorAll(".view-button")];
+    const markViewButtons = () => {
+      for (const candidate of viewButtons) {
+        const active = candidate.dataset.view === view;
+        candidate.classList.toggle("active", active);
+        candidate.setAttribute("aria-pressed", String(active));
+      }
+    };
+    markViewButtons();
+    for (const button of viewButtons) {
+      button.addEventListener("click", () => {
+        if (button.dataset.view === view) return;
+        view = button.dataset.view;
+        markViewButtons();
+        // A node cannot be carried across: a card and a row are different
+        // elements. So everything a node was given is given again -- the hover
+        // preview registration happens as each is built, and the availability
+        // answer is reapplied from the one already held.
+        statementPreview.close();
+        nodes = buildNodes();
+        for (const [index, item] of listed.entries()) item.node = nodes[index];
+        remount();
+        arrange();
+        decorateListed();
+        update();
+        const address = new URL(window.location.href);
+        if (view === DEFAULT_LANDING_VIEW) address.searchParams.delete("view");
+        else address.searchParams.set("view", view);
+        window.history.replaceState(null, "", address);
+      });
+    }
     document.querySelectorAll(".filter").forEach((button) => {
       button.addEventListener("click", () => {
         trust = button.dataset.trust;

--- a/assets/app.js
+++ b/assets/app.js
@@ -72,18 +72,22 @@ function el(tag, className, text) {
 }
 
 /**
- * One abstract as a paragraph, with the submitter's own code spans kept apart
- * from their prose.
+ * One abstract as a paragraph, with the submitter's own code spans and the
+ * mathematics in their sentences each kept apart from the prose.
  *
  * Both surfaces that show an abstract build it here, so a card and an entry
- * page mark the same runs. Each run is appended as text or as a `code`
- * element, never as markup, which is what keeps a submitter's abstract unable
- * to introduce any.
+ * page mark the same runs. A span a submitter marked is `code`; an expression
+ * found by its operators is not, because this page found it rather than being
+ * told, and saying `code` would claim otherwise. Each run is appended as text
+ * or as one element, never as markup, which is what keeps a submitter's
+ * abstract unable to introduce any.
  */
 function abstractParagraph(className, text) {
   const paragraph = el("p", className);
   for (const segment of abstractSegments(text)) {
-    paragraph.append(segment.code ? el("code", "", segment.text) : segment.text);
+    if (segment.kind === "code") paragraph.append(el("code", "", segment.text));
+    else if (segment.kind === "math") paragraph.append(el("span", "expression", segment.text));
+    else paragraph.append(segment.text);
   }
   return paragraph;
 }

--- a/assets/app.js
+++ b/assets/app.js
@@ -386,7 +386,7 @@ const DEFAULT_LANDING_VIEW = "table";
  * chosen view is then a link someone can send, and this page goes on keeping
  * nothing about whoever is reading it.
  */
-export function requestedLandingView(search) {
+function requestedLandingView(search) {
   const value = new URLSearchParams(search).get("view");
   return LANDING_VIEWS.has(value) ? value : DEFAULT_LANDING_VIEW;
 }
@@ -682,12 +682,14 @@ async function renderIndex() {
       grid.append(table);
     };
     /**
-     * The cards, in the order asked for, dated by the day that order keys on.
+     * The listed results, in the order asked for, dated by the day that order
+     * keys on.
      *
-     * Appending a card already in the grid moves it, so this rearranges the
-     * cards rather than rebuilding them: a rebuilt card would lose its hover
+     * Appending a node already in the grid moves it, so this rearranges what is
+     * there rather than rebuilding it: a rebuilt card would lose its hover
      * preview registration and whatever the availability answer decorated it
-     * with.
+     * with, and a rebuilt row would lose the registration too. Changing view is
+     * the one thing that does rebuild, and puts both back.
      */
     const arrange = () => {
       statementPreview.close();

--- a/assets/presentation-text.mjs
+++ b/assets/presentation-text.mjs
@@ -28,24 +28,63 @@ export function presentationAbstract(entry) {
 // break, so an unpaired tick costs at most its own line.
 const CODE_SPAN = /`([^`\n]+)`/g;
 
+// Most submitters mark nothing, and write their mathematics into the sentence:
+// "a colour count mu ≥ 2; and a target order type theta = omega^alpha with
+// alpha > 0". Set those apart too -- but find them by their operators, never by
+// deciding which words are variables. "kappa" alone stays prose here, because a
+// page that restyles a bare word has asserted something about a submitter's
+// prose that the submitter did not.
+//
+// An atom is what can stand either side of an operator.
+const ATOM =
+  "[A-Za-z0-9_'\\u0370-\\u03FF\\u2100-\\u214F\\u2070-\\u209C\\u{1D400}-\\u{1D7FF}]";
+// These mean one thing wherever they appear, so they may bind tightly: x^2.
+const TIGHT =
+  "[=^\\u2190\\u2192\\u21A6\\u2208\\u2209\\u2260\\u2261\\u2264\\u2265" +
+  "\\u2282\\u2286\\u2287\\u2200\\u2203\\u2227\\u2228\\u2248\\u222A\\u2229\\u00D7\\u00B1]";
+// `<` and `>` do not. Mathematicians write inner products as <x*y, z>, and
+// reading those as comparisons cut the notation at the wrong places and pulled
+// the words either side of it in: "the inner product <x*y" and "v> equals".
+// Spaces are what separate the comparison from the bracket, so only a spaced
+// one counts. Deliberately absent for the same reason: / + - * : , all of which
+// carry prose ("a Lean 4 / Mathlib development", "compact--Hausdorff").
+const EXPRESSION = new RegExp(
+  `${ATOM}+(?:(?:\\s?${TIGHT}\\s?|\\s[<>]\\s)${ATOM}+)+`,
+  "gu",
+);
+
+function withExpressions(text, segments) {
+  let read = 0;
+  for (const match of text.matchAll(EXPRESSION)) {
+    if (match.index > read) {
+      segments.push({ kind: "prose", text: text.slice(read, match.index) });
+    }
+    segments.push({ kind: "math", text: match[0] });
+    read = match.index + match[0].length;
+  }
+  if (read < text.length) segments.push({ kind: "prose", text: text.slice(read) });
+}
+
 /**
- * One abstract as alternating prose and code runs, in order.
+ * One abstract as prose, marked code, and mathematical expressions, in order.
  *
- * Returns `[{ code, text }]`, never empty text, so a caller appends each run
- * as a text node or a `code` element and nothing else. Callers build the DOM:
- * the runs carry no markup, which is what keeps a submitter's text incapable
- * of introducing any.
+ * Returns `[{ kind, text }]` with `kind` one of "prose", "code" or "math", and
+ * never empty text, so a caller appends each run as a text node or as one
+ * element. Callers build the DOM: the runs carry no markup, which is what keeps
+ * a submitter's text incapable of introducing any.
+ *
+ * A submitter's own code span wins over anything found inside it: the marks
+ * they wrote are read first, and expressions are looked for only in what is
+ * left over.
  */
 export function abstractSegments(text) {
   const segments = [];
   let read = 0;
   for (const match of text.matchAll(CODE_SPAN)) {
-    if (match.index > read) {
-      segments.push({ code: false, text: text.slice(read, match.index) });
-    }
-    segments.push({ code: true, text: match[1] });
+    if (match.index > read) withExpressions(text.slice(read, match.index), segments);
+    segments.push({ kind: "code", text: match[1] });
     read = match.index + match[0].length;
   }
-  if (read < text.length) segments.push({ code: false, text: text.slice(read) });
+  if (read < text.length) withExpressions(text.slice(read), segments);
   return segments;
 }

--- a/assets/presentation-text.mjs
+++ b/assets/presentation-text.mjs
@@ -11,3 +11,41 @@ export function presentationAbstract(entry) {
   if (SUPPRESSED_ABSTRACTS.has(key)) return "";
   return entry.abstract;
 }
+
+// Submitters already mark identifiers in an abstract the way they would
+// anywhere else, with Markdown code spans -- 38 of them across the published
+// set, holding things like `Polynomial.roots_countP_pos_le_signVariations` and
+// `ℤ × ℤ`. Rendering the abstract verbatim showed the reader the backticks as
+// punctuation and left the identifier in the same face as the prose around it,
+// so the one thing the submitter did say about their own text was the one
+// thing the page dropped.
+//
+// This reads that delimiter and nothing else. It is not a Markdown parser and
+// must not become one: an abstract is a submitter's plain text, and every
+// further construct guessed at here is the page deciding what their prose
+// meant. A run with no closing backtick stays prose, backtick and all, rather
+// than swallowing the rest of the abstract, and a span never crosses a line
+// break, so an unpaired tick costs at most its own line.
+const CODE_SPAN = /`([^`\n]+)`/g;
+
+/**
+ * One abstract as alternating prose and code runs, in order.
+ *
+ * Returns `[{ code, text }]`, never empty text, so a caller appends each run
+ * as a text node or a `code` element and nothing else. Callers build the DOM:
+ * the runs carry no markup, which is what keeps a submitter's text incapable
+ * of introducing any.
+ */
+export function abstractSegments(text) {
+  const segments = [];
+  let read = 0;
+  for (const match of text.matchAll(CODE_SPAN)) {
+    if (match.index > read) {
+      segments.push({ code: false, text: text.slice(read, match.index) });
+    }
+    segments.push({ code: true, text: match[1] });
+    read = match.index + match[0].length;
+  }
+  if (read < text.length) segments.push({ code: false, text: text.slice(read) });
+  return segments;
+}

--- a/assets/statement-preview.mjs
+++ b/assets/statement-preview.mjs
@@ -213,8 +213,13 @@ export function createStatementPreview({
     }, openDelayMs);
   }
 
+  // What makes a link previewable is that a surface registered it, not what
+  // wraps it: the cards put their title in an h3 and the table puts it in a
+  // cell, and matching the markup meant the table's titles silently had no
+  // preview. The registration below is the check that was always doing the
+  // work -- every other link on a card is absent from it.
   function titleLink(node) {
-    const link = node?.closest?.("h3 > a");
+    const link = node?.closest?.("a");
     return link && sources.has(link) ? link : null;
   }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -520,6 +520,106 @@ button:focus-visible {
   margin-top: 1rem;
 }
 
+/* The table view. Two hundred results are a list to be scanned before any one
+   of them is read, so a row carries what tells them apart and nothing else --
+   the abstract is what the cards are for. It scrolls inside its own container
+   rather than widening the page, because a long title and a long author list
+   are both ordinary here. */
+.entry-table-view {
+  display: block;
+  overflow-x: auto;
+}
+
+.entry-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: .92rem;
+}
+
+.entry-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: .5rem .7rem;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper);
+  color: var(--muted);
+  font: bold .72rem/1.3 var(--sans);
+  letter-spacing: .06em;
+  text-align: left;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.entry-table td {
+  padding: .55rem .7rem;
+  border-bottom: 1px solid var(--token-line);
+  vertical-align: top;
+}
+
+.entry-row:hover td {
+  background: var(--shade);
+}
+
+.row-result {
+  min-width: 22rem;
+  font-size: 1rem;
+}
+
+.row-authors {
+  min-width: 10rem;
+  color: var(--muted);
+}
+
+.row-dependencies,
+.row-registered {
+  color: var(--muted);
+  font: .8rem/1.4 var(--sans);
+}
+
+.row-dependencies {
+  white-space: nowrap;
+}
+
+/* A result has two dates whenever its latest version is not its first, and
+   which of them leads is what the order control decides. Both are shown, one
+   per line: run together on a single nowrap line they read as one date and
+   pushed the column off the page. */
+.row-registered span {
+  display: block;
+  white-space: nowrap;
+}
+
+.row-registered .entry-origin-date {
+  color: var(--faint);
+  font-size: .92em;
+}
+
+.view-switch {
+  display: flex;
+  gap: .4rem;
+  align-items: baseline;
+}
+
+.view-button {
+  padding: .25rem .7rem;
+  border: 1px solid var(--line);
+  background: var(--control);
+  color: var(--ink);
+  font: .8rem var(--sans);
+  cursor: pointer;
+}
+
+.view-button:hover {
+  background: var(--control-hover);
+}
+
+.view-button.active {
+  border-color: var(--ink);
+  background: var(--ink);
+  color: var(--paper);
+}
+
 .entry-card {
   padding: 1.15rem .2rem 1.25rem;
   border-bottom: 1px solid var(--line);

--- a/assets/style.css
+++ b/assets/style.css
@@ -557,6 +557,30 @@ button:focus-visible {
   overflow-wrap: anywhere;
 }
 
+/* An abstract is the submitter's plain text, and several lay their argument
+   out over lines -- a claim, its numbered hypotheses indented under it, then
+   the conclusion. Collapsing that whitespace ran the hypotheses together into
+   one paragraph, so the structure the submitter wrote is kept rather than
+   reflowed. Which line breaks were meant as structure and which were only
+   wrapping is not decidable from the text, so neither is guessed at here. */
+.lede,
+.card-abstract {
+  white-space: pre-wrap;
+}
+
+/* Set an identifier apart from the sentence holding it, so a reader skimming
+   an abstract can see where the prose stops and a name from the formalization
+   starts. Quieter than the token lists, which are a surface of their own
+   rather than a few words inside a paragraph. */
+.lede code,
+.card-abstract code {
+  padding: .05em .3em;
+  border-radius: 3px;
+  background: var(--shade);
+  font-size: .88em;
+  overflow-wrap: anywhere;
+}
+
 .card-meta {
   display: flex;
   gap: .75rem 2rem;

--- a/assets/style.css
+++ b/assets/style.css
@@ -31,7 +31,16 @@
   --max: 64rem;
   --serif: Georgia, "Times New Roman", Times, serif;
   --sans: Arial, Helvetica, sans-serif;
-  --mono: "Courier New", Courier, monospace;
+  /* Lean output is Unicode-dense: Greek, ℕ/ℝ, ∀ ∃ ≤ → ∘ ⊢, and ⋯ where the
+     pretty-printer elided a subterm. Courier New is missing much of that, and a
+     missing glyph is not a visible failure: the browser silently substitutes
+     another face for those characters alone, so ∀ and ⋯ arrived in a different
+     weight beside identifiers drawn by Courier New. Font matching walks this
+     list per character rather than once per element, so the families that can
+     draw those glyphs have to be named here and not left to the generic --
+     which on Windows resolves to Courier New again. */
+  --mono: ui-monospace, "SF Mono", Menlo, Consolas,
+          "DejaVu Sans Mono", "Liberation Mono", monospace;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/assets/style.css
+++ b/assets/style.css
@@ -203,8 +203,17 @@ h3 {
 }
 
 .hero-copy,
+/* An abstract is the longest stretch of prose on the site and the one a
+   reader actually reads, rather than scans. At the body's 1.45 it set nine
+   tight lines under the title, and a 72ch measure left it narrower than the
+   card showing the same text at 76ch. Give it the leading long-form prose
+   wants and the measure its sibling already used: a slightly longer line is
+   comfortable exactly when the leading grows with it, which is why these two
+   move together. */
 .lede {
-  max-width: 72ch;
+  max-width: 76ch;
+  font-size: 1.05rem;
+  line-height: 1.6;
 }
 
 .metric-row {
@@ -554,6 +563,7 @@ button:focus-visible {
 .card-abstract {
   max-width: 76ch;
   margin-bottom: .75rem;
+  line-height: 1.6;
   overflow-wrap: anywhere;
 }
 
@@ -912,7 +922,10 @@ footer {
 }
 
 .entry-heading h1 {
+  /* The global .2rem left a 2rem title sitting all but on top of the abstract,
+     so the two read as one block instead of a title and the text under it. */
   margin-top: .5rem;
+  margin-bottom: .75rem;
   font-size: 2rem;
   overflow-wrap: anywhere;
 }
@@ -1232,6 +1245,23 @@ body[data-page="not-found"] main a {
   margin-bottom: .2rem;
   padding-left: .7rem;
   border-left: 2px solid var(--caution);
+}
+
+/* Explanatory prose on an entry ran the full width of the page -- 104
+   characters to a line at the body's 1.45, twice the measure of the abstract
+   sitting above it -- so the same reader met two different typographies on one
+   page. Hold prose to a reading measure and give it the abstract's leading.
+   What is not prose keeps the width it needs: token lists, detail rows, the
+   render frame, and the row of source controls below. */
+.entry-page p,
+.entry-page .reason-list li,
+.entry-page .provenance-sources li {
+  max-width: 76ch;
+  line-height: 1.6;
+}
+
+.entry-page .challenge-links {
+  max-width: none;
 }
 
 .challenge-frame {

--- a/assets/style.css
+++ b/assets/style.css
@@ -582,6 +582,16 @@ button:focus-visible {
    an abstract can see where the prose stops and a name from the formalization
    starts. Quieter than the token lists, which are a surface of their own
    rather than a few words inside a paragraph. */
+/* An expression this page found by its operators, rather than one a submitter
+   marked. The face is enough to separate it from the sentence around it; the
+   ground below is kept for the spans they marked themselves, so the stronger
+   signal stays with the stronger claim. */
+.lede .expression,
+.card-abstract .expression {
+  font-family: var(--mono);
+  font-size: .92em;
+}
+
 .lede code,
 .card-abstract code {
   padding: .05em .3em;

--- a/index.html
+++ b/index.html
@@ -51,6 +51,11 @@
         <div id="search-results" class="entry-grid" aria-live="polite"></div>
 
         <div class="toolbar">
+          <div class="view-switch" role="group" aria-label="Result view">
+            <span>View:</span>
+            <button class="view-button active" type="button" data-view="table" aria-pressed="true">Table</button>
+            <button class="view-button" type="button" data-view="cards" aria-pressed="false">Cards</button>
+          </div>
           <div class="filters" role="group" aria-label="Statement dependency filters">
             <span>Show:</span>
             <button class="filter active" type="button" data-trust="all" aria-pressed="true">All</button>

--- a/tests/appearance.test.js
+++ b/tests/appearance.test.js
@@ -90,6 +90,39 @@ test("all page colours are palette variables", () => {
   assert.deepEqual(literals, []);
 });
 
+// Every code surface routes through --mono, and the one that matters most is
+// the core-notation audit view: Lean writes it in Greek binder names, ∀ and →,
+// and the ⋯ it leaves where it elided a subterm. Courier New is missing several
+// of those, and the browser substituted another face for exactly those
+// characters, which is the finding that produced this stack. A covering family
+// has to be named for each platform, because the generic at the end of the list
+// is where a reader lands when none of the named ones is installed -- and on
+// Windows that generic resolves to Courier New again. Which faces Chromium
+// actually reaches for is asserted in the browser suite; this only holds the
+// declaration still.
+test("the monospace stack names a math-capable family on every platform", () => {
+  const [, declaration] = css.match(/--mono:\s*([^;]+);/) ?? [];
+  assert.ok(declaration, "style.css declares no --mono stack");
+  const families = declaration
+    .split(",")
+    .map((family) => family.trim().replace(/^"|"$/g, ""));
+  assert.equal(families.at(-1), "monospace", "--mono must end in the generic family");
+  assert.ok(
+    !families.includes("Courier New"),
+    "Courier New carries no Greek letters or mathematical operators",
+  );
+  for (const [platform, candidates] of [
+    ["Apple", ["ui-monospace", "SF Mono", "Menlo"]],
+    ["Windows", ["Consolas", "Cascadia Mono"]],
+    ["Linux", ["DejaVu Sans Mono", "Liberation Mono"]],
+  ]) {
+    assert.ok(
+      candidates.some((family) => families.includes(family)),
+      `--mono names no math-capable family for ${platform}`,
+    );
+  }
+});
+
 // Driven by the build manifest rather than a list written here: a page added
 // to the deployment and forgotten by this test is exactly the page that ships
 // without the chrome colours, and `subject.html` had already been missed once.

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -53,6 +53,7 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
             "A browser confinement fixture for the registry, about the "
             "quasicoherent behaviour of a synthetic result.\n"
             "  It classifies `AddCircle (1 : \u211d)` by `\u2124` and notes a 90` turn.\n"
+            "  It holds for mu \u2265 2 and every n > 3, on 2^kappa.\n"
             "    (1) the first indented hypothesis\n"
             "    (2) the second indented hypothesis"
         ),

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -718,7 +718,12 @@ html, body {{ background: var(--palomar-paper); color: var(--palomar-ink); }}
                     {
                         "name": "Example.theorem",
                         "declaration": (
-                            "theorem Example.theorem : Eq Nat.zero Nat.zero"
+                            # Carries the glyph classes core notation actually
+                            # emits and Courier New cannot draw: a Greek binder
+                            # name, the quantifier and arrow, and the marker Lean
+                            # leaves where it elided a subterm.
+                            "theorem Example.theorem : "
+                            "∀ {α : Type u_1} (a b : α), Eq a b → Eq b ⋯"
                         ),
                     }
                 ],

--- a/tests/fixture_server.py
+++ b/tests/fixture_server.py
@@ -46,7 +46,16 @@ def entry(identifier: str, lines: int, version: int = 1) -> dict:
         "version": version,
         "status": "registered",
         "title": f"Fixture {identifier} version {version}",
-        "abstract": "A browser confinement fixture for the registry, about the quasicoherent behaviour of a synthetic result.",
+        # Carries what submitters actually write: an identifier they marked
+        # as a code span, a tick they left unpaired, and a claim laid out
+        # over indented lines rather than in one paragraph.
+        "abstract": (
+            "A browser confinement fixture for the registry, about the "
+            "quasicoherent behaviour of a synthetic result.\n"
+            "  It classifies `AddCircle (1 : \u211d)` by `\u2124` and notes a 90` turn.\n"
+            "    (1) the first indented hypothesis\n"
+            "    (2) the second indented hypothesis"
+        ),
         "authors": [{
             "name": "Example",
             "orcid": "0000-0002-1825-0097",

--- a/tests/presentation-text.test.mjs
+++ b/tests/presentation-text.test.mjs
@@ -40,16 +40,16 @@ test("a submitter's code spans are separated from their prose", () => {
   assert.deepEqual(
     abstractSegments("classifies `AddCircle (1 : ℝ)` by `ℤ` today"),
     [
-      { code: false, text: "classifies " },
-      { code: true, text: "AddCircle (1 : ℝ)" },
-      { code: false, text: " by " },
-      { code: true, text: "ℤ" },
-      { code: false, text: " today" },
+      { kind: "prose", text: "classifies " },
+      { kind: "code", text: "AddCircle (1 : ℝ)" },
+      { kind: "prose", text: " by " },
+      { kind: "code", text: "ℤ" },
+      { kind: "prose", text: " today" },
     ],
   );
   assert.deepEqual(
     abstractSegments("no marks at all"),
-    [{ code: false, text: "no marks at all" }],
+    [{ kind: "prose", text: "no marks at all" }],
   );
 });
 
@@ -60,19 +60,19 @@ test("a submitter's code spans are separated from their prose", () => {
 test("an unpaired backtick stays prose and takes no more than its own line", () => {
   assert.deepEqual(
     abstractSegments("an unclosed `tick stays put"),
-    [{ code: false, text: "an unclosed `tick stays put" }],
+    [{ kind: "prose", text: "an unclosed `tick stays put" }],
   );
   assert.deepEqual(
     abstractSegments("opens `here\nand closes `there` below"),
     [
-      { code: false, text: "opens `here\nand closes " },
-      { code: true, text: "there" },
-      { code: false, text: " below" },
+      { kind: "prose", text: "opens `here\nand closes " },
+      { kind: "code", text: "there" },
+      { kind: "prose", text: " below" },
     ],
   );
   assert.deepEqual(
     abstractSegments("empty `` marks are not a code run"),
-    [{ code: false, text: "empty `` marks are not a code run" }],
+    [{ kind: "prose", text: "empty `` marks are not a code run" }],
   );
 });
 
@@ -92,7 +92,7 @@ test("the runs reassemble into exactly the abstract that was read", () => {
   ]) {
     assert.equal(
       abstractSegments(abstract)
-        .map((segment) => (segment.code ? `\`${segment.text}\`` : segment.text))
+        .map((segment) => (segment.kind === "code" ? `\`${segment.text}\`` : segment.text))
         .join(""),
       abstract,
     );
@@ -107,4 +107,71 @@ test("no run is empty", () => {
       assert.ok(segment.text.length > 0, `empty run from ${JSON.stringify(abstract)}`);
     }
   }
+});
+
+const kinds = (text) =>
+  abstractSegments(text).map((segment) => [segment.kind, segment.text]);
+const mathIn = (text) =>
+  abstractSegments(text).filter((s) => s.kind === "math").map((s) => s.text);
+
+// Most submitters mark nothing and write the mathematics into the sentence.
+// These are found by their operators, so the reader gets the same separation
+// without the page having to decide which words are variables.
+test("mathematics written into a sentence is found by its operators", () => {
+  assert.deepEqual(
+    mathIn(
+      "Fix an ordinal kappa; a colour count mu ≥ 2; and a target order type " +
+        "theta = omega^alpha with alpha > 0, on 2^kappa.",
+    ),
+    ["mu ≥ 2", "theta = omega^alpha", "alpha > 0", "2^kappa"],
+  );
+  // "kappa" on its own is left alone: a bare word carries no operator, and
+  // restyling it would assert something about the prose that was never said.
+  assert.deepEqual(
+    kinds("Fix an ordinal kappa")[0],
+    ["prose", "Fix an ordinal kappa"],
+  );
+});
+
+// Mathematicians write inner products as <x*y, z>. Reading those brackets as
+// comparisons cut the notation at the wrong places and pulled in the words
+// either side -- "the inner product <x*y" and "v> equals" -- so a comparison
+// counts only when it is spaced, which is what separates the two in practice.
+test("angle brackets around a term are not read as comparisons", () => {
+  assert.deepEqual(mathIn("the associativity of the inner product <x*y, z> = <y, x*z>"), []);
+  assert.deepEqual(mathIn("the supremum of <1,v>^2 / <Av,v> equals c*"), []);
+  // A spaced comparison is still found.
+  assert.deepEqual(mathIn("every r_n < 1 and n > 10 hold"), ["r_n < 1", "n > 10"]);
+});
+
+// Identifiers, citations and versions carry dots, slashes and digits but no
+// operator, and each of these appears in real published abstracts.
+test("citations, versions and prose punctuation are not mathematics", () => {
+  for (const text of [
+    "A Lean 4 / Mathlib development of the companion paper",
+    "(doi:10.13140/RG.2.2.10727.82081)",
+    "arXiv:2602.17613",
+    "the pinned Mathlib revision (Mathlib v4.34.0-rc1)",
+    "proves compact--Hausdorff and discrete sufficient cases",
+    "the sequence A061419, which is therefore not holonomic",
+  ]) {
+    assert.deepEqual(mathIn(text), [], text);
+  }
+});
+
+// A submitter's own mark is the stronger statement, so it is read first and an
+// expression is looked for only in what is left over. A code span is never
+// reopened to look inside it.
+test("a submitter's marked span outranks anything found inside it", () => {
+  assert.deepEqual(
+    kinds("classifies `n ≥ 3` by `ℤ` where m ≥ 2"),
+    [
+      ["prose", "classifies "],
+      ["code", "n ≥ 3"],
+      ["prose", " by "],
+      ["code", "ℤ"],
+      ["prose", " where "],
+      ["math", "m ≥ 2"],
+    ],
+  );
 });

--- a/tests/presentation-text.test.mjs
+++ b/tests/presentation-text.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { presentationAbstract } from "../assets/presentation-text.mjs";
+import { abstractSegments, presentationAbstract } from "../assets/presentation-text.mjs";
 
 test("the accidentally published AI review synthesis is not presentation text", () => {
   assert.equal(
@@ -31,4 +31,80 @@ test("submitter-authored abstracts and later corrected versions remain visible",
     }),
     "A corrected submitter-authored description.",
   );
+});
+
+// Submitters mark identifiers in an abstract with Markdown code spans, and the
+// page used to show the backticks to the reader as punctuation. These are the
+// runs it reads, and the ones it deliberately leaves alone.
+test("a submitter's code spans are separated from their prose", () => {
+  assert.deepEqual(
+    abstractSegments("classifies `AddCircle (1 : ℝ)` by `ℤ` today"),
+    [
+      { code: false, text: "classifies " },
+      { code: true, text: "AddCircle (1 : ℝ)" },
+      { code: false, text: " by " },
+      { code: true, text: "ℤ" },
+      { code: false, text: " today" },
+    ],
+  );
+  assert.deepEqual(
+    abstractSegments("no marks at all"),
+    [{ code: false, text: "no marks at all" }],
+  );
+});
+
+// An abstract is plain text a submitter wrote, not a document this page parses.
+// A tick they used for something else must cost them that tick and nothing
+// more: swallowing the rest of the abstract into one code run would hide the
+// text, and hiding a submitter's words is worse than showing a stray mark.
+test("an unpaired backtick stays prose and takes no more than its own line", () => {
+  assert.deepEqual(
+    abstractSegments("an unclosed `tick stays put"),
+    [{ code: false, text: "an unclosed `tick stays put" }],
+  );
+  assert.deepEqual(
+    abstractSegments("opens `here\nand closes `there` below"),
+    [
+      { code: false, text: "opens `here\nand closes " },
+      { code: true, text: "there" },
+      { code: false, text: " below" },
+    ],
+  );
+  assert.deepEqual(
+    abstractSegments("empty `` marks are not a code run"),
+    [{ code: false, text: "empty `` marks are not a code run" }],
+  );
+});
+
+// Every run is reassembled by a caller as text or as a `code` element, so the
+// runs must carry the whole abstract and nothing but the abstract: a segmenter
+// that dropped or duplicated a character would quietly rewrite a record. Put
+// the delimiters back around the code runs and the original must return.
+test("the runs reassemble into exactly the abstract that was read", () => {
+  for (const abstract of [
+    "plain",
+    "`leads` and trails `here`",
+    "``",
+    "`",
+    "a `b` c `d` e",
+    "line one\n  indented `code` two",
+    "",
+  ]) {
+    assert.equal(
+      abstractSegments(abstract)
+        .map((segment) => (segment.code ? `\`${segment.text}\`` : segment.text))
+        .join(""),
+      abstract,
+    );
+  }
+});
+
+// A run with no text would reach the caller as an empty text node or, worse, an
+// empty `code` element with a ground and padding and nothing inside it.
+test("no run is empty", () => {
+  for (const abstract of ["`a`", "a `b`", "`a` b", "``", ""]) {
+    for (const segment of abstractSegments(abstract)) {
+      assert.ok(segment.text.length > 0, `empty run from ${JSON.stringify(abstract)}`);
+    }
+  }
 });

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -694,6 +694,45 @@ test("an unversioned entry link resolves to the current immutable URL", async ({
   );
 });
 
+// An entry page is read, not scanned, and it used to offer the reader two
+// typographies at once: an abstract held to 72 characters a line, and the
+// explanations under it running the full 1024px to 104. Both sat at the body's
+// 1.45. This measures what the page actually renders rather than checking the
+// rules that produce it, and it walks the prose it finds rather than a list
+// written here, so a paragraph added later without a measure is caught too.
+test("prose on an entry page holds one reading measure and leading", async ({ page }) => {
+  await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}`);
+  await expect(page.locator("p.lede")).toBeVisible();
+
+  const loose = await page.evaluate(() => {
+    const characterWidth = (node) => {
+      const probe = document.createElement("span");
+      probe.textContent = "0".repeat(100);
+      probe.style.cssText = "position:absolute;visibility:hidden;white-space:pre";
+      node.append(probe);
+      const width = probe.getBoundingClientRect().width / 100;
+      probe.remove();
+      return width;
+    };
+    return [...document.querySelectorAll("main p, main li")]
+      // Rows of controls are not prose, and a short line cannot be too long.
+      .filter((node) => !node.classList.contains("challenge-links"))
+      .filter((node) => (node.textContent || "").trim().length > 110)
+      .map((node) => {
+        const style = getComputedStyle(node);
+        return {
+          name: node.className || node.tagName,
+          characters: Math.round(node.getBoundingClientRect().width / characterWidth(node)),
+          leading: Number(
+            (parseFloat(style.lineHeight) / parseFloat(style.fontSize)).toFixed(2),
+          ),
+        };
+      })
+      .filter((row) => row.characters > 80 || row.leading < 1.55);
+  });
+  expect(loose, "entry prose outside a comfortable measure or leading").toEqual([]);
+});
+
 // Submitters mark identifiers in an abstract with Markdown code spans, and the
 // page used to render the abstract verbatim: the reader got the backticks as
 // punctuation, and the identifier in the same face as the sentence holding it.

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -694,6 +694,42 @@ test("an unversioned entry link resolves to the current immutable URL", async ({
   );
 });
 
+// Submitters mark identifiers in an abstract with Markdown code spans, and the
+// page used to render the abstract verbatim: the reader got the backticks as
+// punctuation, and the identifier in the same face as the sentence holding it.
+// Several submitters also lay a claim out over indented lines, which collapsing
+// whitespace ran together into one paragraph.
+test("an abstract keeps the submitter's code spans and their line structure", async ({ page }) => {
+  await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}`);
+  const lede = page.locator("p.lede");
+  await expect(lede).toBeVisible();
+
+  await expect(lede.locator("code")).toHaveText(["AddCircle (1 : ℝ)", "ℤ"]);
+  // The marks are read, so they are gone from what the reader sees -- but only
+  // the paired ones. A tick a submitter used for something else is their text,
+  // and stays.
+  await expect(lede).toContainText("It classifies AddCircle (1 : ℝ) by ℤ");
+  await expect(lede).toContainText("a 90` turn");
+
+  // Rendered, not merely present: an identifier that reads as prose is the
+  // defect this closes.
+  const inline = lede.locator("code").first();
+  await expect(inline).toHaveCSS("font-family", /mono/i);
+  const [codeGround, ledeGround] = await Promise.all([
+    inline.evaluate((n) => getComputedStyle(n).backgroundColor),
+    lede.evaluate((n) => getComputedStyle(n).backgroundColor),
+  ]);
+  expect(codeGround, "an inline code span sits on the same ground as the prose")
+    .not.toBe(ledeGround);
+
+  // The indented hypotheses are the submitter's structure, and each has to
+  // start its own line rather than being folded into the sentence above it.
+  await expect(lede).toHaveCSS("white-space", "pre-wrap");
+  const lines = (await lede.textContent()).split("\n").map((line) => line.trimEnd());
+  expect(lines).toContain("    (1) the first indented hypothesis");
+  expect(lines).toContain("    (2) the second indented hypothesis");
+});
+
 test("an entry answers its reader's first three questions first", async ({ page }) => {
   await page.goto(`/entry.html?id=PALOMAR-2026-07-29-000123&database=${database}`);
   await expect(page.locator(".entry-evidence")).toBeVisible();

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -1598,7 +1598,7 @@ test("larger Challenge falls back to the dedicated wrapper", async ({ page }) =>
   await audit.locator("summary").click();
   const auditSource = audit.locator(".challenge-audit-declaration pre");
   await expect(auditSource).toHaveText(
-    "theorem Example.theorem : Eq Nat.zero Nat.zero",
+    "theorem Example.theorem : ∀ {α : Type u_1} (a b : α), Eq a b → Eq b ⋯",
   );
   await expect(auditSource).toHaveAttribute("tabindex", "0");
   await expect(audit.locator(".challenge-audit-declaration")).toHaveAttribute(
@@ -1617,6 +1617,40 @@ test("larger Challenge falls back to the dedicated wrapper", async ({ page }) =>
   await expect(audit.locator(".challenge-audit-limits")).toContainText(
     "omitted subterm with ⋯",
   );
+  // The audit view is where a reader checks notation, and Lean writes it in
+  // Greek, quantifiers, arrows, and the ⋯ it leaves where it elided a subterm.
+  // A family that cannot draw those does not fail visibly: the browser quietly
+  // substitutes another face for the characters it is missing, so ∀ arrives in
+  // a different weight beside identifiers drawn by the declared font. Advance
+  // widths do not catch it, because the substitute is monospaced too. Ask
+  // Chromium which platform fonts it actually reached for instead.
+  //
+  // The fixture declaration deliberately stays inside the repertoire a
+  // monospace family is expected to carry, which is what one face here means.
+  // Published entries do reach past it -- a statement naming 𝒜 pulls in a math
+  // face no general-purpose monospace font covers -- and that is a property of
+  // the Mathematical Alphanumeric Symbols block, not a defect in the stack, so
+  // it is deliberately not what this fixture asks about.
+  const client = await page.context().newCDPSession(page);
+  await client.send("DOM.enable");
+  await client.send("CSS.enable");
+  const { root } = await client.send("DOM.getDocument");
+  const { nodeId } = await client.send("DOM.querySelector", {
+    nodeId: root.nodeId,
+    selector: ".challenge-audit-declaration pre",
+  });
+  const { fonts } = await client.send("CSS.getPlatformFontsForNode", { nodeId });
+  await client.detach();
+  // A node that rendered nothing reports nothing, which would otherwise agree
+  // with this by drawing no glyphs at all.
+  expect(
+    fonts.reduce((total, font) => total + font.glyphCount, 0),
+    "the audit view drew no glyphs to measure",
+  ).toBeGreaterThan(0);
+  expect(
+    fonts.map((font) => `${font.familyName} (${font.glyphCount} glyphs)`).sort(),
+    "the audit view was drawn from more than one face: --mono is missing glyphs Lean prints",
+  ).toHaveLength(1);
   await audit.locator("summary").click();
   await expect(audit.locator(".challenge-audit-declaration")).not.toBeVisible();
   const dependencies = page.getByRole("link", { name: "Inspect statement dependencies" });

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -89,7 +89,7 @@ const currentEntrySchema = Number(
 
 test("the registry follows the browser's light and dark preference", async ({ page }) => {
   await page.emulateMedia({ colorScheme: "dark" });
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await expect(page.locator("html")).toHaveCSS("background-color", "rgb(16, 18, 22)");
   await expect(page.locator("body")).toHaveCSS("color", "rgb(232, 234, 238)");
   await expect(page.locator(".toolbar")).toHaveCSS("background-color", "rgb(28, 32, 39)");
@@ -198,7 +198,7 @@ test("long reference pages expose an adaptive table of contents", async ({ page 
 });
 
 test("search mode removes unresolved hero furniture and restores it on clear", async ({ page }) => {
-  await page.goto(`/?database=${database}&q=synthetically`);
+  await page.goto(`/?view=cards&database=${database}&q=synthetically`);
   await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
   await expect(page.locator("body")).toHaveClass(/registry-searching/);
   await expect(page.locator(".hero-copy")).toBeHidden();
@@ -215,6 +215,65 @@ test("search mode removes unresolved hero furniture and restores it on clear", a
   await expect(page.locator("#metric-projects")).toHaveText("1");
 });
 
+// Two hundred results are a list to be scanned before any one of them is read,
+// so the landing arrives as a table and the cards, which lead with the
+// abstract, are the alternative. The choice rides in the URL rather than on the
+// reader's device: the registry deep-links its order and its filters the same
+// way, and this page keeps nothing about whoever is reading it.
+test("the landing arrives as a table, and the cards are one link away", async ({ page }) => {
+  await page.goto(`/?database=${database}`);
+  const rows = page.locator("#entry-grid tr.entry-row");
+  await expect(rows.first()).toBeVisible();
+  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(0);
+  await expect(page.locator("#entry-grid th")).toHaveText([
+    "Result", "Authors", "Subjects", "Dependencies", "Registered",
+  ]);
+  await expect(page.getByRole("button", { name: "Table" })).toHaveAttribute("aria-pressed", "true");
+
+  // A row carries less than a card, so the rendering behind its title is worth
+  // more here, not less: the same hover preview has to reach it.
+  const listed = await rows.count();
+  await rows.first().locator("a").first().hover();
+  await expect(page.locator(".statement-preview")).toHaveCount(1);
+
+  await page.getByRole("button", { name: "Cards" }).click();
+  await expect(page.locator("#entry-grid .entry-card")).toHaveCount(listed);
+  await expect(page.locator("#entry-grid tr.entry-row")).toHaveCount(0);
+  // Linkable, so a reader can send the view they are reading in.
+  expect(new URL(page.url()).searchParams.get("view")).toBe("cards");
+
+  await page.getByRole("button", { name: "Table" }).click();
+  await expect(page.locator("#entry-grid tr.entry-row")).toHaveCount(listed);
+  // The default is the bare address rather than a parameter spelling it out.
+  expect(new URL(page.url()).searchParams.has("view")).toBe(false);
+
+  await page.goto(`/?view=cards&database=${database}`);
+  await expect(page.locator("#entry-grid .entry-card").first()).toBeVisible();
+  await expect(page.getByRole("button", { name: "Cards" })).toHaveAttribute("aria-pressed", "true");
+
+  // An unknown view is not an error a reader should meet; it is the default.
+  await page.goto(`/?view=nonsense&database=${database}`);
+  await expect(page.locator("#entry-grid tr.entry-row").first()).toBeVisible();
+});
+
+// The toolbar narrows the selection by reading data attributes off whichever
+// node is showing, so the rows have to carry what the cards carry.
+test("the toolbar narrows the table as it narrows the cards", async ({ page }) => {
+  await page.goto(`/?database=${database}`);
+  const rows = page.locator("#entry-grid tr.entry-row:visible");
+  await expect(rows.first()).toBeVisible();
+  const all = await rows.count();
+
+  await page.getByRole("button", { name: "Mathlib only" }).click();
+  const mathlibOnly = await rows.count();
+  expect(mathlibOnly).toBeGreaterThan(0);
+  expect(mathlibOnly).toBeLessThan(all);
+
+  // And the same narrowing survives being carried into the other view.
+  await page.getByRole("button", { name: "Cards" }).click();
+  await expect(page.locator("#entry-grid .entry-card:visible")).toHaveCount(mathlibOnly);
+});
+
 test("user-facing pages do not overflow narrow mobile viewports", async ({ page }) => {
   await page.route("**/database/recent.json", async (route) => {
     const response = await route.fetch();
@@ -227,7 +286,10 @@ test("user-facing pages do not overflow narrow mobile viewports", async ({ page 
   });
 
   const surfaces = [
-    { name: "registry", path: `/?database=${database}`, ready: ".entry-card" },
+    // Both landing views: the table is the default and the likelier of the two
+    // to be pushed wide, by a long title or a long list of authors.
+    { name: "registry table", path: `/?database=${database}`, ready: "tr.entry-row" },
+    { name: "registry cards", path: `/?view=cards&database=${database}`, ready: ".entry-card" },
     { name: "search", path: `/?database=${database}&q=synthetically`, ready: "#search-results .entry-card" },
     {
       name: "entry",
@@ -263,7 +325,7 @@ test("user-facing pages do not overflow narrow mobile viewports", async ({ page 
 
 test("navigation and action controls expose mobile-sized targets", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await expect(page.locator(".entry-card")).toHaveCount(2);
   await expectMinimumTargets(
     page.locator(
@@ -334,7 +396,7 @@ test("landing cards show the registration date and dated identifier", async ({ p
   // A landing record read is a regression even if its result happens to be
   // valid, so make one fail loudly instead of letting it hide in the fixture.
   await page.route("**/database/entries/*.json", (route) => route.abort());
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   const first = page.locator(".entry-card").first();
   await expect(first.locator(".entry-id")).toContainText("PALOMAR-2026-07-29-");
   await expect(first.locator(".entry-id")).toContainText("v2 · current");
@@ -382,7 +444,7 @@ test("landing cards show the registration date and dated identifier", async ({ p
 });
 
 test("card metadata is on the card, not behind a toggle", async ({ page }) => {
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   const card = page.locator(".entry-card").first();
 
   // Titles in this registry are repository names, so the authors and the
@@ -412,7 +474,7 @@ test("landing cards preserve the publisher's newest-first order", async ({ page 
     }));
     await route.fulfill({ response, json: recent });
   });
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
 
   // Recency and identifier order deliberately disagree. The DOM must follow
   // recent.json, whose order has already been validated as newest-first.
@@ -430,7 +492,7 @@ test("an unusable recent row is omitted without hiding its valid siblings", asyn
     await route.fulfill({ response, json: document });
   });
 
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await expect(page.locator("#entry-grid .entry-card")).toHaveCount(1);
   await expect(page.locator("#registry-warning")).toBeVisible();
   await expect(page.locator("#registry-warning")).toHaveText(
@@ -449,7 +511,7 @@ test("an entirely unusable recent projection is not reported as an empty registr
     await route.fulfill({ response, json: document });
   });
 
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await expect(page.locator("#entry-grid .entry-card")).toHaveCount(0);
   await expect(page.locator("#status")).toHaveClass(/warning/);
   await expect(page.locator("#status")).toContainText("registry entries could not be displayed");
@@ -461,7 +523,7 @@ test("an unavailable recent summary reports failure instead of emptiness", async
     route.fulfill({ status: 503, body: "temporarily unavailable" }),
   );
 
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
 
   await expect(page.locator("#status")).toContainText("The registry could not be loaded: 503");
   await expect(page.locator("#entry-grid .entry-card")).toHaveCount(0);
@@ -470,7 +532,7 @@ test("an unavailable recent summary reports failure instead of emptiness", async
 });
 
 test("registry entries can be filtered by arXiv and MSC classifications", async ({ page }) => {
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await expect(page.locator("#arxiv-query")).toBeVisible();
   await expect(page.locator("#msc-query")).toBeVisible();
   await expect(page.locator('#arxiv-options option[value="math.NT"]')).toHaveCount(1);
@@ -491,7 +553,7 @@ test("registry entries can be filtered by arXiv and MSC classifications", async 
 });
 
 test("an MSC filter matches every code beginning with what was typed", async ({ page }) => {
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await expect(page.locator(".entry-card:visible")).toHaveCount(2);
 
   // 000123 is 05C10, 000124 is 11N13.
@@ -522,7 +584,7 @@ test("an MSC filter matches every code beginning with what was typed", async ({ 
 });
 
 test("the registry can be ordered by when a result first entered it", async ({ page }) => {
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   // 000123 is a v2 registered on 2 August; 000124 is a v1 registered on 29
   // July, the same day 000123 first entered the registry.
   await expect(page.locator(".entry-card .entry-id")).toHaveText([
@@ -552,7 +614,7 @@ test("the registry can be ordered by when a result first entered it", async ({ p
 });
 
 test("a date range narrows the listing by the date it is ordered by", async ({ page }) => {
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await page.locator("#date-from").fill("2026-08-01");
   await expect(page.locator(".entry-card:visible")).toHaveCount(1);
   await expect(page.locator(".entry-card:visible")).toContainText("000123");
@@ -572,7 +634,7 @@ test("a date range narrows the listing by the date it is ordered by", async ({ p
 });
 
 test("a range that cannot be read, or cannot hold a day, matches nothing and says so", async ({ page }) => {
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await page.locator("#date-from").fill("2026-08-13");
   await page.locator("#date-to").fill("2026-08-02");
   await expect(page.locator(".entry-card:visible")).toHaveCount(0);
@@ -587,7 +649,7 @@ test("a range that cannot be read, or cannot hold a day, matches nothing and say
 });
 
 test("a range reaching past the newest results says what the page cannot answer for", async ({ page }) => {
-  await page.goto(`/?database=${database}&from=2026-01-01`);
+  await page.goto(`/?view=cards&database=${database}&from=2026-01-01`);
   await expect(page.locator("#date-from")).toHaveValue("2026-01-01");
   await expect(page.locator(".entry-card:visible")).toHaveCount(2);
   await expect(page.locator("#status")).toHaveText(
@@ -597,28 +659,28 @@ test("a range reaching past the newest results says what the page cannot answer 
 });
 
 test("an order and a range apply from a deep link", async ({ page }) => {
-  await page.goto(`/?database=${database}&order=registered&from=2026-07-29&to=2026-07-29`);
+  await page.goto(`/?view=cards&database=${database}&order=registered&from=2026-07-29&to=2026-07-29`);
   await expect(page.locator("#order-by")).toHaveValue("registered");
   await expect(page.locator(".entry-card:visible")).toHaveCount(2);
   await expect(page.locator(".entry-card").first().locator(".entry-id"))
     .toHaveText("PALOMAR-2026-07-29-000124 v1 · current");
 
   // An order nothing offers is the default rather than an empty page.
-  await page.goto(`/?database=${database}&order=sideways`);
+  await page.goto(`/?view=cards&database=${database}&order=sideways`);
   await expect(page.locator("#order-by")).toHaveValue("updated");
   await expect(page.locator(".entry-card").first().locator(".entry-id"))
     .toHaveText("PALOMAR-2026-07-29-000123 v2 · current");
 });
 
 test("an MSC prefix applies from a deep link", async ({ page }) => {
-  await page.goto(`/?database=${database}&msc=11`);
+  await page.goto(`/?view=cards&database=${database}&msc=11`);
   await expect(page.locator("#msc-query")).toHaveValue("11");
   await expect(page.locator(".entry-card:visible")).toHaveCount(1);
   await expect(page.locator(".entry-card:visible")).toContainText("000124");
 });
 
 test("classification filters apply from a deep link", async ({ page }) => {
-  await page.goto(`/?database=${database}&arxiv=math.NT`);
+  await page.goto(`/?view=cards&database=${database}&arxiv=math.NT`);
   await expect(page.locator("#arxiv-query")).toBeVisible();
   await expect(page.locator("#arxiv-query")).toHaveValue("math.NT");
   await expect(page.locator(".entry-card:visible")).toHaveCount(1);
@@ -626,7 +688,7 @@ test("classification filters apply from a deep link", async ({ page }) => {
 });
 
 test("absent classifications produce a useful empty result", async ({ page }) => {
-  await page.goto(`/?database=${database}&arxiv=math.AG`);
+  await page.goto(`/?view=cards&database=${database}&arxiv=math.AG`);
   await expect(page.locator("#arxiv-query")).toHaveValue("math.AG");
   await expect(page.locator(".entry-card:visible")).toHaveCount(0);
   await expect(page.locator("#status")).toHaveText(
@@ -648,7 +710,7 @@ test("absent classifications produce a useful empty result", async ({ page }) =>
 });
 
 test("malformed classification parameters are bounded and identified", async ({ page }) => {
-  await page.goto(`/?database=${database}&arxiv=${encodeURIComponent("not a code".repeat(20))}`);
+  await page.goto(`/?view=cards&database=${database}&arxiv=${encodeURIComponent("not a code".repeat(20))}`);
   await expect(page.locator("#arxiv-query")).toHaveValue("not a codenot a codenot a codeno");
   await expect(page.locator(".entry-card:visible")).toHaveCount(0);
   await expect(page.locator("#status")).toHaveText(
@@ -866,7 +928,7 @@ test("the licence caveat travels with the licence evidence it qualifies", async 
 });
 
 test("the subject filters share the toolbar's line, ending at its right edge", async ({ page }) => {
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   const card = page.locator(".entry-card").first();
 
   const toolbar = await page.locator(".toolbar").boundingBox();
@@ -1222,7 +1284,7 @@ test("a recent row without the required preservation mapping is omitted", async 
     recent.entries[0].preservation = null;
     await route.fulfill({ response, json: recent });
   });
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
 
   await expect(page.locator(".entry-card")).toHaveCount(1);
   await expect(page.locator("#registry-warning")).toHaveText(
@@ -1240,7 +1302,7 @@ test("a card says the original is unavailable exactly when the manifest says so"
     await new Promise((resolve) => { releaseAvailability = resolve; });
     await route.continue();
   });
-  await page.goto(`/?database=${database}&availability=${missingAvailability}`);
+  await page.goto(`/?view=cards&database=${database}&availability=${missingAvailability}`);
   const card = page.locator(".entry-card").first();
   await expect(card).toHaveCount(1);
   await availabilityRequested;
@@ -1258,7 +1320,7 @@ test("a card says the original is unavailable exactly when the manifest says so"
   await expect(page.locator("#arxiv-query")).toHaveValue("math.CO");
   await expect(page.locator(".entry-card:visible")).toHaveCount(1);
 
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await expect(page.locator(".entry-card .source-status")).toHaveCount(0);
 });
 
@@ -1283,7 +1345,7 @@ test("progressive cards never apply a stale missing claim", async ({ page }) => 
     await route.fulfill({ response, json: availability });
   });
 
-  await page.goto(`/?database=${database}&availability=${missingAvailability}`);
+  await page.goto(`/?view=cards&database=${database}&availability=${missingAvailability}`);
   const card = page.locator(".entry-card").first();
   await expect(card).toHaveCount(1);
   await availabilityRequested;
@@ -1366,7 +1428,7 @@ test("entry pages offer a version-pinned BibTeX citation that can be copied", as
 });
 
 test("a single current version has no supersession treatment", async ({ page }) => {
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   const card = page.locator(".entry-card").nth(1);
   await expect(card.locator(".version-history-link")).toHaveCount(0);
 
@@ -1447,7 +1509,7 @@ test("unknown exact versions remain generic not-found pages", async ({ page }) =
 });
 
 test("the index version-history link reaches history loaded at runtime", async ({ page }) => {
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await page.locator(".entry-card").first().getByRole("link", { name: "2 versions" }).click();
 
   await expect(page).toHaveURL(/#version-history$/);
@@ -1465,7 +1527,7 @@ test("optional metric markup cannot take down the registry", async ({ page }) =>
     contentType: "text/html; charset=utf-8",
   }));
 
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await expect(page.locator(".entry-card")).toHaveCount(2);
   await expect(page.locator("#status")).not.toContainText("could not be loaded");
 });
@@ -1797,7 +1859,7 @@ test("current HTML remains compatible with cached JavaScript from the previous d
   // fresh shared modules, which is the adjacent Pages deployment boundary this
   // regression exercises.
 
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await expect(page.locator(".entry-card")).toHaveCount(2);
   await expect(page.locator("#status")).not.toContainText("could not be loaded");
 
@@ -1823,7 +1885,7 @@ test("current JavaScript preserves represented deep links with cached HTML", asy
     return route.continue();
   });
 
-  await page.goto(`/?database=${database}&arxiv=math.NT`);
+  await page.goto(`/?view=cards&database=${database}&arxiv=math.NT`);
   await expect(page.locator("#arxiv-query, #arxiv-filter")).toHaveValue("math.NT");
   await expect(page.locator(".entry-card:visible")).toHaveCount(1);
   await expect(page.locator(".entry-card:visible")).toContainText("000124");
@@ -1869,7 +1931,7 @@ test("classification codes are spaced, and their descriptions are hovers", async
 });
 
 test("a card's classifications are muted links, glossed on hover", async ({ page }) => {
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   const card = page.locator(".entry-card", { hasText: "PALOMAR-2026-07-29-000123" });
   const arxiv = card.locator(".category-token", { hasText: "math.CO" });
   const msc = card.locator(".category-token", { hasText: "MSC 05C10" });
@@ -2041,7 +2103,7 @@ test("a search reads one postings sequence per word and confirms every hit", asy
     const path = new URL(request.url()).pathname;
     if (path.startsWith("/database/")) asked.push(path);
   });
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await expect(page.locator(".entry-card")).toHaveCount(2);
 
   asked.length = 0;
@@ -2082,7 +2144,7 @@ test("runtime data reads reuse a fresh HTTP response", async ({ page }) => {
       transferSize: entry.transferSize,
     })), headUrl);
 
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await page.evaluate(() => performance.clearResourceTimings());
   await runSearch(page, "cacheprobe");
   await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
@@ -2111,7 +2173,7 @@ test("an over-limit term count is an accessible warning and can be corrected", a
     if (path.startsWith("/database/")) asked.push(path);
   });
 
-  await page.goto(`/?database=${database}&q=${encodeURIComponent(query)}`);
+  await page.goto(`/?view=cards&database=${database}&q=${encodeURIComponent(query)}`);
   await expect(page.locator("#query")).toHaveValue(query);
   await expect(page.locator("#search-status")).toHaveText(
     `Use at most ${SEARCH_TERM_LIMIT} distinct normalized words; ` +
@@ -2126,7 +2188,7 @@ test("an over-limit term count is an accessible warning and can be corrected", a
   expect(asked.filter((path) => path === "/database/recent.json")).toEqual([]);
   await expect(page.locator("#entry-grid")).toBeHidden();
 
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
   asked.length = 0;
   await runSearch(page, query);
@@ -2158,7 +2220,7 @@ test("huge few-distinct linked and typed queries fail before I/O or history", as
   });
   page.on("pageerror", (error) => pageErrors.push(error));
 
-  await page.goto(`/?database=${database}&q=${encodeURIComponent(query)}`);
+  await page.goto(`/?view=cards&database=${database}&q=${encodeURIComponent(query)}`);
   await expect(page.locator("#search-status")).toContainText(
     `Shorten the search to at most ${SEARCH_QUERY_CHARACTER_LIMIT} characters`,
   );
@@ -2172,7 +2234,7 @@ test("huge few-distinct linked and typed queries fail before I/O or history", as
   expect(asked.filter((path) => path === "/database/recent.json")).toEqual([]);
   expect(pageErrors).toEqual([]);
 
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
   const before = page.url();
   asked.length = 0;
@@ -2197,7 +2259,7 @@ test("search cards retain posting order when posting pages finish out of order",
     await route.continue();
   });
 
-  await page.goto(`/?database=${database}&q=quasicoherent`);
+  await page.goto(`/?view=cards&database=${database}&q=quasicoherent`);
 
   await expect(page.locator("#search-results .entry-card")).toHaveCount(2);
   await expect(page.locator("#search-results .entry-id")).toHaveText([
@@ -2211,7 +2273,7 @@ test("a failed posting page leaves validated search cards and reports degradatio
     route.fulfill({ status: 503, body: "temporarily unavailable" }),
   );
 
-  await page.goto(`/?database=${database}&q=quasicoherent`);
+  await page.goto(`/?view=cards&database=${database}&q=quasicoherent`);
 
   await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
   await expect(page.locator("#search-results .entry-id")).toHaveText([
@@ -2351,7 +2413,7 @@ test("a superseded slow search cannot repaint a newer query", async ({ page }) =
     await new Promise((resolve) => setTimeout(resolve, 250));
     await route.continue().catch(() => {});
   });
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
 
   await startSearch(page, "quasicoherent");
   await expect.poll(() => slowHeadRequests).toBe(1);
@@ -2383,7 +2445,7 @@ test("a linked search hides landing DOM and retries one failed landing load", as
     await route.continue();
   });
 
-  await page.goto(`/?database=${database}&q=synthetically`);
+  await page.goto(`/?view=cards&database=${database}&q=synthetically`);
   await expect(page.locator("#search-results .entry-card")).toHaveCount(1);
   expect(recentRequests).toBe(0);
   expect(await page.evaluate(() => ({
@@ -2415,7 +2477,7 @@ test("a linked search hides landing DOM and retries one failed landing load", as
 });
 
 test("a search runs from a link, and says so when nothing carries the words", async ({ page }) => {
-  await page.goto(`/?database=${database}&q=quasicoherent`);
+  await page.goto(`/?view=cards&database=${database}&q=quasicoherent`);
   await expect(page.locator("#search-results .entry-card")).toHaveCount(2);
 
   await runSearch(page, "quasicoherent unobtainium");
@@ -2430,7 +2492,7 @@ test("a search runs from a link, and says so when nothing carries the words", as
 test("a hostile query cannot construct a path outside the postings grammar", async ({ page }) => {
   const asked = [];
   page.on("request", (request) => asked.push(new URL(request.url()).pathname));
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
 
   asked.length = 0;
   await runSearch(page, "../../etc/passwd?x=1 <script>");
@@ -2450,7 +2512,7 @@ test("a hostile query cannot construct a path outside the postings grammar", asy
 });
 
 test("a query with no word in it leaves the listing alone", async ({ page }) => {
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await runSearch(page, "a !");
   await expect(page.locator("#entry-grid")).toBeVisible();
   await expect(page.locator("#search-status")).toBeHidden();
@@ -2464,7 +2526,7 @@ test("a word the indexer drops leaves the query instead of failing it", async ({
   // that from a wrong answer nobody could diagnose into no question at all.
   const asked = [];
   page.on("request", (request) => asked.push(new URL(request.url()).pathname));
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
 
   asked.length = 0;
   await runSearch(page, "the quasicoherent sheaves");
@@ -2477,7 +2539,7 @@ test("a word the indexer drops leaves the query instead of failing it", async ({
 
 test("a search made only of words the indexer drops says which they were", async ({ page }) => {
   // Otherwise this is a registry that appears to hold nothing.
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await runSearch(page, "the of and");
 
   await expect(page.locator("#search-status")).toContainText("too common to be indexed");
@@ -2505,7 +2567,7 @@ test("typing runs one search at the pause, not one per keystroke", async ({ page
     const path = new URL(request.url()).pathname;
     if (path.endsWith("/head.json")) heads.push(path);
   });
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
 
   // There is no button to press, so the pause is the whole of the instruction.
@@ -2525,7 +2587,7 @@ test("a keystroke abandons the answer to the query it just replaced", async ({ p
   // the two, an answer to what the reader has already typed past would arrive
   // verified and undimmed under a box that says something else.
   const held = await holdSearchHead(page, "quasicoherent");
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
 
   await startSearch(page, "quasicoherent");
@@ -2556,7 +2618,7 @@ test("confirming a result keeps the reader on the card they were standing on", a
   // The provisional cards are replaced wholesale, so without this the reader's
   // focus goes with the node that carried it and lands on the document.
   const held = await holdSearchHead(page, "quasicoherent");
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
 
   await startSearch(page, "quasicoherent");
@@ -2577,7 +2639,7 @@ test("confirming a result keeps the reader on the card they were standing on", a
 
 test("a pause shows the entries already loaded, marked as not yet the answer", async ({ page }) => {
   const held = await holdSearchHead(page, "quasicoherent");
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
 
   await startSearch(page, "quasicoherent");
@@ -2609,7 +2671,7 @@ test("nothing loaded to show leaves the wait to the spinner alone", async ({ pag
   const held = await holdSearchHead(page, "synthetically");
   // A linked search never reads the landing selection, so there is nothing in
   // hand to show, and the status must not claim otherwise.
-  await page.goto(`/?database=${database}&q=synthetically`);
+  await page.goto(`/?view=cards&database=${database}&q=synthetically`);
   await held.requested;
   await expect(page.locator("#search-spinner")).toBeVisible();
   await expect(page.locator("#search-status")).toHaveText("Searching the registry…");
@@ -2624,7 +2686,7 @@ test("a provisional match the index does not confirm is taken away", async ({ pa
   // What the dimming is for. "quasi" sits inside a word the newest entries
   // carry, so it is in hand at once, but the index knows whole words and holds
   // nothing under it. The cards go and the reader is told why.
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
 
   await runSearch(page, "quasi");
@@ -2635,7 +2697,7 @@ test("a provisional match the index does not confirm is taken away", async ({ pa
 });
 
 test("emptying the box gives the listing and its filters back", async ({ page }) => {
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   // Set before searching, because a search takes the toolbar off the page.
   await page.locator("#arxiv-query").fill("math.CO");
   await expect(page.locator(".entry-card:visible")).toHaveCount(1);
@@ -2762,7 +2824,7 @@ for (const scheme of ["light", "dark"]) {
   test(`${scheme} text stays readable once opacity and grounds are composited`, async ({ page }) => {
     await page.emulateMedia({ colorScheme: scheme });
 
-    await page.goto(`/?database=${database}`);
+    await page.goto(`/?view=cards&database=${database}`);
     await expect(page.locator("#entry-grid .entry-card")).toHaveCount(2);
     await readableTextOnly(page, `${scheme} listing`, 40);
 
@@ -2791,7 +2853,7 @@ for (const scheme of ["light", "dark"]) {
 test("resting on a landing title raises the result's rendering over the listing", async ({ page }) => {
   const asked = [];
   page.on("request", (request) => asked.push(new URL(request.url()).pathname));
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   const title = page.locator(".entry-card h3 > a").first();
   const identifier = await page.locator(".entry-card .entry-id").first().textContent();
   const versioned = /(PALOMAR-[0-9-]+) v([0-9]+)/.exec(identifier);
@@ -2825,7 +2887,7 @@ test("resting on a landing title raises the result's rendering over the listing"
 });
 
 test("a search result previews from the record it already holds", async ({ page }) => {
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   // Runs on the typing pause now, and the provisional cards it stands in are
   // drawn like the verified ones, so wait for the spinner rather than counting.
   await runSearch(page, "quasicoherent");
@@ -2843,7 +2905,7 @@ test("a search result previews from the record it already holds", async ({ page 
 });
 
 test("a preview survives the pointer crossing into it", async ({ page }) => {
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   await page.locator(".entry-card h3 > a").first().hover();
   const panel = page.locator(".statement-preview");
   await expect(panel).toBeVisible();
@@ -2861,7 +2923,7 @@ test("an absent or unusable render companion leaves the listing usable", async (
       body
         ? route.fulfill({ status: 200, contentType: "application/json", body })
         : route.fulfill({ status: 404, contentType: "application/json", body: "{}" }));
-    await page.goto(`/?database=${database}`);
+    await page.goto(`/?view=cards&database=${database}`);
     const title = page.locator(".entry-card h3 > a").first();
     await title.hover();
     await page.waitForTimeout(600);
@@ -2877,7 +2939,7 @@ test("previews are not raised where a pointer cannot rest", async ({ browser }) 
   const context = await browser.newContext({ hasTouch: true, isMobile: false });
   const page = await context.newPage();
   await page.emulateMedia({ media: "screen", forcedColors: "none" });
-  await page.goto(`/?database=${database}`);
+  await page.goto(`/?view=cards&database=${database}`);
   // The controller asks `(hover: hover)`; a coarse pointer answers no, and the
   // stylesheet refuses to show a panel even if one were somehow raised.
   const hides = await page.evaluate(() =>

--- a/tests/site.spec.js
+++ b/tests/site.spec.js
@@ -750,6 +750,20 @@ test("an abstract keeps the submitter's code spans and their line structure", as
   await expect(lede).toContainText("It classifies AddCircle (1 : ℝ) by ℤ");
   await expect(lede).toContainText("a 90` turn");
 
+  // Most submitters mark nothing and write the mathematics into the sentence.
+  // Those are found by their operators and set apart too, in the face but not
+  // on the ground: this page found them rather than being told, and the
+  // stronger signal stays with the span the submitter marked themselves.
+  await expect(lede.locator(".expression")).toHaveText(["mu ≥ 2", "n > 3", "2^kappa"]);
+  const expression = lede.locator(".expression").first();
+  await expect(expression).toHaveCSS("font-family", /mono/i);
+  const [mathGround, proseGround] = await Promise.all([
+    expression.evaluate((n) => getComputedStyle(n).backgroundColor),
+    lede.evaluate((n) => getComputedStyle(n).backgroundColor),
+  ]);
+  expect(mathGround, "a found expression carries no ground of its own")
+    .toBe(proseGround);
+
   // Rendered, not merely present: an identifier that reads as prose is the
   // defect this closes.
   const inline = lede.locator("code").first();

--- a/tests/statement-preview.test.mjs
+++ b/tests/statement-preview.test.mjs
@@ -143,7 +143,18 @@ function fakeBrowser({ hover = true } = {}) {
 
 function titleLink(browser) {
   const link = browser.createElement("a");
-  link.matches = "h3 > a";
+  // What the preview asks for. It resolves the nearest anchor and lets the
+  // registration decide, rather than requiring the markup a card happens to
+  // use, because the table shows the same titles from a cell.
+  link.matches = "a";
+  link.isConnected = true;
+  return link;
+}
+
+/** An anchor on a listing that is not a title: never registered, never framed. */
+function plainLink(browser) {
+  const link = browser.createElement("a");
+  link.matches = "a";
   link.isConnected = true;
   return link;
 }
@@ -396,4 +407,20 @@ test("a lookup refuses a companion document that was never validated", () => {
   const validated = validateRecentRenders(recentRenders());
   assert.equal(recentRenderRow(validated, "PALOMAR-2026-07-29-000123").version, 1);
   assert.equal(recentRenderRow(validated, "PALOMAR-2026-07-29-000999"), null);
+});
+
+// Resolving the nearest anchor rather than a card's own markup puts every link
+// on a listing in front of the check, not just the titles. The registration is
+// what keeps the rest of them out -- a card carries a repository link, a record
+// link and an archive link beside the title it registers.
+test("an anchor that was never registered raises nothing", async () => {
+  const browser = fakeBrowser();
+  const { preview, grid, reads } = build(browser);
+  preview.register(titleLink(browser), recentRow());
+
+  grid.emit("mouseover", { target: plainLink(browser) });
+  await browser.tick(OPEN_MS);
+
+  assert.equal(panels(browser).length, 0, "an unregistered anchor framed something");
+  assert.equal(reads(), 0, "an unregistered anchor started a read");
 });


### PR DESCRIPTION
Six commits to make mathematics and prose readable for users. Each stands alone and can be reviewed or dropped without the others. I measured before changing anything, and the numbers below are from the published set.

| Commit | Change |
| `aec6f36` | Monospace stack that can draw the glyphs Lean prints |
| `57701ae` | Keep a submitter's code spans and line structure in an abstract |
| `9caefcd` | One reading measure and leading for an entry's prose |
| `3218a40` | Set mathematics apart from prose, found by its operators |
| `594fddb` | Land the registry as a table, with cards one click away |
| `0607d08` | Review cleanups: a dead export, an out of date comment |

### 1. Monospace stack

Courier New lacks many characters Lean prints. Missing glyphs show no error; the browser silently swaps in another font for just those characters, so symbols arrive in a different weight from the identifiers beside them. Chromium reports the fonts actually used. On entry `PALOMAR-2026-09-08-000002`:

| Audit view | Before | After |
| Fonts used | Courier New 3740, **Menlo 6, Courier 40** | **Menlo 3786** |

46 glyphs (`∀`, `ε₁`, `↑`, subscripts) were drawn by two other fonts. The generic fallback resolves to Courier New again on Windows, so the new stack names a covering family per platform.

Not every entry was affected: on `…09-07-000007` Courier New drew all 243 glyphs itself. And `…09-08-000003` still needs a second font after the fix, because `𝒜` is in the Mathematical Alphanumeric Symbols block, which no general purpose monospace font covers.

### 2. Code spans and line structure in abstracts

Submitters use Markdown code spans: 38 across 200 entries, holding things like `ℤ × ℤ`. Abstracts rendered verbatim, so readers saw the backticks as punctuation. Fourteen abstracts contain newlines and fifteen contain numbered items, which `white-space: normal` collapsed into one paragraph.

This reads that one delimiter and keeps whitespace as written. It is not a Markdown parser and must not become one. An unpaired backtick stays prose and never crosses a line. Runs carry no markup, so an abstract still cannot introduce any.

Whether a line break is structure or wrapping cannot be decided from the text, so neither case is guessed at.

### 3. One reading measure for entry prose

The abstract ran at 72 characters per line, the explanations below it at 104, both at 1.45 line height.

| Block | Before | After |
|---|---|---|
| `.lede` | 72 ch / 1.45 | 76 ch / 1.60 |
| `.challenge-surface-disclosure` | **104 ch** / 1.45 | 76 ch / 1.60 |
| evidence paragraphs | **97 ch** / 1.45 | 76 ch / 1.60 |
| `.licence-boundary`, `.review-explanation` | **104 ch** / 1.45 | 76 ch / 1.60 |
| bibliography entries | **102 ch** / 1.45 | 76 ch / 1.60 |

76ch is what `.card-abstract` already used for the same text. Control rows are left alone. `h1` had a 0.2rem bottom margin under a 2rem title, so heading and abstract ran together; now 0.75rem. The test measures what the page renders and walks whatever prose it finds, so a paragraph added later without a measure is caught.

### 4. Mathematics written into a sentence

Only nine entries of 200 mark anything. The rest write it into the prose, for example "a colour count mu ≥ 2; and a target order type theta = omega^alpha with alpha > 0".

These are found by their operators, not by deciding which words are variables. So `2^kappa` is set apart and the bare `kappa` next to it is not. Running the detector over every published abstract turned up two failure modes, both now tests:

- Inner products are written `<x*y, z>`. Reading those brackets as comparisons split the notation and pulled in neighbouring words, giving spans like `v> equals`. A comparison now counts only when spaced, taking prose word captures from 47 to 0.
- `/ + - * :` appear in prose as often as in mathematics (`a Lean 4 / Mathlib development`), so none anchors an expression. That also leaves DOIs, arXiv ids and pinned versions alone.

A found expression is a `span`, not `code`, and uses the mono face without the background: the page found it rather than being told, so the stronger signal stays with spans a submitter marked.

Not done on purpose: learning a variable from an abstract's own expressions. Across the published set that learns 82 tokens including *modulus*, *measure*, *threshold*, *primes* and *floor*, which would then be styled as variables throughout the abstract containing them.

### 5. Registry as a table

| | Table | Cards |
| DOM nodes | 3,801 | 7,306 |
| Text on the page | 99,700 chars | 409,500 chars |
| Grid height | 25,200 px | 119,000 px |

200 results are a list to scan before reading any one. The landing page now shows result, authors, subjects, dependencies and registration date, with cards one click away.

This does not make the page load faster and I am not claiming it does. Both views come from the same `recent.json` (454 KB, 53% abstracts) and its shape belongs to the producer. What changes is how much reaches the screen.

The view is stored in the URL (`?view=cards`), matching how order, dates and subject filters already deep link, and keeping "no account, no cookie, and no analytics" accurate.

Switching rebuilds the nodes and restores what each carries: hover previews are registered as each is built, and the availability result is reapplied from the one already held. Rows carry the same data attributes as cards, since the toolbar filters by reading them off whichever node is displayed.

One existing bug fixed on the way: registration already decided whether hovering opens a preview, but `titleLink` also required a card's `h3 > a`, so table titles silently had none. It now resolves the nearest anchor and lets registration decide.

## Notes for reviewers

- One browser test fails and it is not from this branch. `a keystroke abandons the answer to the query it just replaced` fails with the same assertion on a clean `upstream/main` checkout. It is a timing sensitive search race.
- Making the table the default required changes to about 60 test navigations, the largest single part of this diff. The change is mechanical (`&view=cards` on landing navigations). The mobile overflow test now covers both landing views, and the table holds at 320px.
- Search results still render as cards in both modes, since the abstract is usually where a match is. Happy to make them follow the view.
- `fix/mobile-formatting` adds about 179 lines to `style.css`. It touches none of these rules, but it is the same file, so whichever lands second needs a small rebase.
- No new dependencies, no new shipped assets, no CSP change, no data contract change.

## Verifying
```sh
npm ci
npm test                 # 302 pass
npm run test:browser     # 99 pass, 2 skipped, 1 pre-existing failure noted above
```

`npm test` needs the Database contracts described in `AGENTS.md`: `PALOMAR_DATABASE_CHECKOUT`, or a sibling `../PalomarDatabase/` holding `schema-v3.json`, `schema-v4.json` and `tests/fixtures/recent.json`.

By eye, with `python3 tests/fixture_server.py`:
- `/` shows the table; **Cards** switches and the URL follows.
- `/entry?id=PALOMAR-2026-09-08-000003&version=1`: `mu ≥ 2`, `theta = omega^alpha`, `2^kappa` set apart.
- `/entry?id=PALOMAR-2026-08-22-000008&version=1`: a theorem that reads as one again.
- `/render?id=PALOMAR-2026-09-08-000002&version=1`, expand the core-notation audit: one font instead of three.